### PR TITLE
docs: add Bun installation instructions to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -99,6 +99,18 @@ npx @kexi/vibe start feat/my-feature
 
 > 注意: npmパッケージにはmacOS (APFS)とLinux (Btrfs/XFS)で最適化されたCopy-on-Writeファイルクローニング用のオプショナルなネイティブバインディング（`@kexi/vibe-native`）が含まれています。利用可能な場合は自動的に使用されます。
 
+### Bun (1.2.0+)
+
+```bash
+# グローバルインストール
+bun add -g @kexi/vibe
+
+# またはbunxで直接実行
+bunx @kexi/vibe start feat/my-feature
+```
+
+> 注意: BunはNode.jsと同じnpmパッケージを使用します。Copy-on-Writeファイルクローニング用のネイティブバインディングは利用可能な場合に自動的に使用されます。
+
 ### Deno (JSR)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ npx @kexi/vibe start feat/my-feature
 
 > Note: The npm package includes optional native bindings (`@kexi/vibe-native`) for optimized Copy-on-Write file cloning on macOS (APFS) and Linux (Btrfs/XFS). These are automatically used when available.
 
+### Bun (1.2.0+)
+
+```bash
+# Global install
+bun add -g @kexi/vibe
+
+# Or run directly with bunx
+bunx @kexi/vibe start feat/my-feature
+```
+
+> Note: Bun uses the same npm package as Node.js. Native bindings for Copy-on-Write file cloning are automatically used when available.
+
 ### Deno (JSR)
 
 ```bash


### PR DESCRIPTION
## Summary

Add Bun installation instructions to README.md and README.ja.md, consistent with the documentation site updates from #263.

## Changes

- Add Bun (1.2.0+) section between npm and Deno sections
- Include `bun add -g` and `bunx` commands
- Note about native bindings compatibility
- Both English and Japanese versions updated

## Related

- #263 - docs: add Bun runtime support documentation
- #262 - feat: add Bun runtime tests

## Test plan

- [x] README.md updated with Bun section
- [x] README.ja.md updated with Bun section (Japanese)
- [ ] Verify markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)