### PR TITLE
fix: add @kexi/vibe-native to import map for native clone support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -29,7 +29,8 @@
     "@std/path": "jsr:@std/path@^1.0.0",
     "@std/toml": "jsr:@std/toml@^1.0.0",
     "@std/assert": "jsr:@std/assert@^1.0.0",
-    "zod": "npm:zod@^3.23.0"
+    "zod": "npm:zod@^3.23.0",
+    "@kexi/vibe-native": "npm:@kexi/vibe-native@^0.15.0"
   },
   "compilerOptions": {
     "strict": true
@@ -72,6 +73,6 @@
       "!packages/core/src/version.ts"
     ]
   },
-  "nodeModulesDir": "none",
+  "nodeModulesDir": "auto",
   "minimumDependencyAge": "P3D"
 }

--- a/deno.lock
+++ b/deno.lock
@@ -9,6 +9,7 @@
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/toml@1": "1.0.11",
+    "npm:@kexi/vibe-native@0.15": "0.15.1",
     "npm:zod@^3.23.0": "3.25.76"
   },
   "jsr": {
@@ -51,6 +52,11 @@
     }
   },
   "npm": {
+    "@kexi/vibe-native@0.15.1": {
+      "integrity": "sha512-Pd5pv4cIEao+MP9Hz2kALrTc5dA0Me7Yuqpv2NJw8ANN6xJvabz/Egg+o/DikUMsM1D1iO4DPKplKb9JhlsKJg==",
+      "os": ["darwin", "linux"],
+      "cpu": ["x64", "arm64"]
+    },
     "zod@3.25.76": {
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
@@ -62,6 +68,7 @@
       "jsr:@std/fs@1",
       "jsr:@std/path@1",
       "jsr:@std/toml@1",
+      "npm:@kexi/vibe-native@0.15",
       "npm:zod@^3.23.0"
     ]
   }


### PR DESCRIPTION
## Summary
- Add `@kexi/vibe-native` to deno.json imports (missing since v0.15.0)
- Change `nodeModulesDir` from `"none"` to `"auto"` (required for N-API modules)

## Problem
Since v0.15.0, NativeCloneStrategy failed with `ERR_MODULE_NOT_FOUND` because `@kexi/vibe-native` was not in the import map. This caused fallback to `StandardStrategy` instead of using efficient CoW cloning.

## Root Cause
Commit 5b86683 migrated from FFI to N-API but forgot to add the module to deno.json imports.

## Test plan
- [x] Verified `isAvailable=true, supportsDirectory=true` with compiled binary
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)