### PR TITLE
docs: add terminal frame to code blocks in installation docs

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -19,12 +19,18 @@ vibe is a CLI tool that simplifies Git Worktree management. It helps you:
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Tabs>
-  <TabItem label="Homebrew">```bash brew install kexi/tap/vibe ```</TabItem>
+  <TabItem label="Homebrew">
+    ```bash frame="terminal"
+    brew install kexi/tap/vibe
+    ```
+  </TabItem>
   <TabItem label="Deno">
-    ```bash deno install -A --global jsr:@kexi/vibe ```
+    ```bash frame="terminal"
+    deno install -A --global jsr:@kexi/vibe
+    ```
   </TabItem>
   <TabItem label="Linux">
-    ```bash
+    ```bash frame="terminal"
     # Ubuntu/Debian (x64)
     curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_amd64.deb
     sudo apt install ./vibe_amd64.deb
@@ -36,7 +42,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
   </TabItem>
   <TabItem label="Windows">
-    ```powershell
+    ```powershell frame="terminal"
     Invoke-WebRequest -Uri "https://github.com/kexi/vibe/releases/latest/download/vibe-windows-x64.exe" -OutFile "$env:LOCALAPPDATA\vibe.exe"
     # Add to PATH (first time only)
     $path = [Environment]::GetEnvironmentVariable("Path", "User")
@@ -52,19 +58,19 @@ Add the following to your shell configuration:
 
 <Tabs>
   <TabItem label="Zsh">
-    ```bash
+    ```bash frame="terminal"
     # Add to ~/.zshrc
     vibe() { eval "$(command vibe "$@")" }
     ```
   </TabItem>
   <TabItem label="Bash">
-    ```bash
+    ```bash frame="terminal"
     # Add to ~/.bashrc
     vibe() { eval "$(command vibe "$@")"; }
     ```
   </TabItem>
   <TabItem label="Fish">
-    ```fish
+    ```fish frame="terminal"
     # Add to ~/.config/fish/config.fish
     function vibe
         eval (command vibe $argv)
@@ -72,7 +78,7 @@ Add the following to your shell configuration:
     ```
   </TabItem>
   <TabItem label="Nushell">
-    ```nu
+    ```nu frame="terminal"
     # Add to ~/.config/nushell/config.nu
     def --env vibe [...args] {
         ^vibe ...$args | lines | each { |line| nu -c $line }
@@ -80,7 +86,7 @@ Add the following to your shell configuration:
     ```
   </TabItem>
   <TabItem label="PowerShell">
-    ```powershell
+    ```powershell frame="terminal"
     # Add to your $PROFILE
     function vibe { Invoke-Expression (& vibe.exe $args) }
     ```
@@ -89,7 +95,7 @@ Add the following to your shell configuration:
 
 ### 3. Create your first worktree
 
-```bash
+```bash frame="terminal"
 # Start working on a new feature
 vibe start feat/my-new-feature
 

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -9,18 +9,18 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Tabs>
   <TabItem label="Homebrew (macOS)">
-    ```bash
+    ```bash frame="terminal"
     brew install kexi/tap/vibe
     ```
   </TabItem>
   <TabItem label="Deno (JSR)">
-    ```bash
+    ```bash frame="terminal"
     deno install -A --global jsr:@kexi/vibe
     ```
 
     **Permissions**: For more security, you can specify exact permissions instead of `-A`:
 
-    ```bash
+    ```bash frame="terminal"
     deno install --global --allow-run --allow-read --allow-write --allow-env --allow-ffi jsr:@kexi/vibe
     ```
 
@@ -39,7 +39,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
     Then run:
 
-    ```bash
+    ```bash frame="terminal"
     mise install
     ```
 
@@ -54,7 +54,7 @@ WSL2 users can use the Linux installation methods below based on their distribut
 
 <Tabs>
   <TabItem label="Ubuntu/Debian">
-    ```bash
+    ```bash frame="terminal"
     # x64
     curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_amd64.deb
     sudo apt install ./vibe_amd64.deb
@@ -69,7 +69,7 @@ WSL2 users can use the Linux installation methods below based on their distribut
 
   </TabItem>
   <TabItem label="Other Distributions">
-    ```bash
+    ```bash frame="terminal"
     # x64
     curl -L https://github.com/kexi/vibe/releases/latest/download/vibe-linux-x64 -o vibe
     chmod +x vibe
@@ -86,7 +86,7 @@ WSL2 users can use the Linux installation methods below based on their distribut
 
 ## Windows
 
-```powershell
+```powershell frame="terminal"
 # Download
 Invoke-WebRequest -Uri "https://github.com/kexi/vibe/releases/latest/download/vibe-windows-x64.exe" -OutFile "$env:LOCALAPPDATA\vibe.exe"
 
@@ -99,7 +99,7 @@ $path = [Environment]::GetEnvironmentVariable("Path", "User")
 
 If you have Deno installed, you can compile from source:
 
-```bash
+```bash frame="terminal"
 git clone https://github.com/kexi/vibe.git
 cd vibe
 deno compile --allow-run --allow-read --allow-write --allow-env --allow-ffi --output vibe main.ts

--- a/docs/src/content/docs/ja/getting-started.mdx
+++ b/docs/src/content/docs/ja/getting-started.mdx
@@ -19,12 +19,18 @@ vibeはGit Worktreeの管理を簡素化するCLIツールです。以下のこ�
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Tabs>
-  <TabItem label="Homebrew">```bash brew install kexi/tap/vibe ```</TabItem>
+  <TabItem label="Homebrew">
+    ```bash frame="terminal"
+    brew install kexi/tap/vibe
+    ```
+  </TabItem>
   <TabItem label="Deno">
-    ```bash deno install -A --global jsr:@kexi/vibe ```
+    ```bash frame="terminal"
+    deno install -A --global jsr:@kexi/vibe
+    ```
   </TabItem>
   <TabItem label="Linux">
-    ```bash
+    ```bash frame="terminal"
     # Ubuntu/Debian (x64)
     curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_amd64.deb
     sudo apt install ./vibe_amd64.deb
@@ -36,7 +42,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
   </TabItem>
   <TabItem label="Windows">
-    ```powershell
+    ```powershell frame="terminal"
     Invoke-WebRequest -Uri "https://github.com/kexi/vibe/releases/latest/download/vibe-windows-x64.exe" -OutFile "$env:LOCALAPPDATA\vibe.exe"
     # PATHに追加（初回のみ）
     $path = [Environment]::GetEnvironmentVariable("Path", "User")
@@ -52,19 +58,19 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Tabs>
   <TabItem label="Zsh">
-    ```bash
+    ```bash frame="terminal"
     # ~/.zshrc に追加
     vibe() { eval "$(command vibe "$@")" }
     ```
   </TabItem>
   <TabItem label="Bash">
