### PR TITLE
ci: add workflow_dispatch trigger to publish-npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,6 +3,7 @@ name: Publish to npm
 on:
   release:
     types: [released]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to enable manual workflow execution

## Note
⚠️ Manual execution from non-tag branches will fail at version validation step (uses `GITHUB_REF_NAME` for version check). For testing, run from a tag ref or skip version validation.

## Test plan
- [ ] Verify workflow appears in Actions tab with "Run workflow" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)