### PR TITLE
build: add --allow-ffi flag to CI/release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Generate version.ts
         run: deno task generate-version --target ${{ matrix.target }} --distribution binary
       - name: Compile binary (${{ matrix.name }})
-        run: deno compile --allow-run --allow-read --allow-write --allow-env --target ${{ matrix.target }} --output vibe-${{ matrix.name }} main.ts
+        run: deno compile --allow-run --allow-read --allow-write --allow-env --allow-ffi --target ${{ matrix.target }} --output vibe-${{ matrix.name }} main.ts
 
   build-deb:
     runs-on: ubuntu-latest
@@ -80,7 +80,7 @@ jobs:
       - name: Generate version.ts
         run: deno task generate-version --target ${{ matrix.target }} --distribution deb
       - name: Compile Linux binary
-        run: deno compile --allow-run --allow-read --allow-write --allow-env --target ${{ matrix.target }} --output vibe-test main.ts
+        run: deno compile --allow-run --allow-read --allow-write --allow-env --allow-ffi --target ${{ matrix.target }} --output vibe-test main.ts
       - name: Build .deb package
         run: |
           VERSION=$(deno task get-version)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: deno task generate-version --target ${{ matrix.target }} --distribution binary
 
       - name: Compile
-        run: deno compile --allow-run --allow-read --allow-write --allow-env --target ${{ matrix.target }} --output ${{ matrix.artifact }} main.ts
+        run: deno compile --allow-run --allow-read --allow-write --allow-env --allow-ffi --target ${{ matrix.target }} --output ${{ matrix.artifact }} main.ts
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -74,7 +74,7 @@ jobs:
           TARGET="${{ matrix.arch == 'amd64' && 'x86_64-unknown-linux-gnu' || 'aarch64-unknown-linux-gnu' }}"
           deno task generate-version --target "$TARGET" --distribution deb
           # Recompile with deb distribution metadata
-          deno compile --allow-run --allow-read --allow-write --allow-env \
+          deno compile --allow-run --allow-read --allow-write --allow-env --allow-ffi \
             --target "$TARGET" \
             --output vibe-deb \
             main.ts


### PR DESCRIPTION
## Summary
- CI/リリースワークフローの全コンパイルコマンドに `--allow-ffi` フラグを追加
- これにより、リリースバイナリでネイティブ clonefile() が有効になる
- このフラグがないと、macOS で FFI ベースの clonefile() ではなく `cp -c` にフォールバックしていた

## Changes
- `.github/workflows/ci.yml`: build-binaries, build-deb に `--allow-ffi` 追加
- `.github/workflows/release.yml`: build, build-deb に `--allow-ffi` 追加

## Test plan
- [ ] CI が通ることを確認
- [ ] macOS でビルドしたバイナリが `(clonefile)` と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)