### PR TITLE
chore: add check:all script to run all package checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Development Commands
 
 ```bash
-# Run all checks (fmt:check, lint, check, test)
+# Run ALL checks for ALL packages (REQUIRED before creating PR)
+pnpm run check:all
+
+# Run checks for core package only (Deno)
 deno task ci
+
+# Run checks for docs package only
+pnpm run check:docs
+
+# Run checks for video package only
+pnpm run check:video
 
 # Run in development mode
 deno task dev <command>
@@ -50,6 +59,7 @@ packages/core/src/
 
 ## PR/Commit Guidelines
 
+- **IMPORTANT**: Before creating a PR, always run `pnpm run check:all` and ensure all checks pass
 - **Title format**: `<type>: <description>`
   - Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
 - Write in English

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "build:native": "pnpm -C packages/native build",
     "test:npm": "pnpm -C packages/npm test",
     "test:e2e": "pnpm -C packages/e2e test",
-    "clean": "pnpm -r exec rm -rf node_modules dist"
+    "clean": "pnpm -r exec rm -rf node_modules dist",
+    "check:docs": "pnpm -C packages/docs lint && pnpm -C packages/docs format && pnpm -C packages/docs check",
+    "check:video": "pnpm -C packages/video typecheck",
+    "check:all": "deno task ci && pnpm run check:docs && pnpm run check:video"
   }
 }

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "remotion studio",
     "render": "remotion render VibeCLIDemo out/vibe-demo.mp4",
-    "upgrade": "remotion upgrade"
+    "upgrade": "remotion upgrade",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@remotion/cli": "4.0.246",


### PR DESCRIPTION
## Summary
- ルートから全パッケージのチェックを実行できる`pnpm run check:all`を追加
- packages/videoに`typecheck`スクリプトを追加
- CLAUDE.mdにPR作成前に`check:all`を実行する必須要件を追記

## Test plan
- [x] `pnpm run check:all` がローカルで全パスすることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)