### PR TITLE
fix: add --ignore-scripts to npm publish for vibe-native

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Publish @kexi/vibe-native
         working-directory: packages/@kexi/vibe-native
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` flag to `npm publish` for `@kexi/vibe-native`
- This prevents `prepublishOnly` script (`napi prepublish -t npm`) from running during CI
- The script was trying to create GitHub releases and failing with 403 error

## Note
There's also an npm OTP error in the logs. Please ensure the `NPM_TOKEN` secret is an **Automation** token (not Publish token), which bypasses 2FA requirements.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)