### PR TITLE
fix: restore --delete-branch and --force options in clean command

### DIFF
--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -1,6 +1,7 @@
 import {
   getMainWorktreePath,
   getRepoRoot,
+  getWorktreeByPath,
   hasUncommittedChanges,
   isMainWorktree,
   runGitCommand,
@@ -10,7 +11,13 @@ import { type HookTrackerInfo, runHooks } from "../utils/hooks.ts";
 import { confirm } from "../utils/prompt.ts";
 import { ProgressTracker } from "../utils/progress.ts";
 
-export async function cleanCommand(): Promise<void> {
+interface CleanOptions {
+  force?: boolean;
+  deleteBranch?: boolean;
+  keepBranch?: boolean;
+}
+
+export async function cleanCommand(options: CleanOptions = {}): Promise<void> {
   try {
     const isMain = await isMainWorktree();
     if (isMain) {
@@ -21,18 +28,28 @@ export async function cleanCommand(): Promise<void> {
     }
 
     const hasChanges = await hasUncommittedChanges();
+    let forceRemove = false;
     if (hasChanges) {
-      const shouldContinue = await confirm(
-        "Warning: This worktree has uncommitted changes. Do you want to continue? (Y/n)",
-      );
-      if (!shouldContinue) {
-        console.error("Clean operation cancelled.");
-        Deno.exit(0);
+      if (options.force) {
+        forceRemove = true;
+      } else {
+        const shouldContinue = await confirm(
+          "Warning: This worktree has uncommitted changes. Do you want to continue? (Y/n)",
+        );
+        if (!shouldContinue) {
+          console.error("Clean operation cancelled.");
+          Deno.exit(0);
+        }
+        forceRemove = true;
       }
     }
 
     const currentWorktreePath = await getRepoRoot();
     const mainPath = await getMainWorktreePath();
+
+    // Get current branch name before removing worktree
+    const worktreeInfo = await getWorktreeByPath(currentWorktreePath);
+    const currentBranch = worktreeInfo?.branch;
 
     // Load configuration
     const config = await loadVibeConfig(currentWorktreePath);
@@ -71,13 +88,12 @@ export async function cleanCommand(): Promise<void> {
     Deno.chdir(mainPath);
 
     // Remove worktree
-    await runGitCommand([
-      "-C",
-      mainPath,
-      "worktree",
-      "remove",
-      currentWorktreePath,
-    ]);
+    const removeArgs = ["-C", mainPath, "worktree", "remove"];
+    if (forceRemove) {
+      removeArgs.push("--force");
+    }
+    removeArgs.push(currentWorktreePath);
+    await runGitCommand(removeArgs);
 
     // Run post_clean hooks from main worktree
     const postCleanHooks = config?.hooks?.post_clean;
@@ -89,6 +105,29 @@ export async function cleanCommand(): Promise<void> {
     }
 
     console.error(`Worktree ${currentWorktreePath} has been removed.`);
+
+    // Determine whether to delete branch
+    // Priority: CLI option > config > default (false)
+    let shouldDeleteBranch = false;
+    if (options.deleteBranch) {
+      shouldDeleteBranch = true;
+    } else if (options.keepBranch) {
+      shouldDeleteBranch = false;
+    } else if (config?.clean?.delete_branch !== undefined) {
+      shouldDeleteBranch = config.clean.delete_branch;
+    }
+
+    // Delete branch if requested
+    if (shouldDeleteBranch && currentBranch) {
+      try {
+        await runGitCommand(["-C", mainPath, "branch", "-d", currentBranch]);
+        console.error(`Branch ${currentBranch} has been deleted.`);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error(`Warning: Could not delete branch ${currentBranch}: ${errorMessage}`);
+        console.error("You may need to delete it manually with: git branch -D " + currentBranch);
+      }
+    }
 
     // Output cd command for shell wrapper to eval
     console.log(`cd '${mainPath}'`);


### PR DESCRIPTION
## Summary
- Restore `--delete-branch` option that was accidentally removed by v0.8.0 revert
- Restore `--force/-f` option for skipping confirmation prompts
- Restore `--keep-branch` option to override config settings
- Fix mismatch between `main.ts` (parsing options) and `clean.ts` (not accepting them)

## Background
The revert commit `e47a21f` reverted `clean.ts` to a version without these features, while `main.ts` still had the option parsing code, causing a runtime mismatch.

## Test plan
- [ ] Run `vibe clean --delete-branch` and verify branch is deleted
- [ ] Run `vibe clean --keep-branch` and verify branch is kept
- [ ] Run `vibe clean --force` with uncommitted changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)