### PR TITLE
fix: add inlineOnly option to resolve tsdown v0.20.1 build error

### DIFF
--- a/packages/npm/tsdown.config.ts
+++ b/packages/npm/tsdown.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   outDir: "dist",
   external: [/^node:.*/, "zod", "@kexi/vibe-native"],
   noExternal: [/^@jsr\/.*/],
+  inlineOnly: [/^@jsr\/.*/],
   outExtensions: () => ({
     js: ".js",
   }),


### PR DESCRIPTION
## Summary
- Add `inlineOnly: [/^@jsr\/.*/]` to `packages/npm/tsdown.config.ts` to fix `publish-cli` job failure
- tsdown v0.20.1 introduced a dependency bundle detection check that errors without explicit `inlineOnly` configuration
- The `@jsr/*` packages are intentionally bundled for Node.js distribution, and this change explicitly permits that behavior

## Test plan
- [x] `pnpm run build` in `packages/npm` completes with exit code 0
- [x] `pnpm run check:all` passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)