### PR TITLE
fix: use pnpm publish to resolve workspace: protocol

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Publish @kexi/vibe-native
         working-directory: packages/@kexi/vibe-native
-        run: npm publish --access public --provenance --ignore-scripts
+        run: pnpm publish --access public --provenance --no-git-checks --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -231,6 +231,6 @@ jobs:
 
       - name: Publish @kexi/vibe
         working-directory: npm
-        run: npm publish --access public --provenance
+        run: pnpm publish --access public --provenance --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "Git worktree helper CLI",
   "type": "module",
   "bin": {

--- a/packages/@kexi/vibe-native/package.json
+++ b/packages/@kexi/vibe-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-native",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "Native clone operations for vibe CLI (clonefile on macOS, FICLONE on Linux)",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

- Replace `npm publish` with `pnpm publish` in publish-npm workflow
- pnpm automatically resolves `workspace:^` to actual version numbers during publish
- Fixes the "Unsupported URL Type workspace:" error when installing from npm

## Problem

Users installing `@kexi/vibe@0.12.6` from npm encountered:
```
npm error Unsupported URL Type "workspace:": workspace:^
```

## Solution

Use `pnpm publish` instead of `npm publish`. pnpm resolves `workspace:^` to the actual version (e.g., `^0.12.7`) during the publish process.

## Verification

```bash
cd npm
pnpm pack --pack-destination /tmp
tar -xOzf /tmp/kexi-vibe-*.tgz package/package.json | jq '.optionalDependencies'
# Output: { "@kexi/vibe-native": "^0.12.7" }
```

🤖 Generated with [Claude Code](https://claude.ai/code)