### PR TITLE
fix: Include src/version.ts in JSR publish

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -50,5 +50,8 @@
     "include": ["src/"],
     "exclude": ["tests/e2e/"]
   },
+  "publish": {
+    "exclude": ["!src/version.ts"]
+  },
   "nodeModulesDir": "auto"
 }


### PR DESCRIPTION
## Summary
- JSR publish failed because `src/version.ts` was excluded from the package
- `src/version.ts` is in `.gitignore` (auto-generated file) but imported by `main.ts`
- Added `publish.exclude` config with negative glob `!src/version.ts` to include the file

Fixes: https://github.com/kexi/vibe/actions/runs/20701834729/job/59425323346

## Test plan
- [x] Verified with `npx jsr publish --dry-run --allow-dirty`
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)