### PR TITLE
fix: exclude @kexi/vibe-native from tsup bundle

### DIFF
--- a/packages/npm/tsup.config.ts
+++ b/packages/npm/tsup.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
     /^node:.*/,
     // Dependencies that are installed via npm
     "zod",
+    // Native module (optional dependency, loaded dynamically at runtime)
+    "@kexi/vibe-native",
   ],
   // Include @jsr packages in bundle (not available on npm registry)
   noExternal: [/^@jsr\/.*/],


### PR DESCRIPTION
## Summary

- `tsup.config.ts` の `external` 配列に `@kexi/vibe-native` を追加
- これにより `publish-npm` ワークフローの `Build CLI` ステップで発生していたエラーを修正

## Problem

`publish-cli` ジョブで `pnpm run build` (tsup) 実行時に以下のエラーが発生:

```
[ERROR] Cannot find module './vibe-native.darwin-arm64.node'
[ERROR] Cannot find module './vibe-native.linux-x64-gnu.node'
... (他16個)
```

## Root Cause

1. `@kexi/vibe-native` は `optionalDependencies` として `workspace:^` で参照
2. ビルド時に `packages/native/` を参照するが、`.node` ファイルは `publish-native` ジョブでのみ生成される
3. tsupがバンドル時に `require('./vibe-native.*.node')` を解決しようとして失敗

## Solution

`@kexi/vibe-native` を `external` に追加し、バンドルから除外。ネイティブモジュールは実行時に動的ロードされるため、バンドルに含める必要がない。

## Test plan

- [x] `pnpm run build` (packages/npm) が成功することを確認
- [x] `pnpm run check:all` が成功することを確認
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)