### PR TITLE
docs: add --base option documentation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,7 +12,7 @@ Git Worktreeを簡単に管理するCLIツール。
 
 | コマンド                       | 説明                                                  |
 | ------------------------------ | ----------------------------------------------------- |
-| `vibe start <branch>`          | 新規または既存ブランチでworktreeを作成（冪等）        |
+| `vibe start <branch> [--base <ref>]` | 新規または既存ブランチでworktreeを作成（冪等）        |
 | `vibe clean`                   | 現在のworktreeを削除してメインに戻る（未コミットの変更がある場合は確認）                  |
 | `vibe trust`                   | `.vibe.toml`と`.vibe.local.toml`ファイルを信頼登録    |
 | `vibe untrust`                 | `.vibe.toml`と`.vibe.local.toml`ファイルの信頼を解除  |
@@ -25,6 +25,9 @@ vibe start feat/new-feature
 
 # 既存ブランチを使用（またはworktreeが既に存在する場合も再実行可能）
 vibe start feat/existing-branch
+
+# 特定のブランチをベースにworktreeを作成
+vibe start feat/new-feature --base main
 
 # 作業完了後、worktreeを削除
 vibe clean
@@ -47,6 +50,14 @@ $ vibe start feat/new-feature
 ブランチ 'feat/new-feature' は既にworktree '/path/to/repo-feat-new-feature' で使用中です。
 既存のworktreeに移動しますか? (Y/n)
 ```
+
+### ベースブランチオプション
+
+`--base`オプションは新しいブランチの開始点を指定します：
+
+- **新規ブランチ**: 指定されたベース（ブランチ、タグ、またはコミット）からブランチを作成
+- **既存ブランチ**: `--base`オプションは警告と共に無視される
+- **無効なベース**: 指定された参照が存在しない場合はエラーで終了
 
 ### クリーンアップ動作
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A CLI tool for easy Git Worktree management.
 
 | Command                      | Description                                         |
 | ---------------------------- | --------------------------------------------------- |
-| `vibe start <branch>`        | Create a worktree with a new or existing branch (idempotent) |
+| `vibe start <branch> [--base <ref>]` | Create a worktree with a new or existing branch (idempotent) |
 | `vibe clean`                 | Delete current worktree and return to main (prompts if uncommitted changes exist) |
 | `vibe trust`                 | Trust `.vibe.toml` and `.vibe.local.toml` files     |
 | `vibe untrust`               | Untrust `.vibe.toml` and `.vibe.local.toml` files   |
@@ -25,6 +25,9 @@ vibe start feat/new-feature
 
 # Use an existing branch (or re-run if worktree already exists)
 vibe start feat/existing-branch
+
+# Create a worktree from a specific base branch
+vibe start feat/new-feature --base main
 
 # After work is done, delete the worktree
 vibe clean
@@ -47,6 +50,14 @@ $ vibe start feat/new-feature
 Branch 'feat/new-feature' is already in use by worktree '/path/to/repo-feat-new-feature'.
 Navigate to the existing worktree? (Y/n)
 ```
+
+### Base Branch Option
+
+The `--base` option specifies the starting point for a new branch:
+
+- **New branch**: Creates the branch from the specified base (branch, tag, or commit)
+- **Existing branch**: The `--base` option is ignored with a warning
+- **Invalid base**: Exits with an error if the specified ref doesn't exist
 
 ### Cleanup Behavior
 

--- a/packages/docs/src/content/docs/commands/index.mdx
+++ b/packages/docs/src/content/docs/commands/index.mdx
@@ -9,14 +9,14 @@ vibe provides a simple set of commands for managing Git Worktrees.
 
 ## Command Summary
 
-| Command               | Description                                     |
-| --------------------- | ----------------------------------------------- |
-| `vibe start <branch>` | Create a worktree with a new or existing branch |
-| `vibe clean`          | Delete current worktree and return to main      |
-| `vibe trust`          | Trust configuration files                       |
-| `vibe untrust`        | Untrust configuration files                     |
-| `vibe config`         | Show current configuration                      |
-| `vibe upgrade`        | Check for updates and show upgrade instructions |
+| Command                              | Description                                     |
+| ------------------------------------ | ----------------------------------------------- |
+| `vibe start <branch> [--base <ref>]` | Create a worktree with a new or existing branch |
+| `vibe clean`                         | Delete current worktree and return to main      |
+| `vibe trust`                         | Trust configuration files                       |
+| `vibe untrust`                       | Untrust configuration files                     |
+| `vibe config`                        | Show current configuration                      |
+| `vibe upgrade`                       | Check for updates and show upgrade instructions |
 
 ## Quick Reference
 
@@ -26,6 +26,9 @@ vibe start feat/new-feature
 
 # Use an existing branch
 vibe start feat/existing-branch
+
+# Create from a specific base branch
+vibe start feat/new-feature --base main
 
 # Clean up when done
 vibe clean

--- a/packages/docs/src/content/docs/ja/commands/index.mdx
+++ b/packages/docs/src/content/docs/ja/commands/index.mdx
@@ -9,14 +9,14 @@ vibeはGit Worktreeを管理するためのシンプルなコマンドセット�
 
 ## コマンド一覧
 
-| コマンド              | 説明                                       |
-| --------------------- | ------------------------------------------ |
-| `vibe start <branch>` | 新規または既存ブランチでWorktreeを作成     |
-| `vibe clean`          | 現在のWorktreeを削除してメインに戻る       |
-| `vibe trust`          | 設定ファイルを信頼登録                     |
-| `vibe untrust`        | 設定ファイルの信頼を解除                   |
-| `vibe config`         | 現在の設定を表示                           |
-| `vibe upgrade`        | アップデートを確認しアップグレード方法表示 |
+| コマンド                             | 説明                                       |
+| ------------------------------------ | ------------------------------------------ |
+| `vibe start <branch> [--base <ref>]` | 新規または既存ブランチでWorktreeを作成     |
+| `vibe clean`                         | 現在のWorktreeを削除してメインに戻る       |
+| `vibe trust`                         | 設定ファイルを信頼登録                     |
+| `vibe untrust`                       | 設定ファイルの信頼を解除                   |
+| `vibe config`                        | 現在の設定を表示                           |
+| `vibe upgrade`                       | アップデートを確認しアップグレード方法表示 |
 
 ## クイックリファレンス
 
@@ -26,6 +26,9 @@ vibe start feat/new-feature
 
 # 既存ブランチを使用
 vibe start feat/existing-branch
+
+# 特定のブランチをベースに作成
+vibe start feat/new-feature --base main
 
 # 作業完了後にクリーンアップ
 vibe clean


### PR DESCRIPTION
## Summary

- Add `--base` option to command tables in README.md and README.ja.md
- Add usage examples for `--base` option in both README files
- Add "Base Branch Option" / "ベースブランチオプション" section explaining the option behavior
- Update command overview pages in packages/docs with `--base` option

## Test plan

- [x] `pnpm run check:docs` passes
- [x] Both English and Japanese versions are synchronized
- [x] Command tables and examples are consistent across all files

🤖 Generated with [Claude Code](https://claude.ai/code)