### PR TITLE
docs: add Bun runtime support documentation

### DIFF
--- a/packages/docs/src/content/docs/changelog.mdx
+++ b/packages/docs/src/content/docs/changelog.mdx
@@ -69,7 +69,7 @@ All notable changes to vibe are documented here.
 
 ### Added
 
-- **Multi-runtime support**: Run vibe in Node.js/npm/npx environments
+- **Multi-runtime support**: Run vibe in Node.js/npm/npx and Bun environments
 - **RuntimeAbstractionLayer**: Unified runtime abstraction for Deno and Node.js
 - **AppContext dependency injection**: Improved testability through DI pattern
 

--- a/packages/docs/src/content/docs/configuration/hooks.mdx
+++ b/packages/docs/src/content/docs/configuration/hooks.mdx
@@ -102,6 +102,17 @@ post_start = [
 pre_clean = ["git stash --include-untracked"]
 ```
 
+### Bun Project
+
+```toml
+[hooks]
+post_start = [
+  "bun install",
+  "bun run build"
+]
+pre_clean = ["git stash --include-untracked"]
+```
+
 ### Database Migration
 
 ```toml

--- a/packages/docs/src/content/docs/getting-started.mdx
+++ b/packages/docs/src/content/docs/getting-started.mdx
@@ -40,6 +40,22 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     :::
 
   </TabItem>
+  <TabItem label="Bun">
+    ```bash frame="terminal"
+    # Global install
+    bun add -g @kexi/vibe
+
+    # Or run directly with bunx
+    bunx @kexi/vibe start feat/my-feature
+    ```
+    :::note
+    Shell setup (Step 2) is required. Select the "bunx" option for bunx usage.
+    :::
+    :::tip
+    Global install is recommended for frequent use. bunx has slower startup due to package resolution overhead.
+    :::
+
+  </TabItem>
   <TabItem label="Deno">
     ```bash frame="terminal"
     deno install -A --global jsr:@kexi/vibe
@@ -77,11 +93,13 @@ Add **one** of the following to your shell configuration (choose based on your i
     ```bash frame="terminal"
     # Add to ~/.zshrc (choose one)
 
-    # For global install (Homebrew, npm -g, Deno)
+    # For global install (Homebrew, npm -g, bun -g, Deno)
     vibe() { eval "$(command vibe "$@")" }
 
     # For npx (without global install)
     vibe() { eval "$(npx @kexi/vibe "$@")" }
+    # Or for bunx:
+    # vibe() { eval "$(bunx @kexi/vibe "$@")" }
     ```
 
   </TabItem>
@@ -89,11 +107,13 @@ Add **one** of the following to your shell configuration (choose based on your i
     ```bash frame="terminal"
     # Add to ~/.bashrc (choose one)
 
-    # For global install (Homebrew, npm -g, Deno)
+    # For global install (Homebrew, npm -g, bun -g, Deno)
     vibe() { eval "$(command vibe "$@")"; }
 
     # For npx (without global install)
     vibe() { eval "$(npx @kexi/vibe "$@")"; }
+    # Or for bunx:
+    # vibe() { eval "$(bunx @kexi/vibe "$@")"; }
     ```
 
   </TabItem>
@@ -101,7 +121,7 @@ Add **one** of the following to your shell configuration (choose based on your i
     ```fish frame="terminal"
     # Add to ~/.config/fish/config.fish (choose one)
 
-    # For global install (Homebrew, npm -g, Deno)
+    # For global install (Homebrew, npm -g, bun -g, Deno)
     function vibe
         eval (command vibe $argv)
     end
@@ -110,6 +130,10 @@ Add **one** of the following to your shell configuration (choose based on your i
     function vibe
         eval (npx @kexi/vibe $argv)
     end
+    # Or for bunx:
+    # function vibe
+    #     eval (bunx @kexi/vibe $argv)
+    # end
     ```
 
   </TabItem>
@@ -117,7 +141,7 @@ Add **one** of the following to your shell configuration (choose based on your i
     ```nu frame="terminal"
     # Add to ~/.config/nushell/config.nu (choose one)
 
-    # For global install (Homebrew, npm -g, Deno)
+    # For global install (Homebrew, npm -g, bun -g, Deno)
     def --env vibe [...args] {
         ^vibe ...$args | lines | each { |line| nu -c $line }
     }
@@ -126,6 +150,10 @@ Add **one** of the following to your shell configuration (choose based on your i
     def --env vibe [...args] {
         npx @kexi/vibe ...$args | lines | each { |line| nu -c $line }
     }
+    # Or for bunx:
+    # def --env vibe [...args] {
+    #     bunx @kexi/vibe ...$args | lines | each { |line| nu -c $line }
+    # }
     ```
 
   </TabItem>
@@ -133,11 +161,13 @@ Add **one** of the following to your shell configuration (choose based on your i
     ```powershell frame="terminal"
     # Add to your $PROFILE (choose one)
 
-    # For global install (Homebrew, npm -g, Deno)
+    # For global install (Homebrew, npm -g, bun -g, Deno)
     function vibe { Invoke-Expression (& vibe.exe $args) }
 
     # For npx (without global install)
     function vibe { Invoke-Expression (& npx @kexi/vibe $args) }
+    # Or for bunx:
+    # function vibe { Invoke-Expression (& bunx @kexi/vibe $args) }
     ```
 
   </TabItem>

--- a/packages/docs/src/content/docs/installation.mdx
+++ b/packages/docs/src/content/docs/installation.mdx
@@ -27,6 +27,20 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     :::
 
   </TabItem>
+  <TabItem label="Bun">
+    ```bash frame="terminal"
+    # Global install
+    bun add -g @kexi/vibe
+
+    # Or run directly with bunx
+    bunx @kexi/vibe start feat/my-feature
+    ```
+
+    :::note
+    Requires Bun 1.2.0 or later. The npm package includes optional native bindings (`@kexi/vibe-native`) for optimized Copy-on-Write file cloning on macOS (APFS) and Linux (Btrfs/XFS). These are automatically used when available.
+    :::
+
+  </TabItem>
   <TabItem label="Deno (JSR)">
     ```bash frame="terminal"
     deno install -A --global jsr:@kexi/vibe

--- a/packages/docs/src/content/docs/ja/changelog.mdx
+++ b/packages/docs/src/content/docs/ja/changelog.mdx
@@ -69,7 +69,7 @@ vibeの主要な変更はここに記録されています。
 
 ### 追加
 
-- **マルチランタイムサポート**: Node.js/npm/npx環境でのvibe実行をサポート
+- **マルチランタイムサポート**: Node.js/npm/npxおよびBun環境でのvibe実行をサポート
 - **RuntimeAbstractionLayer**: DenoとNode.js両対応の統一ランタイム抽象化レイヤー
 - **AppContext依存性注入**: DIパターンによるテスタビリティの向上
 

--- a/packages/docs/src/content/docs/ja/configuration/hooks.mdx
+++ b/packages/docs/src/content/docs/ja/configuration/hooks.mdx
@@ -102,6 +102,17 @@ post_start = [
 pre_clean = ["git stash --include-untracked"]
 ```
 
+### Bunプロジェクト
+
+```toml
+[hooks]
+post_start = [
+  "bun install",
+  "bun run build"
+]
+pre_clean = ["git stash --include-untracked"]
+```
+
 ### データベースマイグレーション
 
 ```toml

--- a/packages/docs/src/content/docs/ja/getting-started.mdx
+++ b/packages/docs/src/content/docs/ja/getting-started.mdx
@@ -40,6 +40,22 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     :::
 
   </TabItem>
+  <TabItem label="Bun">
+    ```bash frame="terminal"
+    # グローバルインストール
+    bun add -g @kexi/vibe
+
+    # またはbunxで直接実行
+    bunx @kexi/vibe start feat/my-feature
+    ```
+    :::note
+    シェル設定（ステップ2）が必要です。bunxを使用する場合は「bunx用」のコマンドを選択してください。
+    :::
+    :::tip
+    頻繁に使用する場合はグローバルインストールを推奨します。bunxはパッケージ解決のため起動が遅くなります。
+    :::
+
+  </TabItem>
   <TabItem label="Deno">
     ```bash frame="terminal"
     deno install -A --global jsr:@kexi/vibe
@@ -77,11 +93,13 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     ```bash frame="terminal"
     # ~/.zshrc に追加（いずれか1つを選択）
 
-    # グローバルインストール用（Homebrew, npm -g, Deno）
+    # グローバルインストール用（Homebrew, npm -g, bun -g, Deno）
     vibe() { eval "$(command vibe "$@")" }
 
     # npx用（グローバルインストールなし）
     vibe() { eval "$(npx @kexi/vibe "$@")" }
+    # bunx用:
+    # vibe() { eval "$(bunx @kexi/vibe "$@")" }
     ```
 
   </TabItem>
@@ -89,11 +107,13 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     ```bash frame="terminal"
     # ~/.bashrc に追加（いずれか1つを選択）
 
-    # グローバルインストール用（Homebrew, npm -g, Deno）
+    # グローバルインストール用（Homebrew, npm -g, bun -g, Deno）
     vibe() { eval "$(command vibe "$@")"; }
 
     # npx用（グローバルインストールなし）
     vibe() { eval "$(npx @kexi/vibe "$@")"; }
+    # bunx用:
+    # vibe() { eval "$(bunx @kexi/vibe "$@")"; }
     ```
 
   </TabItem>
@@ -101,7 +121,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     ```fish frame="terminal"
     # ~/.config/fish/config.fish に追加（いずれか1つを選択）
 
-    # グローバルインストール用（Homebrew, npm -g, Deno）
+    # グローバルインストール用（Homebrew, npm -g, bun -g, Deno）
     function vibe
         eval (command vibe $argv)
     end
@@ -110,6 +130,10 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     function vibe
         eval (npx @kexi/vibe $argv)
     end
+    # bunx用:
+    # function vibe
+    #     eval (bunx @kexi/vibe $argv)
+    # end
     ```
 
   </TabItem>
@@ -117,7 +141,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     ```nu frame="terminal"
     # ~/.config/nushell/config.nu に追加（いずれか1つを選択）
 
-    # グローバルインストール用（Homebrew, npm -g, Deno）
+    # グローバルインストール用（Homebrew, npm -g, bun -g, Deno）
     def --env vibe [...args] {
         ^vibe ...$args | lines | each { |line| nu -c $line }
     }
@@ -126,6 +150,10 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     def --env vibe [...args] {
         npx @kexi/vibe ...$args | lines | each { |line| nu -c $line }
     }
+    # bunx用:
+    # def --env vibe [...args] {
+    #     bunx @kexi/vibe ...$args | lines | each { |line| nu -c $line }
+    # }
     ```
 
   </TabItem>
@@ -133,11 +161,13 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     ```powershell frame="terminal"
     # $PROFILE に追加（いずれか1つを選択）
 
-    # グローバルインストール用（Homebrew, npm -g, Deno）
+    # グローバルインストール用（Homebrew, npm -g, bun -g, Deno）
     function vibe { Invoke-Expression (& vibe.exe $args) }
 
     # npx用（グローバルインストールなし）
     function vibe { Invoke-Expression (& npx @kexi/vibe $args) }
+    # bunx用:
+    # function vibe { Invoke-Expression (& bunx @kexi/vibe $args) }
     ```
 
   </TabItem>

--- a/packages/docs/src/content/docs/ja/installation.mdx
+++ b/packages/docs/src/content/docs/ja/installation.mdx
@@ -27,6 +27,20 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     :::
 
   </TabItem>
+  <TabItem label="Bun">
+    ```bash frame="terminal"
+    # グローバルインストール
+    bun add -g @kexi/vibe
+
+    # またはbunxで直接実行
+    bunx @kexi/vibe start feat/my-feature
+    ```
+
+    :::note
+    Bun 1.2.0以降が必要です。npmパッケージにはmacOS (APFS)とLinux (Btrfs/XFS)で最適化されたCopy-on-Writeファイルクローニング用のオプショナルなネイティブバインディング（`@kexi/vibe-native`）が含まれています。利用可能な場合は自動的に使用されます。
+    :::
+
+  </TabItem>
   <TabItem label="Deno (JSR)">
     ```bash frame="terminal"
     deno install -A --global jsr:@kexi/vibe


### PR DESCRIPTION
## Summary

- Add Bun installation tab to installation guide (`bun add -g` and `bunx` commands)
- Add Bun tab to getting started guide with shell setup instructions
- Update shell configuration examples to include `bunx` option for all shells
- Add Bun project example to hooks configuration (Common Patterns section)
- Update changelog v0.12.0 to mention Bun environment support

Both English and Japanese documentation versions are updated synchronously.

## Related

Bun runtime support was implemented in #262 (feat/bun-runtime-tests).

## Test plan

- [x] Run `pnpm run check:docs` - 0 errors, 0 warnings
- [ ] Verify docs build locally with `pnpm -C packages/docs dev`
- [ ] Check all Bun tabs render correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)