### PR TITLE
fix(docs): Add .prettierignore and format files

### DIFF
--- a/docs/.prettierignore
+++ b/docs/.prettierignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+.astro/
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary

- Add `.prettierignore` to exclude lock files and build artifacts
- Format `copy-strategies.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)