### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",


### PR DESCRIPTION
## Summary
- バージョンを 0.10.0 から 0.11.0 にバンプ

## Test plan
- [x] `deno task generate-version` でバージョンが正しく生成されることを確認
- [x] `src/version.ts` に `0.11.0` が反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)