-    ```bash
+    ```bash frame="terminal"
     # ~/.bashrc に追加
     vibe() { eval "$(command vibe "$@")"; }
     ```
   </TabItem>
   <TabItem label="Fish">
-    ```fish
+    ```fish frame="terminal"
     # ~/.config/fish/config.fish に追加
     function vibe
         eval (command vibe $argv)
@@ -72,7 +78,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     ```
   </TabItem>
   <TabItem label="Nushell">
-    ```nu
+    ```nu frame="terminal"
     # ~/.config/nushell/config.nu に追加
     def --env vibe [...args] {
         ^vibe ...$args | lines | each { |line| nu -c $line }
@@ -80,7 +86,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     ```
   </TabItem>
   <TabItem label="PowerShell">
-    ```powershell
+    ```powershell frame="terminal"
     # $PROFILE に追加
     function vibe { Invoke-Expression (& vibe.exe $args) }
     ```
@@ -89,7 +95,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 ### 3. 最初のWorktreeを作成
 
-```bash
+```bash frame="terminal"
 # 新機能の作業を開始
 vibe start feat/my-new-feature
 

--- a/docs/src/content/docs/ja/installation.mdx
+++ b/docs/src/content/docs/ja/installation.mdx
@@ -9,18 +9,18 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Tabs>
   <TabItem label="Homebrew (macOS)">
-    ```bash
+    ```bash frame="terminal"
     brew install kexi/tap/vibe
     ```
   </TabItem>
   <TabItem label="Deno (JSR)">
-    ```bash
+    ```bash frame="terminal"
     deno install -A --global jsr:@kexi/vibe
     ```
 
     **権限設定**: より安全にするため、`-A`の代わりに必要な権限のみを指定できます：
 
-    ```bash
+    ```bash frame="terminal"
     deno install --global --allow-run --allow-read --allow-write --allow-env --allow-ffi jsr:@kexi/vibe
     ```
 
@@ -39,7 +39,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
     その後、インストール：
 
-    ```bash
+    ```bash frame="terminal"
     mise install
     ```
 
@@ -54,7 +54,7 @@ WSL2ユーザーは、使用しているディストリビューションに応�
 
 <Tabs>
   <TabItem label="Ubuntu/Debian">
-    ```bash
+    ```bash frame="terminal"
     # x64
     curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_amd64.deb
     sudo apt install ./vibe_amd64.deb
@@ -69,7 +69,7 @@ WSL2ユーザーは、使用しているディストリビューションに応�
 
   </TabItem>
   <TabItem label="その他のディストリビューション">
-    ```bash
+    ```bash frame="terminal"
     # x64
     curl -L https://github.com/kexi/vibe/releases/latest/download/vibe-linux-x64 -o vibe
     chmod +x vibe
@@ -86,7 +86,7 @@ WSL2ユーザーは、使用しているディストリビューションに応�
 
 ## Windows
 
-```powershell
+```powershell frame="terminal"
 # ダウンロード
 Invoke-WebRequest -Uri "https://github.com/kexi/vibe/releases/latest/download/vibe-windows-x64.exe" -OutFile "$env:LOCALAPPDATA\vibe.exe"
 
@@ -99,7 +99,7 @@ $path = [Environment]::GetEnvironmentVariable("Path", "User")
 
 Denoがインストールされている場合、ソースからコンパイルできます：
 
-```bash
+```bash frame="terminal"
 git clone https://github.com/kexi/vibe.git
 cd vibe
 deno compile --allow-run --allow-read --allow-write --allow-env --allow-ffi --output vibe main.ts


### PR DESCRIPTION
## Summary
- Add `frame="terminal"` to all shell command code blocks in installation and getting-started docs
- Unify the Expressive Code terminal window styling across all installation pages (EN/JA)
- Fix inline code blocks to use multi-line format for proper frame rendering

## Test plan
- [ ] Run `pnpm dev` in docs directory
- [ ] Verify `/installation/` shows terminal frames on all code blocks
- [ ] Verify `/ja/installation/` shows terminal frames on all code blocks
- [ ] Verify `/getting-started/` shows terminal frames on all code blocks
- [ ] Verify `/ja/getting-started/` shows terminal frames on all code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)