### PR TITLE
docs: add shell setup step to Quick Start on homepage

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -43,9 +43,14 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 # Install via Homebrew (macOS)
 brew install kexi/tap/vibe
 
+# Set up shell integration (add to ~/.zshrc)
+vibe() { eval "$(command vibe "$@")" }
+
 # Create a worktree for a new feature
 vibe start feat/new-feature
 
 # When done, clean up
 vibe clean
 ```
+
+> **Note:** Using a different shell? See the [Getting Started](/getting-started/#2-set-up-your-shell) guide for Bash, Fish, Nushell, and PowerShell setup.


### PR DESCRIPTION
## Summary
- Quick Startセクションにシェル統合の設定ステップを追加
- 他のシェル（Bash、Fish、Nushell、PowerShell）向けにGetting Startedページへのリンクを含む注釈を追加

## Background
`vibe`はシェルラッパー関数が必要です（サブプロセスは親プロセスのディレクトリを変更できないため）。シェル統合なしでは`vibe start`実行後にworktreeへ自動的に`cd`されません。

Closes #168

## Test plan
- [ ] ドキュメントサイトでQuick Startセクションを確認
- [ ] シェル設定コードブロックが正しく表示されることを確認
- [ ] Getting Startedへのリンクが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)