### PR TITLE
fix: skip postinstall scripts in CI native build

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -83,7 +83,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Install dependencies
-        run: pnpm install --filter @kexi/vibe-native
+        run: pnpm install --filter @kexi/vibe-native --ignore-scripts
 
       - name: Build native module
         working-directory: packages/@kexi/vibe-native


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` option to pnpm install in `build-native` job
- Prevents node-pty from failing with `node-gyp: not found` error on Linux

## Problem
Linux builds (x86_64 and aarch64) failed with:
```
node_modules/node-pty install: sh: 1: node-gyp: not found
ELIFECYCLE  Command failed.
```

This occurred because:
1. pnpm workspace shared node_modules installs node-pty (e2e test dependency)
2. node-pty lacks Linux prebuilds, triggering `node-gyp rebuild`
3. node-gyp is not installed in the CI environment

macOS builds succeeded because node-pty has prebuilds available.

## Test plan
- [ ] Verify Linux x86_64 build passes in CI
- [ ] Verify Linux aarch64 build passes in CI
- [ ] Verify macOS builds still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)