### PR TITLE
docs: update changelog for v0.5.1, v0.5.2, v0.6.0, v0.7.0

### DIFF
--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -5,6 +5,69 @@ description: Version history and release notes for vibe
 
 All notable changes to vibe are documented here.
 
+## v0.7.0
+
+**Released:** 2026-01-13
+
+### Added
+
+- OGP meta tags for SNS preview on documentation site
+
+### Changed
+
+- Converted to pnpm workspace with docs CI checks
+- Configured minimum release age for supply chain security
+
+### Fixed
+
+- `vibe clean` now outputs cd command to return to main worktree
+
+---
+
+## v0.6.0
+
+**Released:** 2026-01-13
+
+### Added
+
+- **Worktree path customization** via external script
+  - Configure `path_script` to dynamically determine worktree directory path
+  - Environment variables: `VIBE_REPO_NAME`, `VIBE_BRANCH_NAME`, `VIBE_SANITIZED_BRANCH`, `VIBE_REPO_ROOT`
+
+### Changed
+
+- Unified deno compile commands into deno task
+
+---
+
+## v0.5.2
+
+**Released:** 2026-01-13
+
+### Fixed
+
+- Added `--allow-ffi` flag to all compile commands in CI/release workflows
+
+---
+
+## v0.5.1
+
+**Released:** 2026-01-13
+
+### Added
+
+- Documentation site (Starlight-based)
+- GitHub Star button in header
+- Windows, Nushell, PowerShell, and Linux installation guides
+- Automated documentation deployment via GitHub Actions
+
+### Changed
+
+- Parallelized directory copy for improved performance
+- Display copy strategy name during file operations
+
+---
+
 ## v0.5.0
 
 **Released:** 2026-01-10

--- a/docs/src/content/docs/ja/changelog.mdx
+++ b/docs/src/content/docs/ja/changelog.mdx
@@ -5,6 +5,69 @@ description: vibeのバージョン履歴とリリースノート
 
 vibeの主要な変更はここに記録されています。
 
+## v0.7.0
+
+**リリース日:** 2026年1月13日
+
+### 追加
+
+- ドキュメントサイトにSNSプレビュー用のOGPメタタグ
+
+### 変更
+
+- pnpm workspaceへの変換とdocs CIチェックの追加
+- サプライチェーンセキュリティのためのminimum release age設定
+
+### 修正
+
+- `vibe clean`でmain worktreeに戻るcdコマンドを出力
+
+---
+
+## v0.6.0
+
+**リリース日:** 2026年1月13日
+
+### 追加
+
+- 外部スクリプトによる**Worktreeパスのカスタマイズ**
+  - `path_script`を設定してworktreeディレクトリパスを動的に決定
+  - 環境変数: `VIBE_REPO_NAME`, `VIBE_BRANCH_NAME`, `VIBE_SANITIZED_BRANCH`, `VIBE_REPO_ROOT`
+
+### 変更
+
+- deno compileコマンドをdeno taskに統一
+
+---
+
+## v0.5.2
+
+**リリース日:** 2026年1月13日
+
+### 修正
+
+- CI/リリースワークフローのコンパイルコマンドに`--allow-ffi`フラグを追加
+
+---
+
+## v0.5.1
+
+**リリース日:** 2026年1月13日
+
+### 追加
+
+- ドキュメントサイト（Starlightベース）
+- ヘッダーにGitHub Starボタン
+- Windows、Nushell、PowerShell、Linuxのインストールガイド
+- GitHub Actionsによるドキュメント自動デプロイ
+
+### 変更
+
+- ディレクトリコピーの並列化によるパフォーマンス改善
+- ファイル操作中にコピー戦略名を表示
+
+---
+
 ## v0.5.0
 
 **リリース日:** 2026年1月10日


### PR DESCRIPTION
## Summary
- v0.5.1〜v0.7.0 のリリースノートを changelog に追加
- 英語版・日本語版の両方を更新

## Changes
- **v0.7.0**: OGP meta tags, pnpm workspace化, vibe clean修正
- **v0.6.0**: path_scriptによるworktreeパスカスタマイズ
- **v0.5.2**: CI/releaseワークフローに--allow-ffiフラグ追加
- **v0.5.1**: ドキュメントサイト、Windows/Linux対応、パフォーマンス改善

## Test plan
- [x] `pnpm --filter docs build` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)