### PR TITLE
chore: Bump version to 0.3.1

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",


### PR DESCRIPTION
## Summary
- Bump version from 0.3.0 to 0.3.1

## Changes since 0.3.0
- fix: vibe clean not working
- chore: Replace Japanese messages with English and update docs
- fix: Return normalized repo root in getRepoInfoFromPath

🤖 Generated with [Claude Code](https://claude.com/claude-code)