### PR TITLE
chore: バージョンを0.1.2に更新

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",


### PR DESCRIPTION
## 概要
v0.1.2リリースのためにバージョンを更新します。

## 変更内容
- `deno.json`のバージョンを`0.1.0`から`0.1.2`に更新

## 関連
- #20 (リリースビルドの修正)
- v0.1.0、v0.1.1のリリースビルドが失敗したため、修正後の最初のリリースとなります

🤖 Generated with [Claude Code](https://claude.com/claude-code)