### PR TITLE
chore: Replace Japanese messages with English and update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,69 @@ This runs:
 
 ## Release Process
 
+### Branching Model
+
+This project follows the git-flow branching model:
+
+- `develop` - Active development branch. All feature branches merge here.
+- `main` - Stable release branch. Only receives merges from develop during releases.
+
+See [AGENTS.md](./AGENTS.md) for detailed branching workflow.
+
+### Releasing a New Version
+
+1. **Prepare the release on develop:**
+   ```bash
+   # Ensure you're on develop and up to date
+   git checkout develop
+   git pull origin develop
+
+   # Update version in deno.json
+   # Update CHANGELOG if you maintain one
+
+   # Commit version bump
+   git add deno.json
+   git commit -m "chore: Bump version to vX.X.X"
+   git push origin develop
+   ```
+
+2. **Sync main with develop:**
+
+   Since main branch has protection rules, you must create a pull request:
+
+   ```bash
+   # Create a sync branch from develop
+   git checkout -b chore/release-vX.X.X
+   git push origin chore/release-vX.X.X
+
+   # Create PR targeting main
+   gh pr create --base main --title "chore: Release vX.X.X" \
+     --body "Sync main with develop for vX.X.X release"
+   ```
+
+   After the PR is merged:
+
+3. **Create and push the tag:**
+   ```bash
+   # Checkout main and pull the merged changes
+   git checkout main
+   git pull origin main
+
+   # Create and push the tag
+   git tag vX.X.X
+   git push origin vX.X.X
+
+   # Return to develop
+   git checkout develop
+   ```
+
+4. **Create the GitHub release:**
+   ```bash
+   gh release create vX.X.X --generate-notes
+   ```
+
+### Automated Release Tasks
+
 When a release is created, GitHub Actions automatically:
 
 1. Builds binaries for each platform

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -67,14 +67,14 @@ export async function startCommand(
     const isBranchUsedInWorktree = existingWorktreePath !== null;
     if (isBranchUsedInWorktree) {
       const shouldNavigate = await confirm(
-        `ブランチ '${branchName}' は既にworktree '${existingWorktreePath}' で使用中です。\n既存のworktreeに移動しますか? (Y/n)`,
+        `Branch '${branchName}' is already used in worktree '${existingWorktreePath}'.\nNavigate to the existing worktree? (Y/n)`,
       );
 
       if (shouldNavigate) {
         console.log(`cd '${existingWorktreePath}'`);
         Deno.exit(0);
       } else {
-        console.error("キャンセルしました");
+        console.error("Cancelled");
         Deno.exit(0);
       }
     }
@@ -105,8 +105,8 @@ export async function startCommand(
       } else {
         // Different branch - offer to overwrite
         const choice = await select(
-          `ディレクトリ '${worktreePath}' は既に存在します (branch: ${existingWorktree.branch}):`,
-          ["上書き(削除して再作成)", "再利用(既存を使用)", "キャンセル"],
+          `Directory '${worktreePath}' already exists (branch: ${existingWorktree.branch}):`,
+          ["Overwrite (remove and recreate)", "Reuse (use existing)", "Cancel"],
         );
 
         if (choice === 0) {
@@ -121,7 +121,7 @@ export async function startCommand(
           return;
         } else {
           // Cancel
-          console.error("キャンセルしました");
+          console.error("Cancelled");
           Deno.exit(0);
         }
       }

--- a/tests/e2e/interactive.test.ts
+++ b/tests/e2e/interactive.test.ts
@@ -56,7 +56,7 @@ describe("interactive prompts", () => {
 
       // Wait for the prompt about branch being in use
       const promptFound = await runner2.waitForPattern(
-        /既存のworktreeに移動しますか/,
+        /Navigate to the existing worktree/,
         5000,
       );
       if (!promptFound) {
@@ -104,7 +104,7 @@ describe("interactive prompts", () => {
 
       // Wait for the prompt
       const promptFound = await runner2.waitForPattern(
-        /既存のworktreeに移動しますか/,
+        /Navigate to the existing worktree/,
         5000,
       );
       if (!promptFound) {
@@ -118,7 +118,7 @@ describe("interactive prompts", () => {
 
       // Verify output contains cancellation message
       const output = runner2.getOutput();
-      assertOutputContains(output, "キャンセルしました");
+      assertOutputContains(output, "Cancelled");
       assertExitCode(runner2.getExitCode(), 0);
     } finally {
       runner2.dispose();
@@ -159,7 +159,7 @@ describe("interactive prompts", () => {
 
       // Wait for directory exists prompt
       const promptFound = await runner2.waitForPattern(
-        /ディレクトリ.*は既に存在します/,
+        /Directory.*already exists/,
         5000,
       );
       if (!promptFound) {
@@ -216,7 +216,7 @@ describe("interactive prompts", () => {
 
       // Wait for directory exists prompt
       const promptFound = await runner2.waitForPattern(
-        /ディレクトリ.*は既に存在します/,
+        /Directory.*already exists/,
         5000,
       );
       if (!promptFound) {
@@ -273,7 +273,7 @@ describe("interactive prompts", () => {
 
       // Wait for directory exists prompt
       const promptFound = await runner2.waitForPattern(
-        /ディレクトリ.*は既に存在します/,
+        /Directory.*already exists/,
         5000,
       );
       if (!promptFound) {
@@ -287,7 +287,7 @@ describe("interactive prompts", () => {
 
       // Verify cancellation message
       const output = runner2.getOutput();
-      assertOutputContains(output, "キャンセルしました");
+      assertOutputContains(output, "Cancelled");
       assertExitCode(runner2.getExitCode(), 0);
     } finally {
       runner2.dispose();
@@ -321,7 +321,7 @@ describe("interactive prompts", () => {
 
       // Wait for the prompt
       const promptFound = await runner2.waitForPattern(
-        /既存のworktreeに移動しますか/,
+        /Navigate to the existing worktree/,
         5000,
       );
       if (!promptFound) {


### PR DESCRIPTION
## Summary
- Replace all Japanese error messages in `src/commands/start.ts` with English
- Update E2E test assertions to match new English messages
- Document git-flow branching model and release process in CONTRIBUTING.md

## Changes

### Error Message Localization
**File: `src/commands/start.ts`**
- ❌ `ブランチ '...' は既にworktree '...' で使用中です` 
  ✅ `Branch '...' is already used in worktree '...'`
- ❌ `キャンセルしました`
  ✅ `Cancelled`
- ❌ `ディレクトリ '...' は既に存在します`
  ✅ `Directory '...' already exists`
- ❌ `["上書き(削除して再作成)", "再利用(既存を使用)", "キャンセル"]`
  ✅ `["Overwrite (remove and recreate)", "Reuse (use existing)", "Cancel"]`

### Test Updates
**File: `tests/e2e/interactive.test.ts`**
- Updated regex patterns and assertions to match new English messages
- All interactive prompt tests now check for English output

### Documentation
**File: `CONTRIBUTING.md`**
- Added git-flow branching model explanation
- Documented release process with branch protection considerations
- Provided step-by-step release workflow

## Motivation

This change addresses the code review feedback on PR #59, which flagged hardcoded Japanese messages as a critical issue. As an international CLI tool, error messages should default to English for broader accessibility.

## Related
- Fixes code review issue in PR #59
- Part of v0.3.0 release preparation