### PR TITLE
docs: Improve README configuration examples

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -224,14 +224,14 @@ files = [".env.local", ".secrets"]
 ```toml
 # .vibe.toml（共有）
 [hooks]
-post_start = ["mise trust", "mise install"]
+post_start = ["npm install", "npm run build"]
 
 # .vibe.local.toml（ローカル）
 [hooks]
 post_start_prepend = ["echo 'ローカルセットアップ'"]
 post_start_append = ["npm run dev"]
 
-# 結果: ["echo 'ローカルセットアップ'", "mise trust", "mise install", "npm run dev"]
+# 結果: ["echo 'ローカルセットアップ'", "npm install", "npm run build", "npm run dev"]
 ```
 
 ### 設定オプション

--- a/README.md
+++ b/README.md
@@ -225,14 +225,14 @@ When both `.vibe.toml` and `.vibe.local.toml` exist:
 ```toml
 # .vibe.toml (shared)
 [hooks]
-post_start = ["mise trust", "mise install"]
+post_start = ["npm install", "npm run build"]
 
 # .vibe.local.toml (local)
 [hooks]
 post_start_prepend = ["echo 'local setup'"]
 post_start_append = ["npm run dev"]
 
-# Result: ["echo 'local setup'", "mise trust", "mise install", "npm run dev"]
+# Result: ["echo 'local setup'", "npm install", "npm run build", "npm run dev"]
 ```
 
 ### Configuration Options


### PR DESCRIPTION
## Summary
- README.mdとREADME.ja.mdのConfiguration Mergingセクションのサンプルコードを改善
- `mise trust`, `mise install`から`npm install`, `npm run build`に変更
- より一般的で理解しやすい例に更新

## 変更内容
### 変更前
```toml
post_start = ["mise trust", "mise install"]
```

### 変更後
```toml
post_start = ["npm install", "npm run build"]
```

## 理由
- `mise`は特定のツールであり、全ての開発者が知っているわけではない
- `npm`はより広く認知されており、新規ユーザーにとって理解しやすい
- サンプルコードはプロジェクトの第一印象を左右するため、アクセシビリティが重要

🤖 Generated with [Claude Code](https://claude.com/claude-code)