### PR TITLE
fix: Rename package scope from @kei to @kexi

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kei/vibe",
+  "name": "@kexi/vibe",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",


### PR DESCRIPTION
## Summary
- deno.jsonのパッケージ名を`@kei/vibe`から`@kexi/vibe`に修正
- GitHubアカウント名との一貫性を確保

## Test plan
- [x] deno.jsonのnameフィールドが`@kexi/vibe`になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)