### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",

--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -5,6 +5,28 @@ description: Version history and release notes for vibe
 
 All notable changes to vibe are documented here.
 
+## v0.8.0
+
+**Released:** 2026-01-14
+
+### Added
+
+- `vibe upgrade` command to check for updates and show upgrade instructions
+- `--dry-run` option for `vibe start` to preview operations without executing
+- `--delete-branch` / `--keep-branch` options for `vibe clean` command
+- `--force` / `-f` option for `vibe clean` to skip confirmation prompts
+- `[clean] delete_branch` config option in `.vibe.toml`
+
+### Changed
+
+- Claude Actions switched from OAuth to API key authentication
+
+### Fixed
+
+- Add `--force` flag when removing worktree with uncommitted changes
+
+---
+
 ## v0.7.0
 
 **Released:** 2026-01-13

--- a/docs/src/content/docs/ja/changelog.mdx
+++ b/docs/src/content/docs/ja/changelog.mdx
@@ -5,6 +5,28 @@ description: vibeのバージョン履歴とリリースノート
 
 vibeの主要な変更はここに記録されています。
 
+## v0.8.0
+
+**リリース日:** 2026年1月14日
+
+### 追加
+
+- `vibe upgrade` コマンド - 新しいバージョンのチェックとアップグレード方法の表示
+- `vibe start` に `--dry-run` オプション - 操作を実行せずにプレビュー
+- `vibe clean` に `--delete-branch` / `--keep-branch` オプション
+- `vibe clean` に `--force` / `-f` オプション - 確認プロンプトをスキップ
+- `.vibe.toml` に `[clean] delete_branch` 設定オプション
+
+### 変更
+
+- Claude ActionsをOAuth認証からAPIキー認証に変更
+
+### 修正
+
+- 未コミットの変更があるworktreeの削除時に`--force`フラグを追加
+
+---
+
 ## v0.7.0
 
 **リリース日:** 2026年1月13日


### PR DESCRIPTION
## Summary
- Bump version to 0.8.0
- Update changelog (English and Japanese)

## Changes in v0.8.0

### Added
- `vibe upgrade` command to check for updates and show upgrade instructions
- `--dry-run` option for `vibe start` to preview operations without executing
- `--delete-branch` / `--keep-branch` options for `vibe clean` command
- `--force` / `-f` option for `vibe clean` to skip confirmation prompts
- `[clean] delete_branch` config option in `.vibe.toml`

### Changed
- Claude Actions switched from OAuth to API key authentication

### Fixed
- Add `--force` flag when removing worktree with uncommitted changes

## Test plan
- [x] Version updated in deno.json
- [x] Changelog updated (English)
- [x] Changelog updated (Japanese)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)