### PR TITLE
fix: Return normalized repo root in getRepoInfoFromPath

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -233,7 +233,7 @@ export async function getRepoInfoFromPath(
 
     return {
       remoteUrl,
-      repoRoot,
+      repoRoot: normalizedRoot,
       relativePath,
     };
   } catch {


### PR DESCRIPTION
## Summary
- Fix `getRepoInfoFromPath` to return the normalized repo root path instead of the unnormalized version

## Problem
The `getRepoInfoFromPath` function was normalizing the repository root path but returning the original unnormalized value. This caused trust/verify matching to fail because:
1. `trust` command saved the unnormalized `repoRoot` 
2. `verify` command compared against the normalized `repoRoot`
3. The paths didn't match, so files appeared as "NOT TRUSTED" even after trusting them

## Solution
Changed `src/utils/git.ts:236` to return `normalizedRoot` instead of `repoRoot`.

## Fixes
- E2E test failure: `trust/untrust/verify commands > verify: Display trust status and hash history`
- The test was failing with "NOT TRUSTED" status because the repository root matching failed

## Test plan
- [x] Fix applied to `src/utils/git.ts`
- [ ] E2E tests pass in CI (specifically the trust/verify test)
- [ ] Verify that trust/verify workflow works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)