### PR TITLE
chore: add generate-version to post_start hook

### DIFF
--- a/.vibe.toml
+++ b/.vibe.toml
@@ -1,6 +1,7 @@
 [hooks]
 post_start = [
   "mise trust",
-  "mise install"
+  "mise install",
+  "deno task generate-version"
 ]
 


### PR DESCRIPTION
## Summary
- Add `deno task generate-version` to `post_start` hook in `.vibe.toml`
- Ensures `version.ts` is automatically generated when creating new worktrees
- Required for type checking as this file is not tracked by git

## Test plan
- [ ] Create a new worktree and verify `version.ts` is generated
- [ ] Run `deno task ci` to confirm type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)