### PR TITLE
docs: Move development documentation from README to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,48 @@
 # Contributing
 
+Thank you for your interest in contributing to vibe!
+
 ## Development Setup
 
 ```bash
 mise install
 ```
+
+## Available Tasks
+
+All tasks are defined in `deno.json` to ensure consistency between local development and CI:
+
+```bash
+# Run all CI checks (same as CI runs)
+deno task ci
+
+# Individual checks
+deno task fmt:check    # Check code formatting
+deno task lint         # Run linter
+deno task check        # Type check
+deno task test         # Run tests
+
+# Auto-fix formatting
+deno task fmt
+
+# Development
+deno task dev          # Run in development mode
+deno task compile      # Build binaries for all platforms
+```
+
+## Running CI Checks Locally
+
+Before pushing, run the same checks that CI will run:
+
+```bash
+deno task ci
+```
+
+This runs:
+1. Format check (`deno task fmt:check`)
+2. Linter (`deno task lint`)
+3. Type check (`deno task check`)
+4. Tests (`deno task test`)
 
 ## Release Process
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -326,43 +326,9 @@ post_start_append = ["npm run dev"]
 | `VIBE_WORKTREE_PATH` | 作成されたworktreeの絶対パス |
 | `VIBE_ORIGIN_PATH`   | 元リポジトリの絶対パス       |
 
-## 開発
+## 開発への参加
 
-### 利用可能なタスク
-
-すべてのタスクは`deno.json`に定義されており、ローカル開発とCIで同じチェックを実行できます：
-
-```bash
-# CIと同じチェックを実行
-deno task ci
-
-# 個別のチェック
-deno task fmt:check    # コードフォーマットをチェック
-deno task lint         # Linterを実行
-deno task check        # 型チェック
-deno task test         # テスト実行
-
-# フォーマット自動修正
-deno task fmt
-
-# 開発
-deno task dev          # 開発モードで実行
-deno task compile      # 全プラットフォーム向けにビルド
-```
-
-### ローカルでCIチェックを実行
-
-プッシュ前に、CIと同じチェックを実行できます：
-
-```bash
-deno task ci
-```
-
-以下を実行します：
-1. フォーマットチェック (`deno task fmt:check`)
-2. Linter (`deno task lint`)
-3. 型チェック (`deno task check`)
-4. テスト (`deno task test`)
+開発環境のセットアップとガイドラインについては [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -327,43 +327,9 @@ The following environment variables are available in all hook commands:
 | `VIBE_WORKTREE_PATH` | Absolute path to the created worktree    |
 | `VIBE_ORIGIN_PATH`   | Absolute path to the original repository |
 
-## Development
+## Contributing
 
-### Available Tasks
-
-All tasks are defined in `deno.json` to ensure consistency between local development and CI:
-
-```bash
-# Run all CI checks (same as CI runs)
-deno task ci
-
-# Individual checks
-deno task fmt:check    # Check code formatting
-deno task lint         # Run linter
-deno task check        # Type check
-deno task test         # Run tests
-
-# Auto-fix formatting
-deno task fmt
-
-# Development
-deno task dev          # Run in development mode
-deno task compile      # Build binaries for all platforms
-```
-
-### Running CI Checks Locally
-
-Before pushing, run the same checks that CI will run:
-
-```bash
-deno task ci
-```
-
-This runs:
-1. Format check (`deno task fmt:check`)
-2. Linter (`deno task lint`)
-3. Type check (`deno task check`)
-4. Tests (`deno task test`)
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
 ## License
 


### PR DESCRIPTION
Keep READMEs focused on user-facing content (installation, usage, configuration). Developer documentation (tasks, CI checks) is now in CONTRIBUTING.md.