### PR TITLE
fix: Remove shell spawning logic from start command

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -90,23 +90,8 @@ export async function startCommand(
             await runVibeConfig(config, repoRoot, worktreePath);
           }
 
-          // Launch shell or output cd command
-          // @ts-ignore: Type inference issue in CI environment only
-          const useShell = config?.shell === true;
-          if (useShell) {
-            const shellPath = Deno.env.get("SHELL") ?? "/bin/sh";
-            const command = new Deno.Command(shellPath, {
-              cwd: worktreePath,
-              stdin: "inherit",
-              stdout: "inherit",
-              stderr: "inherit",
-            });
-            const process = command.spawn();
-            const status = await process.status;
-            Deno.exit(status.code);
-          } else {
-            console.log(`cd '${worktreePath}'`);
-          }
+          // Output cd command
+          console.log(`cd '${worktreePath}'`);
           return;
         } else {
           // Cancel


### PR DESCRIPTION
## Summary
- Remove shell spawning logic that caused `vibe start` to launch a subshell
- Always output `cd` command for eval-based shell function wrapper
- Removes unused `config.shell` option

## Background
The previous implementation would spawn a new shell when `config.shell === true`, which caused users to enter a subshell instead of changing directories in their current shell. This was inconsistent with the intended design of using a shell function wrapper with `eval`.

## Changes
- Removed shell spawning code (lines 93-109 in start.ts)
- Always outputs `cd` command for shell function wrapper to evaluate
- Simplifies the code by removing the conditional logic

## Test plan
- [x] Create a new worktree with `vibe start <branch>`
- [x] Verify that `cd` command is output correctly
- [x] Confirm no subshell is spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)