### PR TITLE
fix(e2e): isolate HOME directory for parallel test execution

### DIFF
--- a/packages/e2e/clean.test.ts
+++ b/packages/e2e/clean.test.ts
@@ -29,7 +29,7 @@ describe("clean command", () => {
   });
 
   test("Remove worktree when no uncommitted changes", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -45,7 +45,7 @@ describe("clean command", () => {
     });
 
     // Run vibe clean from the worktree
-    const runner = new VibeCommandRunner(vibePath, worktreePath);
+    const runner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await runner.spawn(["clean"]);
       await runner.waitForExit();
@@ -66,7 +66,7 @@ describe("clean command", () => {
   });
 
   test("Remove worktree with uncommitted changes using --force", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -94,7 +94,7 @@ describe("clean command", () => {
     fs.writeFileSync(`${worktreePath}/uncommitted.txt`, "uncommitted changes");
 
     // Run vibe clean with --force from the worktree
-    const runner = new VibeCommandRunner(vibePath, worktreePath);
+    const runner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await runner.spawn(["clean", "--force"]);
       await runner.waitForExit();
@@ -115,11 +115,11 @@ describe("clean command", () => {
   });
 
   test("Error when run from main worktree", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       // Run vibe clean from main worktree (should fail)
@@ -144,7 +144,7 @@ describe("clean command", () => {
   });
 
   test("Delete branch with --delete-branch option", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -164,7 +164,7 @@ describe("clean command", () => {
     expect(branchExists(repoPath, branchName)).toBe(true);
 
     // Run vibe clean with --delete-branch
-    const runner = new VibeCommandRunner(vibePath, worktreePath);
+    const runner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await runner.spawn(["clean", "--delete-branch"]);
       await runner.waitForExit();
@@ -186,7 +186,7 @@ describe("clean command", () => {
   });
 
   test("Keep branch with --keep-branch option even when config has delete_branch=true", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -209,7 +209,7 @@ describe("clean command", () => {
     });
 
     // Trust the config from worktree path (trust is path-based)
-    const trustRunner = new VibeCommandRunner(vibePath, worktreePath);
+    const trustRunner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await trustRunner.spawn(["trust"]);
       await trustRunner.waitForExit();
@@ -226,7 +226,7 @@ describe("clean command", () => {
     );
 
     // Verify trust was successful before proceeding
-    const verifyRunner = new VibeCommandRunner(vibePath, worktreePath);
+    const verifyRunner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await verifyRunner.spawn(["verify"]);
       await verifyRunner.waitForExit();
@@ -246,7 +246,7 @@ describe("clean command", () => {
     expect(branchExists(repoPath, branchName)).toBe(true);
 
     // Run vibe clean with --keep-branch (should override config)
-    const runner = new VibeCommandRunner(vibePath, worktreePath);
+    const runner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await runner.spawn(["clean", "--keep-branch"]);
       await runner.waitForExit();
@@ -265,7 +265,7 @@ describe("clean command", () => {
   });
 
   test("Delete branch when config has delete_branch=true", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -288,7 +288,7 @@ describe("clean command", () => {
     });
 
     // Trust the config from worktree path (trust is path-based)
-    const trustRunner = new VibeCommandRunner(vibePath, worktreePath);
+    const trustRunner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await trustRunner.spawn(["trust"]);
       await trustRunner.waitForExit();
@@ -305,7 +305,7 @@ describe("clean command", () => {
     );
 
     // Verify trust was successful before proceeding
-    const verifyRunner = new VibeCommandRunner(vibePath, worktreePath);
+    const verifyRunner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await verifyRunner.spawn(["verify"]);
       await verifyRunner.waitForExit();
@@ -316,7 +316,7 @@ describe("clean command", () => {
     }
 
     // Additional sync wait - verify trust is stable with a second check
-    const verifyRunner2 = new VibeCommandRunner(vibePath, worktreePath);
+    const verifyRunner2 = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await verifyRunner2.spawn(["verify"]);
       await verifyRunner2.waitForExit();
@@ -329,7 +329,7 @@ describe("clean command", () => {
     expect(branchExists(repoPath, branchName)).toBe(true);
 
     // Run vibe clean (should use config)
-    const runner = new VibeCommandRunner(vibePath, worktreePath);
+    const runner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await runner.spawn(["clean"]);
       await runner.waitForExit();
@@ -351,7 +351,7 @@ describe("clean command", () => {
   });
 
   test("Error when --delete-branch and --keep-branch are used together", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -367,7 +367,7 @@ describe("clean command", () => {
     });
 
     // Run vibe clean with both --delete-branch and --keep-branch (should fail)
-    const runner = new VibeCommandRunner(vibePath, worktreePath);
+    const runner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await runner.spawn(["clean", "--delete-branch", "--keep-branch"]);
       await runner.waitForExit();
@@ -398,7 +398,7 @@ describe("clean command", () => {
   });
 
   test("Clean worktree with large files", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -415,7 +415,7 @@ describe("clean command", () => {
     const largeContent = "x".repeat(1024 * 1024);
     writeFileSync(join(worktreePath, "large-file.txt"), largeContent);
 
-    const runner = new VibeCommandRunner(vibePath, worktreePath);
+    const runner = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await runner.spawn(["clean", "--force"]);
       await runner.waitForExit();

--- a/packages/e2e/concurrent-clean.test.ts
+++ b/packages/e2e/concurrent-clean.test.ts
@@ -19,7 +19,7 @@ describe("concurrent clean command", () => {
   // Skip this test in CI as it's flaky due to file system locking on macOS CI
   // The test works locally but times out in GitHub Actions
   test.skip("Two concurrent clean commands on same worktree should not panic", { timeout: 120000 }, async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -35,8 +35,8 @@ describe("concurrent clean command", () => {
     });
 
     // Run two clean commands concurrently
-    const runner1 = new VibeCommandRunner(vibePath, worktreePath);
-    const runner2 = new VibeCommandRunner(vibePath, worktreePath);
+    const runner1 = new VibeCommandRunner(vibePath, worktreePath, homePath);
+    const runner2 = new VibeCommandRunner(vibePath, worktreePath, homePath);
 
     try {
       // Spawn both processes nearly simultaneously
@@ -85,7 +85,7 @@ describe("concurrent clean command", () => {
   });
 
   test("Second clean command after first completes should handle gracefully", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -101,7 +101,7 @@ describe("concurrent clean command", () => {
     });
 
     // Run first clean command
-    const runner1 = new VibeCommandRunner(vibePath, worktreePath);
+    const runner1 = new VibeCommandRunner(vibePath, worktreePath, homePath);
     try {
       await runner1.spawn(["clean", "--force"]);
       await runner1.waitForExit();
@@ -116,7 +116,7 @@ describe("concurrent clean command", () => {
     // This simulates the case where another process already cleaned up
     // Note: This will fail because we can't cd to a non-existent directory
     // but the important thing is it should not panic
-    const runner2 = new VibeCommandRunner(vibePath, repoPath);
+    const runner2 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner2.spawn(["clean"]);
       await runner2.waitForExit();

--- a/packages/e2e/config.test.ts
+++ b/packages/e2e/config.test.ts
@@ -14,11 +14,11 @@ describe("config command", () => {
   });
 
   test("Display settings in JSON format", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       // Run vibe config

--- a/packages/e2e/errors/disk-errors.test.ts
+++ b/packages/e2e/errors/disk-errors.test.ts
@@ -32,7 +32,7 @@ describe("disk space errors", () => {
   });
 
   test("Warning when file copy fails (simulating disk space issues)", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     // Create a .vibe.toml that tries to copy a non-existent file
@@ -50,7 +50,7 @@ files = ["this-file-does-not-exist.txt", "another-missing-file.conf"]
     commitVibeToml(repoPath);
 
     // Trust the .vibe.toml file using vibe trust command
-    const trustRunner = new VibeCommandRunner(getVibePath(), repoPath);
+    const trustRunner = new VibeCommandRunner(getVibePath(), repoPath, homePath);
     try {
       await trustRunner.spawn(["trust"]);
       await trustRunner.waitForExit();
@@ -59,7 +59,7 @@ files = ["this-file-does-not-exist.txt", "another-missing-file.conf"]
     }
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       await runner.spawn(["start", "feat/test-disk-error"]);
@@ -87,7 +87,7 @@ files = ["this-file-does-not-exist.txt", "another-missing-file.conf"]
   });
 
   test("Worktree creation succeeds despite copy failures", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     // Create some files that will succeed first
@@ -113,7 +113,7 @@ files = ["*.txt", "config/*.json"]
     commitVibeToml(repoPath);
 
     // Trust the .vibe.toml file
-    const trustRunner = new VibeCommandRunner(getVibePath(), repoPath);
+    const trustRunner = new VibeCommandRunner(getVibePath(), repoPath, homePath);
     try {
       await trustRunner.spawn(["trust"]);
       await trustRunner.waitForExit();
@@ -129,7 +129,7 @@ files = ["*.txt", "config/*.json"]
     );
 
     // Verify trust was successful before proceeding
-    const verifyRunner = new VibeCommandRunner(getVibePath(), repoPath);
+    const verifyRunner = new VibeCommandRunner(getVibePath(), repoPath, homePath);
     try {
       await verifyRunner.spawn(["verify"]);
       await verifyRunner.waitForExit();
@@ -139,7 +139,7 @@ files = ["*.txt", "config/*.json"]
     }
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       await runner.spawn(["start", "feat/partial-copy"]);

--- a/packages/e2e/errors/git-errors.test.ts
+++ b/packages/e2e/errors/git-errors.test.ts
@@ -24,11 +24,11 @@ describe("git configuration errors", () => {
   });
 
   test("Error when not in a git repository", async () => {
-    const { dirPath, cleanup: dirCleanup } = await setupNonGitDirectory();
+    const { dirPath, homePath, cleanup: dirCleanup } = await setupNonGitDirectory();
     cleanup = dirCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, dirPath);
+    const runner = new VibeCommandRunner(vibePath, dirPath, homePath);
 
     try {
       await runner.spawn(["start", "feat/test"]);
@@ -47,12 +47,12 @@ describe("git configuration errors", () => {
   });
 
   test("Error when git user.email is missing", async () => {
-    const { repoPath, cleanup: repoCleanup } =
+    const { repoPath, homePath, cleanup: repoCleanup } =
       await setupGitRepoWithoutUserConfig();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       await runner.spawn(["start", "feat/test"]);
@@ -76,11 +76,11 @@ describe("git configuration errors", () => {
   });
 
   test("Error when .git/config is corrupted", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupCorruptedGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupCorruptedGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       await runner.spawn(["start", "feat/test"]);
@@ -100,11 +100,11 @@ describe("git configuration errors", () => {
   });
 
   test("Handle detached HEAD state", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupDetachedHeadRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupDetachedHeadRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       await runner.spawn(["start", "feat/test"]);
@@ -126,11 +126,11 @@ describe("git configuration errors", () => {
   });
 
   test("Error when branch name contains invalid characters", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       // Try to create a branch with path traversal characters
@@ -151,11 +151,11 @@ describe("git configuration errors", () => {
   });
 
   test("Error when branch name has special characters", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       // Try to create a branch with spaces and special chars

--- a/packages/e2e/errors/permission-errors.test.ts
+++ b/packages/e2e/errors/permission-errors.test.ts
@@ -33,7 +33,7 @@ describe("permission errors", () => {
   });
 
   test("Handle permission errors gracefully", async () => {
-    const { repoPath, cleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup } = await setupTestGitRepo();
     repoCleanup = cleanup;
 
     // Note: We cannot reliably test parent directory permissions on macOS
@@ -41,7 +41,7 @@ describe("permission errors", () => {
     // This test validates that the command handles permission issues gracefully.
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       // Just run a normal start command to verify no permission issues
@@ -61,7 +61,7 @@ describe("permission errors", () => {
   });
 
   test("Error when .vibe.toml is not readable", async () => {
-    const { repoPath, cleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup } = await setupTestGitRepo();
     repoCleanup = cleanup;
 
     // Create a .vibe.toml file
@@ -79,7 +79,7 @@ files = ["README.md"]
     permissionCleanup = await makeInaccessible(vibeTomlPath);
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       await runner.spawn(["start", "feat/test"]);
@@ -100,7 +100,7 @@ files = ["README.md"]
   });
 
   test("Warning when config file cannot be copied (non-fatal)", async () => {
-    const { repoPath, cleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup } = await setupTestGitRepo();
     repoCleanup = cleanup;
 
     // Create a .vibe.toml with a copy configuration
@@ -118,7 +118,7 @@ files = ["nonexistent.txt"]
     writeFileSync(testFilePath, "test content");
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       await runner.spawn(["start", "feat/test"]);
@@ -141,13 +141,13 @@ files = ["nonexistent.txt"]
   });
 
   test("Handle permission errors during worktree operations", async () => {
-    const { repoPath, cleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup } = await setupTestGitRepo();
     repoCleanup = cleanup;
 
     const vibePath = getVibePath();
 
     // First create a worktree normally
-    const runner1 = new VibeCommandRunner(vibePath, repoPath);
+    const runner1 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner1.spawn(["start", "feat/permission-test"]);
       await runner1.waitForExit();

--- a/packages/e2e/helpers/error-setup.ts
+++ b/packages/e2e/helpers/error-setup.ts
@@ -9,9 +9,11 @@ import { dirname, join } from "path";
  */
 export async function setupNonGitDirectory(): Promise<{
   dirPath: string;
+  homePath: string;
   cleanup: () => Promise<void>;
 }> {
   const tempDir = mkdtempSync(join(tmpdir(), "vibe-e2e-non-git-"));
+  const homePath = mkdtempSync(join(tmpdir(), "vibe-e2e-home-"));
 
   const cleanup = async () => {
     try {
@@ -19,9 +21,14 @@ export async function setupNonGitDirectory(): Promise<{
     } catch {
       // Ignore errors if directory is already removed
     }
+    try {
+      rmSync(homePath, { recursive: true, force: true });
+    } catch {
+      // Ignore errors if directory is already removed
+    }
   };
 
-  return { dirPath: tempDir, cleanup };
+  return { dirPath: tempDir, homePath, cleanup };
 }
 
 /**
@@ -30,9 +37,11 @@ export async function setupNonGitDirectory(): Promise<{
  */
 export async function setupGitRepoWithoutUserConfig(): Promise<{
   repoPath: string;
+  homePath: string;
   cleanup: () => Promise<void>;
 }> {
   const tempDir = mkdtempSync(join(tmpdir(), "vibe-e2e-no-config-"));
+  const homePath = mkdtempSync(join(tmpdir(), "vibe-e2e-home-"));
 
   // Initialize Git repository WITHOUT user config
   execFileSync("git", ["init"], { cwd: tempDir, stdio: "pipe" });
@@ -69,9 +78,14 @@ export async function setupGitRepoWithoutUserConfig(): Promise<{
     } catch {
       // Ignore errors if directory is already removed
     }
+    try {
+      rmSync(homePath, { recursive: true, force: true });
+    } catch {
+      // Ignore errors if directory is already removed
+    }
   };
 
-  return { repoPath: tempDir, cleanup };
+  return { repoPath: tempDir, homePath, cleanup };
 }
 
 /**
@@ -80,9 +94,11 @@ export async function setupGitRepoWithoutUserConfig(): Promise<{
  */
 export async function setupCorruptedGitRepo(): Promise<{
   repoPath: string;
+  homePath: string;
   cleanup: () => Promise<void>;
 }> {
   const tempDir = mkdtempSync(join(tmpdir(), "vibe-e2e-corrupted-"));
+  const homePath = mkdtempSync(join(tmpdir(), "vibe-e2e-home-"));
 
   // Initialize a normal git repository first
   execFileSync("git", ["init"], { cwd: tempDir, stdio: "pipe" });
@@ -135,9 +151,14 @@ export async function setupCorruptedGitRepo(): Promise<{
     } catch {
       // Ignore errors if directory is already removed
     }
+    try {
+      rmSync(homePath, { recursive: true, force: true });
+    } catch {
+      // Ignore errors if directory is already removed
+    }
   };
 
-  return { repoPath: tempDir, cleanup };
+  return { repoPath: tempDir, homePath, cleanup };
 }
 
 /**
@@ -146,9 +167,11 @@ export async function setupCorruptedGitRepo(): Promise<{
  */
 export async function setupDetachedHeadRepo(): Promise<{
   repoPath: string;
+  homePath: string;
   cleanup: () => Promise<void>;
 }> {
   const tempDir = mkdtempSync(join(tmpdir(), "vibe-e2e-detached-"));
+  const homePath = mkdtempSync(join(tmpdir(), "vibe-e2e-home-"));
 
   // Initialize Git repository
   execFileSync("git", ["init"], { cwd: tempDir, stdio: "pipe" });
@@ -195,9 +218,14 @@ export async function setupDetachedHeadRepo(): Promise<{
     } catch {
       // Ignore errors if directory is already removed
     }
+    try {
+      rmSync(homePath, { recursive: true, force: true });
+    } catch {
+      // Ignore errors if directory is already removed
+    }
   };
 
-  return { repoPath: tempDir, cleanup };
+  return { repoPath: tempDir, homePath, cleanup };
 }
 
 /**

--- a/packages/e2e/helpers/git-setup.ts
+++ b/packages/e2e/helpers/git-setup.ts
@@ -8,9 +8,11 @@ import { join } from "path";
  */
 export async function setupTestGitRepo(): Promise<{
   repoPath: string;
+  homePath: string;
   cleanup: () => Promise<void>;
 }> {
   const tempDir = mkdtempSync(join(tmpdir(), "vibe-e2e-test-"));
+  const homePath = mkdtempSync(join(tmpdir(), "vibe-e2e-home-"));
 
   // Initialize Git repository
   runCommand(["git", "init"], tempDir);
@@ -36,15 +38,20 @@ export async function setupTestGitRepo(): Promise<{
       // Ignore errors during cleanup
     }
 
-    // Remove temporary directory
+    // Remove temporary directories
     try {
       rmSync(tempDir, { recursive: true, force: true });
     } catch {
       // Ignore errors if directory is already removed
     }
+    try {
+      rmSync(homePath, { recursive: true, force: true });
+    } catch {
+      // Ignore errors if directory is already removed
+    }
   };
 
-  return { repoPath: tempDir, cleanup };
+  return { repoPath: tempDir, homePath, cleanup };
 }
 
 /**

--- a/packages/e2e/helpers/pty.ts
+++ b/packages/e2e/helpers/pty.ts
@@ -1,5 +1,6 @@
 import * as pty from "node-pty";
-import { join } from "path";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
 type IPty = pty.IPty;
 
@@ -15,6 +16,7 @@ export class VibeCommandRunner {
   constructor(
     private vibePath: string,
     private cwd: string,
+    private homePath?: string,
   ) {}
 
   /**
@@ -30,6 +32,7 @@ export class VibeCommandRunner {
         cwd: this.cwd,
         env: {
           ...process.env,
+          HOME: this.homePath ?? process.env.HOME,
           TERM: "xterm-256color",
           VIBE_FORCE_INTERACTIVE: "1",
         },
@@ -138,6 +141,8 @@ export function getVibePath(): string {
     return process.env.VIBE_BINARY_PATH;
   }
 
-  // Use process.cwd() which will be the repo root when tests run
-  return join(process.cwd(), "vibe-e2e");
+  // Get repo root by going up from packages/e2e/helpers directory
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(currentDir, "..", "..", "..");
+  return join(repoRoot, "vibe-e2e");
 }

--- a/packages/e2e/interactive.test.ts
+++ b/packages/e2e/interactive.test.ts
@@ -29,7 +29,7 @@ describe("interactive prompts", () => {
   });
 
   test("Navigate to existing worktree when branch in use (Y response)", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -39,7 +39,7 @@ describe("interactive prompts", () => {
     const repoName = basename(repoPath);
     const worktreePath = `${parentDir}/${repoName}-feat-test`;
 
-    const runner1 = new VibeCommandRunner(vibePath, repoPath);
+    const runner1 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner1.spawn(["start", "feat/test"]);
       await runner1.waitForExit();
@@ -49,7 +49,7 @@ describe("interactive prompts", () => {
     }
 
     // Step 2: Try to create the same branch again (should prompt)
-    const runner2 = new VibeCommandRunner(vibePath, repoPath);
+    const runner2 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       // Await spawn to ensure PTY is ready before continuing
       await runner2.spawn(["start", "feat/test"]);
@@ -82,13 +82,13 @@ describe("interactive prompts", () => {
   });
 
   test("Cancel when branch in use (n response)", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
 
     // Step 1: Create a worktree with branch "feat/test"
-    const runner1 = new VibeCommandRunner(vibePath, repoPath);
+    const runner1 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner1.spawn(["start", "feat/test"]);
       await runner1.waitForExit();
@@ -98,7 +98,7 @@ describe("interactive prompts", () => {
     }
 
     // Step 2: Try to create the same branch again and cancel
-    const runner2 = new VibeCommandRunner(vibePath, repoPath);
+    const runner2 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner2.spawn(["start", "feat/test"]);
 
@@ -126,7 +126,7 @@ describe("interactive prompts", () => {
   });
 
   test("Overwrite existing directory (choice 1)", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -136,7 +136,7 @@ describe("interactive prompts", () => {
     const repoName = basename(repoPath);
     const worktreePath = `${parentDir}/${repoName}-feat-overwrite`;
 
-    const runner1 = new VibeCommandRunner(vibePath, repoPath);
+    const runner1 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner1.spawn(["start", "feat/overwrite"]);
       await runner1.waitForExit();
@@ -153,7 +153,7 @@ describe("interactive prompts", () => {
     execFileSync("git", ["branch", "-D", originalBranch], { cwd: repoPath, stdio: "pipe" });
 
     // Step 3: Try to create the same worktree again (directory exists but branch is available)
-    const runner2 = new VibeCommandRunner(vibePath, repoPath);
+    const runner2 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner2.spawn(["start", "feat/overwrite"]);
 
@@ -183,7 +183,7 @@ describe("interactive prompts", () => {
   });
 
   test("Reuse existing directory (choice 2)", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -193,7 +193,7 @@ describe("interactive prompts", () => {
     const repoName = basename(repoPath);
     const worktreePath = `${parentDir}/${repoName}-feat-reuse`;
 
-    const runner1 = new VibeCommandRunner(vibePath, repoPath);
+    const runner1 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner1.spawn(["start", "feat/reuse"]);
       await runner1.waitForExit();
@@ -210,7 +210,7 @@ describe("interactive prompts", () => {
     execFileSync("git", ["branch", "-D", originalBranch], { cwd: repoPath, stdio: "pipe" });
 
     // Step 3: Try to create the same worktree again and reuse
-    const runner2 = new VibeCommandRunner(vibePath, repoPath);
+    const runner2 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner2.spawn(["start", "feat/reuse"]);
 
@@ -240,7 +240,7 @@ describe("interactive prompts", () => {
   });
 
   test("Cancel when directory exists (choice 3)", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -250,7 +250,7 @@ describe("interactive prompts", () => {
     const repoName = basename(repoPath);
     const worktreePath = `${parentDir}/${repoName}-feat-cancel`;
 
-    const runner1 = new VibeCommandRunner(vibePath, repoPath);
+    const runner1 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner1.spawn(["start", "feat/cancel"]);
       await runner1.waitForExit();
@@ -267,7 +267,7 @@ describe("interactive prompts", () => {
     execFileSync("git", ["branch", "-D", originalBranch], { cwd: repoPath, stdio: "pipe" });
 
     // Step 3: Try to create the same worktree again and cancel
-    const runner2 = new VibeCommandRunner(vibePath, repoPath);
+    const runner2 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner2.spawn(["start", "feat/cancel"]);
 
@@ -295,7 +295,7 @@ describe("interactive prompts", () => {
   });
 
   test("Handle invalid input gracefully in confirmation", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -305,7 +305,7 @@ describe("interactive prompts", () => {
     const repoName = basename(repoPath);
     const worktreePath = `${parentDir}/${repoName}-feat-invalid`;
 
-    const runner1 = new VibeCommandRunner(vibePath, repoPath);
+    const runner1 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner1.spawn(["start", "feat/invalid"]);
       await runner1.waitForExit();
@@ -315,7 +315,7 @@ describe("interactive prompts", () => {
     }
 
     // Step 2: Try again with invalid input then valid input
-    const runner2 = new VibeCommandRunner(vibePath, repoPath);
+    const runner2 = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner2.spawn(["start", "feat/invalid"]);
 

--- a/packages/e2e/start.test.ts
+++ b/packages/e2e/start.test.ts
@@ -22,11 +22,11 @@ describe("start command", () => {
   });
 
   test("Create worktree with new branch", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       // Run vibe start feat/new-feature
@@ -53,7 +53,7 @@ describe("start command", () => {
   });
 
   test("Use --reuse flag with existing branch", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -69,7 +69,7 @@ describe("start command", () => {
     });
 
     // Run vibe start existing-branch --reuse
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner.spawn(["start", "existing-branch", "--reuse"]);
       await runner.waitForExit();
@@ -94,11 +94,11 @@ describe("start command", () => {
   });
 
   test("Error when branch name is missing", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       // Run vibe start without branch name
@@ -123,7 +123,7 @@ describe("start command", () => {
   });
 
   test("--no-hooks skips pre-start and post-start hooks", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -142,7 +142,7 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.post-hook-ran"]
     });
 
     // Trust the config
-    const trustRunner = new VibeCommandRunner(vibePath, repoPath);
+    const trustRunner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await trustRunner.spawn(["trust"]);
       await trustRunner.waitForExit();
@@ -153,7 +153,7 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.post-hook-ran"]
     }
 
     // Run vibe start with --no-hooks
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner.spawn(["start", "feat/test-no-hooks", "--no-hooks"]);
       await runner.waitForExit();
@@ -180,7 +180,7 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.post-hook-ran"]
   });
 
   test("--no-copy skips file copying", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -204,7 +204,7 @@ files = [".env.local"]
     });
 
     // Trust the config
-    const trustRunner = new VibeCommandRunner(vibePath, repoPath);
+    const trustRunner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await trustRunner.spawn(["trust"]);
       await trustRunner.waitForExit();
@@ -215,7 +215,7 @@ files = [".env.local"]
     }
 
     // Run vibe start with --no-copy
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner.spawn(["start", "feat/test-no-copy", "--no-copy"]);
       await runner.waitForExit();
@@ -239,7 +239,7 @@ files = [".env.local"]
   });
 
   test("--no-hooks and --no-copy can be combined", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -265,7 +265,7 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.hook-ran"]
     });
 
     // Trust the config
-    const trustRunner = new VibeCommandRunner(vibePath, repoPath);
+    const trustRunner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await trustRunner.spawn(["trust"]);
       await trustRunner.waitForExit();
@@ -276,7 +276,7 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.hook-ran"]
     }
 
     // Verify trust was successful before proceeding
-    const verifyRunner = new VibeCommandRunner(vibePath, repoPath);
+    const verifyRunner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await verifyRunner.spawn(["verify"]);
       await verifyRunner.waitForExit();
@@ -294,7 +294,7 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.hook-ran"]
     );
 
     // Run vibe start with both --no-hooks and --no-copy
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner.spawn([
         "start",
@@ -326,7 +326,7 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.hook-ran"]
   });
 
   test("worktree.path_script in .vibe.toml determines worktree path", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -357,7 +357,7 @@ path_script = "./worktree-path.sh"
     });
 
     // Trust the config
-    const trustRunner = new VibeCommandRunner(vibePath, repoPath);
+    const trustRunner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await trustRunner.spawn(["trust"]);
       await trustRunner.waitForExit();
@@ -374,7 +374,7 @@ path_script = "./worktree-path.sh"
     );
 
     // Run vibe start
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner.spawn(["start", "feat/custom-path"]);
       await runner.waitForExit();
@@ -395,7 +395,7 @@ path_script = "./worktree-path.sh"
   });
 
   test(".vibe.local.toml path_script takes precedence over .vibe.toml", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -450,7 +450,7 @@ path_script = "./local-path.sh"
     });
 
     // Trust the configs
-    const trustRunner = new VibeCommandRunner(vibePath, repoPath);
+    const trustRunner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await trustRunner.spawn(["trust"]);
       await trustRunner.waitForExit();
@@ -461,7 +461,7 @@ path_script = "./local-path.sh"
     }
 
     // Run vibe start
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
     try {
       await runner.spawn(["start", "feat/precedence-test"]);
       await runner.waitForExit();

--- a/packages/e2e/trust.test.ts
+++ b/packages/e2e/trust.test.ts
@@ -16,11 +16,11 @@ describe("trust/untrust/verify commands", () => {
   });
 
   test("trust: Add .vibe.toml to trusted list", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       // Create .vibe.toml
@@ -47,7 +47,7 @@ describe("trust/untrust/verify commands", () => {
   });
 
   test("verify: Display trust status and hash history", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -58,13 +58,13 @@ describe("trust/untrust/verify commands", () => {
       '[hooks]\npost_start = ["echo test"]\n',
     );
 
-    const trustRunner = new VibeCommandRunner(vibePath, repoPath);
+    const trustRunner = new VibeCommandRunner(vibePath, repoPath, homePath);
     await trustRunner.spawn(["trust"]);
     await trustRunner.waitForExit();
     trustRunner.dispose();
 
     // Run vibe verify
-    const verifyRunner = new VibeCommandRunner(vibePath, repoPath);
+    const verifyRunner = new VibeCommandRunner(vibePath, repoPath, homePath);
     await verifyRunner.spawn(["verify"]);
     await verifyRunner.waitForExit();
 
@@ -81,7 +81,7 @@ describe("trust/untrust/verify commands", () => {
   });
 
   test("untrust: Remove from trusted list", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
@@ -92,13 +92,13 @@ describe("trust/untrust/verify commands", () => {
       '[hooks]\npost_start = ["echo test"]\n',
     );
 
-    const trustRunner = new VibeCommandRunner(vibePath, repoPath);
+    const trustRunner = new VibeCommandRunner(vibePath, repoPath, homePath);
     await trustRunner.spawn(["trust"]);
     await trustRunner.waitForExit();
     trustRunner.dispose();
 
     // Run vibe untrust
-    const untrustRunner = new VibeCommandRunner(vibePath, repoPath);
+    const untrustRunner = new VibeCommandRunner(vibePath, repoPath, homePath);
     await untrustRunner.spawn(["untrust"]);
     await untrustRunner.waitForExit();
 
@@ -115,11 +115,11 @@ describe("trust/untrust/verify commands", () => {
   });
 
   test("trust: Handle .vibe.local.toml", async () => {
-    const { repoPath, cleanup: repoCleanup } = await setupTestGitRepo();
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;
 
     const vibePath = getVibePath();
-    const runner = new VibeCommandRunner(vibePath, repoPath);
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
 
     try {
       // Create .vibe.local.toml


### PR DESCRIPTION
## Summary
- E2Eテストの並列実行時に各テストでHOME環境変数を分離
- `~/.config/vibe/settings.json`の競合によるflaky testを解消
- `getVibePath()`をESM対応に修正

## Changes
- `VibeCommandRunner`に`homePath`パラメータを追加してHOME環境変数をオーバーライド
- `setupTestGitRepo`および各errorセットアップ関数でHOME用一時ディレクトリを作成
- 全テストファイルで`homePath`を`VibeCommandRunner`に渡すよう更新

## Test plan
- [x] ローカルでE2Eテスト3回連続パス確認
- [ ] CIでテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)