### PR TITLE
docs: Add Google Tag Manager

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -6,8 +6,19 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "vibe",
+      head: [
+        {
+          tag: "script",
+          content: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-KPMKW4GX');`,
+        },
+      ],
       components: {
         SocialIcons: "./src/components/CustomSocialIcons.astro",
+        SkipLink: "./src/components/SkipLink.astro",
       },
       defaultLocale: "root",
       locales: {

--- a/docs/src/components/SkipLink.astro
+++ b/docs/src/components/SkipLink.astro
@@ -1,0 +1,36 @@
+---
+const PAGE_TITLE_ID = "_top";
+---
+
+<!-- Google Tag Manager (noscript) -->
+<noscript>
+  <iframe
+    src="https://www.googletagmanager.com/ns.html?id=GTM-KPMKW4GX"
+    height="0"
+    width="0"
+    style="display:none;visibility:hidden"></iframe>
+</noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<a href={`#${PAGE_TITLE_ID}`}>{Astro.locals.t("skipLink.label")}</a>
+
+<style>
+  @layer starlight.core {
+    a {
+      clip: rect(0, 0, 0, 0);
+      position: fixed;
+      top: 0.75rem;
+      inset-inline-start: 0.75rem;
+    }
+    a:focus {
+      clip: unset;
+      z-index: var(--sl-z-index-skiplink);
+      display: block;
+      padding: 0.5rem 1rem;
+      text-decoration: none;
+      color: var(--sl-color-text-invert);
+      background-color: var(--sl-color-text-accent);
+      box-shadow: var(--sl-shadow-lg);
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add Google Tag Manager (GTM-KPMKW4GX) to documentation site
- GTM script added to `<head>` via Starlight head config
- Custom SkipLink component created for noscript fallback in `<body>`

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [ ] Verify GTM tag fires correctly in GTM Preview mode after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)