### PR TITLE
fix(docs): format vibe-toml.mdx with prettier

### DIFF
--- a/docs/src/content/docs/configuration/vibe-toml.mdx
+++ b/docs/src/content/docs/configuration/vibe-toml.mdx
@@ -108,12 +108,12 @@ path_script = "~/.config/vibe/worktree-path.sh"
 
 The script receives these environment variables:
 
-| Variable | Description | Example |
-| -------- | ----------- | ------- |
-| `VIBE_REPO_NAME` | Repository name | `my-project` |
-| `VIBE_BRANCH_NAME` | Branch name | `feat/new-feature` |
+| Variable                | Description                       | Example            |
+| ----------------------- | --------------------------------- | ------------------ |
+| `VIBE_REPO_NAME`        | Repository name                   | `my-project`       |
+| `VIBE_BRANCH_NAME`      | Branch name                       | `feat/new-feature` |
 | `VIBE_SANITIZED_BRANCH` | Sanitized branch name (`/` → `-`) | `feat-new-feature` |
-| `VIBE_REPO_ROOT` | Repository root path | `/path/to/repo` |
+| `VIBE_REPO_ROOT`        | Repository root path              | `/path/to/repo`    |
 
 **Example script:**
 

--- a/docs/src/content/docs/ja/configuration/vibe-toml.mdx
+++ b/docs/src/content/docs/ja/configuration/vibe-toml.mdx
@@ -108,12 +108,12 @@ path_script = "~/.config/vibe/worktree-path.sh"
 
 スクリプトは以下の環境変数を受け取ります：
 
-| 環境変数 | 説明 | 例 |
-| -------- | ---- | --- |
-| `VIBE_REPO_NAME` | リポジトリ名 | `my-project` |
-| `VIBE_BRANCH_NAME` | ブランチ名 | `feat/new-feature` |
+| 環境変数                | 説明                                | 例                 |
+| ----------------------- | ----------------------------------- | ------------------ |
+| `VIBE_REPO_NAME`        | リポジトリ名                        | `my-project`       |
+| `VIBE_BRANCH_NAME`      | ブランチ名                          | `feat/new-feature` |
 | `VIBE_SANITIZED_BRANCH` | サニタイズ済みブランチ名（`/`→`-`） | `feat-new-feature` |
-| `VIBE_REPO_ROOT` | リポジトリルートパス | `/path/to/repo` |
+| `VIBE_REPO_ROOT`        | リポジトリルートパス                | `/path/to/repo`    |
 
 **スクリプト例：**
 


### PR DESCRIPTION
## Summary
- Fix prettier formatting issues in `vibe-toml.mdx` files (EN/JA)
- Resolves CI failure on main branch

## Test plan
- [x] `pnpm format` passes in docs directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)