### PR TITLE
fix(docs): Add missing astro-eslint-parser dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -25,6 +25,7 @@
     "@eslint/js": "^9.17.0",
     "@typescript-eslint/eslint-plugin": "^8.52.0",
     "@typescript-eslint/parser": "^8.52.0",
+    "astro-eslint-parser": "^1.2.0",
     "eslint": "^9.39.2",
     "eslint-plugin-astro": "^1.5.0",
     "prettier": "^3.7.4",


### PR DESCRIPTION
## Summary

Add missing `astro-eslint-parser` to devDependencies to fix docs CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)