### PR TITLE
fix(docs): add twitter:card meta tag for X OGP display

### DIFF
--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -13,4 +13,5 @@ const ogImageUrl = `${siteUrl}/og/${slug}.png`;
 <meta property="og:image" content={ogImageUrl} />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
+<meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content={ogImageUrl} />


### PR DESCRIPTION
## Summary
- Fix OGP image not displaying on X (Twitter)
- Add `twitter:card` meta tag

## Root Cause
X (Twitter) requires the `twitter:card` meta tag to display OGP images, but it was not set.

## Changes
Added the following to `docs/src/components/Head.astro`:
```html
<meta name="twitter:card" content="summary_large_image" />
```

## Test plan
- [ ] After deployment, share a URL on X (Twitter) and verify the OGP image displays

🤖 Generated with [Claude Code](https://claude.ai/code)