### PR TITLE
fix: resolve GitHub Actions CI build failures

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -66,7 +66,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -83,8 +83,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Install dependencies
-        working-directory: packages/@kexi/vibe-native
-        run: pnpm install
+        run: pnpm install --filter @kexi/vibe-native
 
       - name: Build native module
         working-directory: packages/@kexi/vibe-native


### PR DESCRIPTION
## Summary
- Replace retired `macos-13` runner with `macos-latest` for `x86_64-apple-darwin` target
- Use `pnpm install --filter @kexi/vibe-native` to avoid installing root `node-pty` dependency that requires `node-gyp`

## Test plan
- [ ] Verify CI passes on all platforms after merging
- [ ] Create a test release tag to confirm publish workflow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)