### PR TITLE
fix: vibe clean not working

### DIFF
--- a/tests/e2e/clean.test.ts
+++ b/tests/e2e/clean.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "child_process";
+import { existsSync } from "fs";
 import { basename, dirname } from "path";
-import { afterEach, describe, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import { getVibePath, VibeCommandRunner } from "./helpers/pty.js";
 import { setupTestGitRepo } from "./helpers/git-setup.js";
 import { assertExitCode, assertOutputContains } from "./helpers/assertions.js";
@@ -42,9 +43,11 @@ describe("clean command", () => {
 
       const output = runner.getOutput();
 
-      // Verify output contains cd command to main repo
-      assertOutputContains(output, "cd");
-      assertOutputContains(output, repoPath);
+      // Verify output contains success message
+      assertOutputContains(output, "has been removed");
+
+      // Verify worktree directory no longer exists
+      expect(existsSync(worktreePath)).toBe(false);
     } finally {
       runner.dispose();
     }


### PR DESCRIPTION
## Issue
close #61

## Summary

- Purpose:
  - Fix the `vibe clean` command to actually remove worktrees instead of just printing the command

- Background:
  - The `vibe clean` command was only outputting the removal command via `console.log()` without actually executing it
  - `post_clean` hooks were also not being executed

- Changes:
  - Modified `src/commands/clean.ts` to execute `git worktree remove` using `runGitCommand()`
  - Added `Deno.chdir(mainPath)` before worktree removal to ensure the process cwd remains valid after deletion
  - `post_clean` hooks are now properly executed via `runHooks()` from the main worktree
  - Updated tests to verify the worktree is actually removed

### Target Branch
develop

## Notes
- `pre_clean` hooks continue to work as before
- `post_clean` hooks now execute correctly from the main worktree after the secondary worktree is removed