### PR TITLE
feat: Add Zod schema validation and migration for settings

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -20,7 +20,8 @@
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "@std/path": "jsr:@std/path@^1.0.0",
     "@std/toml": "jsr:@std/toml@^1.0.0",
-    "@std/assert": "jsr:@std/assert@^1.0.0"
+    "@std/assert": "jsr:@std/assert@^1.0.0",
+    "zod": "npm:zod@^3.23.0"
   },
   "compilerOptions": {
     "strict": true

--- a/deno.lock
+++ b/deno.lock
@@ -6,7 +6,8 @@
     "jsr:@std/collections@^1.1.3": "1.1.3",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/path@1": "1.1.4",
-    "jsr:@std/toml@1": "1.0.11"
+    "jsr:@std/toml@1": "1.0.11",
+    "npm:zod@^3.23.0": "3.25.76"
   },
   "jsr": {
     "@std/assert@1.0.16": {
@@ -37,12 +38,18 @@
       ]
     }
   },
+  "npm": {
+    "zod@3.25.76": {
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+    }
+  },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
       "jsr:@std/cli@1",
       "jsr:@std/path@1",
-      "jsr:@std/toml@1"
+      "jsr:@std/toml@1",
+      "npm:zod@^3.23.0"
     ]
   }
 }

--- a/src/utils/settings.test.ts
+++ b/src/utils/settings.test.ts
@@ -1,10 +1,74 @@
 import { assertEquals } from "@std/assert";
-import { addTrustedPath, isTrusted, loadUserSettings, removeTrustedPath } from "./settings.ts";
+import {
+  _internal,
+  addTrustedPath,
+  isTrusted,
+  loadUserSettings,
+  removeTrustedPath,
+} from "./settings.ts";
 
 Deno.test("loadUserSettings returns default settings when file not exists", async () => {
   const settings = await loadUserSettings();
+  assertEquals(settings.version, _internal.CURRENT_SCHEMA_VERSION);
   assertEquals(settings.permissions.allow, []);
   assertEquals(settings.permissions.deny, []);
+});
+
+// ===== マイグレーションテスト =====
+
+Deno.test("getSchemaVersion returns 0 for legacy settings without version", () => {
+  const legacyData = {
+    permissions: { allow: [], deny: [] },
+  };
+  assertEquals(_internal.getSchemaVersion(legacyData), 0);
+});
+
+Deno.test("getSchemaVersion returns correct version for versioned settings", () => {
+  const v1Data = {
+    version: 1,
+    permissions: { allow: [], deny: [] },
+  };
+  assertEquals(_internal.getSchemaVersion(v1Data), 1);
+});
+
+Deno.test("migrateSettings migrates legacy settings to v1", () => {
+  const legacyData = {
+    permissions: {
+      allow: ["/path/to/repo/.vibe.toml"],
+      deny: [],
+    },
+  };
+
+  const migrated = _internal.migrateSettings(legacyData);
+
+  assertEquals(migrated, {
+    version: 1,
+    permissions: {
+      allow: ["/path/to/repo/.vibe.toml"],
+      deny: [],
+    },
+  });
+});
+
+Deno.test("migrateSettings keeps v1 settings unchanged", () => {
+  const v1Data = {
+    version: 1,
+    permissions: {
+      allow: ["/path/to/repo/.vibe.toml"],
+      deny: [],
+    },
+  };
+
+  const migrated = _internal.migrateSettings(v1Data);
+
+  assertEquals(migrated, v1Data);
+});
+
+Deno.test("createDefaultSettings returns settings with current version", () => {
+  const defaults = _internal.createDefaultSettings();
+  assertEquals(defaults.version, _internal.CURRENT_SCHEMA_VERSION);
+  assertEquals(defaults.permissions.allow, []);
+  assertEquals(defaults.permissions.deny, []);
 });
 
 Deno.test("addTrustedPath and isTrusted work correctly", async () => {


### PR DESCRIPTION
## Summary
- Zodによるスキーマバリデーションを導入し、設定ファイルの型安全性を向上
- バージョン付き設定スキーマ（v1）を実装
- レガシー形式からの自動マイグレーション機能を追加

## Changes
- `zod` を依存関係に追加
- `src/utils/settings.ts`: スキーマ定義とマイグレーション機能を実装
- マイグレーション関連のテストを追加

## Migration Strategy
```typescript
const migrations: Record<number, MigrationFn> = {
  0: (data) => { /* legacy → v1 */ },
  // 将来: 1: (data) => { /* v1 → v2 */ },
};
```

## New Settings Format
```json
{
  "version": 1,
  "permissions": {
    "allow": [],
    "deny": []
  }
}
```

## Test plan
- [x] 既存のテストが全てパス
- [x] マイグレーションテストを追加
- [x] 型チェック・lintがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)