### PR TITLE
chore: release v0.5.2

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",


### PR DESCRIPTION
## Summary
- バージョンを 0.5.1 から 0.5.2 に更新

## Changes in this release
- `--allow-ffi` フラグをCI/リリースワークフローに追加 (#101)
- リリースバイナリでネイティブ clonefile() が有効に

## Test plan
- [ ] CI が通ることを確認
- [ ] リリース後、macOS で `(clonefile)` と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)