### PR TITLE
fix: add --ignore-scripts to publish-native install step

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/@kexi/vibe-native
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Generate index.js and index.d.ts
         working-directory: packages/@kexi/vibe-native


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` flag to publish-native job's `pnpm install` step
- Fixes node-pty installation failure due to missing node-gyp

## Problem
The publish-native job was failing with:
```
node-gyp: not found
ELIFECYCLE  Command failed.
```

This was because `pnpm install` without `--ignore-scripts` tries to run postinstall scripts, which require node-gyp for node-pty.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)