### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Git worktree helper CLI",
   "type": "module",
   "bin": {

--- a/packages/@kexi/vibe-native/package.json
+++ b/packages/@kexi/vibe-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-native",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Native clone operations for vibe CLI (clonefile on macOS, FICLONE on Linux)",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary
- Bump version to 0.12.1 for CI fix release

## Test plan
- [ ] Merge and create release tag v0.12.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)