### PR TITLE
docs: Add Nushell, PowerShell and Linux to Getting Started

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -23,6 +23,18 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   <TabItem label="Deno">
     ```bash deno install -A --global jsr:@kexi/vibe ```
   </TabItem>
+  <TabItem label="Linux">
+    ```bash
+    # Ubuntu/Debian (x64)
+    curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_amd64.deb
+    sudo apt install ./vibe_amd64.deb
+
+    # Other distributions (x64)
+    curl -L https://github.com/kexi/vibe/releases/latest/download/vibe-linux-x64 -o vibe
+    chmod +x vibe && sudo mv vibe /usr/local/bin/
+    ```
+
+  </TabItem>
 </Tabs>
 
 ### 2. Set up your shell
@@ -48,6 +60,20 @@ Add the following to your shell configuration:
     function vibe
         eval (command vibe $argv)
     end
+    ```
+  </TabItem>
+  <TabItem label="Nushell">
+    ```nu
+    # Add to ~/.config/nushell/config.nu
+    def --env vibe [...args] {
+        ^vibe ...$args | lines | each { |line| nu -c $line }
+    }
+    ```
+  </TabItem>
+  <TabItem label="PowerShell">
+    ```powershell
+    # Add to your $PROFILE
+    function vibe { Invoke-Expression (& vibe.exe $args) }
     ```
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/ja/getting-started.mdx
+++ b/docs/src/content/docs/ja/getting-started.mdx
@@ -23,6 +23,18 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   <TabItem label="Deno">
     ```bash deno install -A --global jsr:@kexi/vibe ```
   </TabItem>
+  <TabItem label="Linux">
+    ```bash
+    # Ubuntu/Debian (x64)
+    curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_amd64.deb
+    sudo apt install ./vibe_amd64.deb
+
+    # その他のディストリビューション (x64)
+    curl -L https://github.com/kexi/vibe/releases/latest/download/vibe-linux-x64 -o vibe
+    chmod +x vibe && sudo mv vibe /usr/local/bin/
+    ```
+
+  </TabItem>
 </Tabs>
 
 ### 2. シェルを設定
@@ -48,6 +60,20 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     function vibe
         eval (command vibe $argv)
     end
+    ```
+  </TabItem>
+  <TabItem label="Nushell">
+    ```nu
+    # ~/.config/nushell/config.nu に追加
+    def --env vibe [...args] {
+        ^vibe ...$args | lines | each { |line| nu -c $line }
+    }
+    ```
+  </TabItem>
+  <TabItem label="PowerShell">
+    ```powershell
+    # $PROFILE に追加
+    function vibe { Invoke-Expression (& vibe.exe $args) }
     ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary
- Add Nushell and PowerShell shell setup instructions
- Add Linux installation options (deb package and binary)
- Updated both English and Japanese versions

## Changes
Getting Started guide now includes all shell types and installation methods that are available in the detailed Installation and Shell Setup pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)