### PR TITLE
Add GitHub Star button to documentation header

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "vibe",
+      components: {
+        SocialIcons: "./src/components/CustomSocialIcons.astro",
+      },
       defaultLocale: "root",
       locales: {
         root: {

--- a/docs/src/components/CustomSocialIcons.astro
+++ b/docs/src/components/CustomSocialIcons.astro
@@ -1,0 +1,41 @@
+---
+import Default from '@astrojs/starlight/components/SocialIcons.astro';
+---
+
+<div class="social-icons-wrapper">
+  <span class="github-button-wrapper">
+    <a
+      class="github-button"
+      href="https://github.com/kexi/vibe"
+      data-color-scheme="no-preference: dark; light: light; dark: dark;"
+      data-icon="octicon-star"
+      data-show-count="true"
+      aria-label="Star kexi/vibe on GitHub"
+    >
+      Star
+    </a>
+  </span>
+  <Default><slot /></Default>
+</div>
+
+<script async defer src="https://buttons.github.io/buttons.js"></script>
+
+<style is:global>
+  .social-icons-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .github-button-wrapper {
+    display: flex;
+    align-items: center;
+    height: 20px;
+  }
+  .github-button-wrapper > span {
+    display: flex !important;
+    align-items: center;
+  }
+  .github-button-wrapper iframe {
+    vertical-align: middle !important;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add GitHub Star button to documentation site header
- Use buttons.github.io for dark mode support
- Override Starlight's SocialIcons component

## Test plan
- [ ] Verify Star button displays correctly in light mode
- [ ] Verify Star button displays correctly in dark mode
- [ ] Verify Star button links to correct repository
- [ ] Verify existing social icons are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)