### PR TITLE
chore: add copy section for node_modules to .vibe.toml

### DIFF
--- a/.vibe.toml
+++ b/.vibe.toml
@@ -1,3 +1,6 @@
+[copy]
+dirs = ["node_modules"]
+
 [hooks]
 post_start = [
   "mise trust",


### PR DESCRIPTION
## Summary
- Add `[copy]` section to `.vibe.toml` to copy `node_modules` when creating new worktrees
- Significantly reduces setup time as pnpm supports CoW (Copy-on-Write) on APFS/Btrfs/XFS filesystems

## Test plan
- [ ] Verify `.vibe.toml` syntax is correct
- [ ] Create a new worktree and confirm `node_modules` is copied

🤖 Generated with [Claude Code](https://claude.ai/code)