### PR TITLE
fix: .vibe.tomlからshell設定を削除

### DIFF
--- a/.vibe.toml
+++ b/.vibe.toml
@@ -1,5 +1,3 @@
-shell = true
-
 [hooks]
 post_start = [
   "mise trust",


### PR DESCRIPTION
## 概要
vibe cleanコマンドでメインワークツリーに移動できるよう、`.vibe.toml`から`shell = true`設定を削除しました。

## 変更内容
- `.vibe.toml`から`shell = true`を削除
- eval方式のみを使用するように統一

## 動作
`vibe clean`を実行すると:
1. pre_cleanフックを実行（現在のワークツリー内で）
2. `cd '${mainPath}' && git worktree remove '${currentWorktreePath}'`というコマンド文字列を出力
3. シェルラッパー`vibe() { eval "$(command vibe "$@")" }`がevalして実行
4. メインワークツリーに移動してワークツリーを削除

## テスト
- [x] `deno task ci` が通ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)