### PR TITLE
fix: リリースビルド時にsrc/version.tsを生成するように修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,18 @@ jobs:
 
       - uses: jdx/mise-action@v2
 
+      - name: Generate version.ts
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          REPOSITORY=$(deno eval "console.log(JSON.parse(Deno.readTextFileSync('deno.json')).repository)")
+          cat > src/version.ts << EOF
+          // This file is auto-generated during release
+          export const VERSION = "$VERSION";
+          export const REPOSITORY_URL = "$REPOSITORY";
+          EOF
+          echo "Generated src/version.ts with VERSION = \"$VERSION\" and REPOSITORY_URL = \"$REPOSITORY\""
+
       - name: Compile
         run: deno compile --allow-run --allow-read --allow-write --allow-env --target ${{ matrix.target }} --output ${{ matrix.artifact }} main.ts
 


### PR DESCRIPTION
## 概要
リリースワークフローでのビルド失敗を修正しました。

## 問題
- リリースワークフロー（v0.1.0）でビルドが失敗していた
- エラー: `Cannot find module 'file:///home/runner/work/vibe/vibe/src/version.ts'`
- `src/version.ts`は通常`scripts/build.ts`で生成されるが、リリースワークフローにはこのステップが欠けていた

## 解決策
`.github/workflows/release.yml`に、Compileステップの前に以下を追加：

1. リリースタグからバージョン番号を抽出（例：`v0.1.0` → `0.1.0`）
2. `deno.json`からリポジトリURLを読み取り
3. これらの情報を使って`src/version.ts`を自動生成

## テスト方法
このPRをマージ後、新しいリリース（v0.1.1など）を作成してワークフローが正常に完了することを確認してください。

## 関連
- Failed release run: https://github.com/kexi/vibe/actions/runs/20549732553

🤖 Generated with [Claude Code](https://claude.com/claude-code)