### PR TITLE
docs: Add English requirement for PR title and description

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ develop ─┴──●──●──●──●─────┴────
 
 - Title format: `<type>: <description>`
   - type: feat, fix, docs, refactor, test, chore
+- PR title and description must be written in English
 - Must pass `deno lint` and `deno fmt --check`
 - Add or update tests for changed code
 


### PR DESCRIPTION
## Summary
- Add guideline that PR title and description must be written in English

## Changes
- Updated `AGENTS.md` PR Guidelines section

🤖 Generated with [Claude Code](https://claude.com/claude-code)