### PR TITLE
fix(docs): Format CustomSocialIcons.astro with Prettier

### DIFF
--- a/docs/src/components/CustomSocialIcons.astro
+++ b/docs/src/components/CustomSocialIcons.astro
@@ -1,5 +1,5 @@
 ---
-import Default from '@astrojs/starlight/components/SocialIcons.astro';
+import Default from "@astrojs/starlight/components/SocialIcons.astro";
 ---
 
 <div class="social-icons-wrapper">


### PR DESCRIPTION
## Summary
- Fix prettier formatting issue in `CustomSocialIcons.astro`
- Unblock docs deployment workflow

## Problem
The Deploy Documentation workflow was failing because `CustomSocialIcons.astro` was not properly formatted with Prettier.

## Solution
Run `prettier --write` on the file to fix formatting (single quotes → double quotes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)