### PR TITLE
fix: Homebrewワークフローのgit push認証を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,4 +164,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/vibe.rb
           git commit -m "Update vibe to $VERSION"
-          git push
+          git push https://x-access-token:${GH_TOKEN}@github.com/kexi/homebrew-tap.git HEAD:main


### PR DESCRIPTION
## 問題
Homebrewの自動更新ジョブが以下のエラーで失敗していました：
```
fatal: could not read Username for 'https://github.com': No such device or address
```

## 原因
- `gh repo clone`でリポジトリをクローンする際は`GH_TOKEN`が使われる
- しかし、その後の`git push`は通常のgitコマンドなので、環境変数を自動的に使用しない
- そのため、プッシュ時に認証ができず失敗していた

## 修正内容
`git push`コマンドで、トークンを含むURLを明示的に指定するように変更：
```bash
git push https://x-access-token:${GH_TOKEN}@github.com/kexi/homebrew-tap.git HEAD:main
```

## 関連
- Failed job: https://github.com/kexi/vibe/actions/runs/20549905666/job/59026137625

🤖 Generated with [Claude Code](https://claude.com/claude-code)