### PR TITLE
fix: add --allow-net flag to build script for upgrade command

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -131,6 +131,7 @@ async function compile(options: CompileOptions): Promise<void> {
     "--allow-write",
     "--allow-env",
     "--allow-ffi",
+    "--allow-net",
   ];
 
   if (options.target !== undefined) {


### PR DESCRIPTION
## Summary
- `upgrade` コマンドが jsr.io から最新バージョン情報を取得するために `--allow-net` フラグが必要
- ビルドスクリプトにフラグが設定されていなかったため、実行時にネットワーク許可のプロンプトが表示されていた
- バージョンを 0.9.1 に更新

## Test plan
- [x] `deno task compile` でビルド
- [x] `./vibe upgrade` を実行し、ネットワーク許可のプロンプトが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)