### PR TITLE
fix: update nix 0.29.0 API compatibility for Linux FICLONE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,39 @@ jobs:
           VERSION=$(deno task get-version)
           deno task build:deb "$VERSION" ${{ matrix.arch }} vibe-test
 
+  build-native:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+        env:
+          MISE_HTTP_TIMEOUT: "120"
+
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install dependencies
+        run: pnpm install --filter @kexi/vibe-native --ignore-scripts
+
+      - name: Build native module
+        working-directory: packages/@kexi/vibe-native
+        run: pnpm exec napi build --platform --release --target ${{ matrix.target }}
+
   e2e-test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -191,7 +224,7 @@ jobs:
         run: pnpm build
 
   build:
-    needs: [build-binaries, build-deb]
+    needs: [build-binaries, build-deb, build-native]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All builds completed successfully"


### PR DESCRIPTION
## Summary
- Fix Linux native module build failures caused by nix 0.29.0 API changes
- `ioctl_write_int!` macro now expects `u64` as second argument (not `i32`)
- `Errno` no longer implements `Into<i32>` on Linux, use direct cast instead
- Add `build-native` job to CI to catch these issues in PRs

## Test plan
- [ ] CI `build-native` job passes for all platforms (Linux x64, Linux arm64, macOS x64, macOS arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)