### PR TITLE
fix(docs): resolve TypeScript and Astro check errors

### DIFF
--- a/packages/docs/src/components/CustomSocialIcons.astro
+++ b/packages/docs/src/components/CustomSocialIcons.astro
@@ -18,7 +18,8 @@ import Default from "@astrojs/starlight/components/SocialIcons.astro";
   <Default><slot /></Default>
 </div>
 
-<script async defer src="https://buttons.github.io/buttons.js"></script>
+<script is:inline async defer src="https://buttons.github.io/buttons.js"
+></script>
 
 <style is:global>
   .social-icons-wrapper {

--- a/packages/docs/src/pages/og/[...slug].png.ts
+++ b/packages/docs/src/pages/og/[...slug].png.ts
@@ -2,6 +2,7 @@ import type { APIRoute, GetStaticPaths } from "astro";
 import { getCollection } from "astro:content";
 import satori from "satori";
 import { Resvg } from "@resvg/resvg-js";
+import type { ReactNode } from "react";
 
 const GOOGLE_FONTS_API_URL =
   "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@700&display=swap";
@@ -158,7 +159,7 @@ export const GET: APIRoute<Props> = async ({ props }) => {
             },
           ],
         },
-      },
+      } as ReactNode,
       {
         width: 1200,
         height: 630,


### PR DESCRIPTION
## Summary
- OG画像生成のsatoriにReactNode型アサーションを追加
- CustomSocialIconsの外部scriptに`is:inline`ディレクティブを追加

## Test plan
- [x] `pnpm -C packages/docs lint` パス
- [x] `pnpm -C packages/docs format` パス
- [x] `pnpm -C packages/docs check` パス

🤖 Generated with [Claude Code](https://claude.ai/code)