### PR TITLE
chore: bump version to 0.12.2

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",
@@ -35,10 +35,17 @@
     "strict": true
   },
   "lint": {
-    "include": ["src/", "main.ts"],
-    "exclude": ["src/runtime/node/"],
+    "include": [
+      "src/",
+      "main.ts"
+    ],
+    "exclude": [
+      "src/runtime/node/"
+    ],
     "rules": {
-      "tags": ["recommended"]
+      "tags": [
+        "recommended"
+      ]
     }
   },
   "fmt": {
@@ -47,14 +54,23 @@
     "indentWidth": 2,
     "semiColons": true,
     "singleQuote": false,
-    "include": ["src/", "main.ts"]
+    "include": [
+      "src/",
+      "main.ts"
+    ]
   },
   "test": {
-    "include": ["src/"],
-    "exclude": ["tests/e2e/"]
+    "include": [
+      "src/"
+    ],
+    "exclude": [
+      "tests/e2e/"
+    ]
   },
   "publish": {
-    "exclude": ["!src/version.ts"]
+    "exclude": [
+      "!src/version.ts"
+    ]
   },
   "nodeModulesDir": "none",
   "minimumDependencyAge": "P3D"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Git worktree helper CLI",
   "type": "module",
   "bin": {

--- a/packages/@kexi/vibe-native/package.json
+++ b/packages/@kexi/vibe-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-native",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Native clone operations for vibe CLI (clonefile on macOS, FICLONE on Linux)",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary
- Bump version from 0.12.1 to 0.12.2

## Changed files
- deno.json
- npm/package.json
- packages/@kexi/vibe-native/package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)