### PR TITLE
fix: add --ignore-scripts to publish-cli install step

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: npm
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Generate version.ts for npm
         run: |


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to publish-cli pnpm install step
- Fixes node-pty installation failure

🤖 Generated with [Claude Code](https://claude.ai/claude-code)