### PR TITLE
fix: replace deno task with bun run in release workflows

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -79,7 +79,7 @@ jobs:
           MISE_HTTP_TIMEOUT: "120"
 
       - name: Build release binary
-        run: deno task compile:ci --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
+        run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           MISE_HTTP_TIMEOUT: "120"
 
       - name: Build release binary
-        run: deno task compile:ci --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
+        run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -73,12 +73,12 @@ jobs:
       - name: Rebuild with deb distribution metadata
         run: |
           TARGET="${{ matrix.arch == 'amd64' && 'x86_64-unknown-linux-gnu' || 'aarch64-unknown-linux-gnu' }}"
-          deno task compile:ci --target "$TARGET" --output vibe-deb --distribution deb
+          bun run scripts/build.ts --target "$TARGET" --output vibe-deb --distribution deb
 
       - name: Build .deb package
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          deno task build:deb "$VERSION" ${{ matrix.arch }} vibe-deb
+          bun run scripts/build-deb.ts "$VERSION" ${{ matrix.arch }} vibe-deb
 
       - name: Upload .deb artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Fix Beta Release workflow failure: `deno task compile:ci` does not exist after Bun migration
- Updated both `release.yml` and `beta-release.yml` to use `bun run scripts/build.ts`

Fixes https://github.com/kexi/vibe/actions/runs/21558972184

## Changes

### `.github/workflows/beta-release.yml`
```diff
- run: deno task compile:ci --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
+ run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
```

### `.github/workflows/release.yml`
```diff
# Build step
- run: deno task compile:ci --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
+ run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary

# Deb rebuild step
- deno task compile:ci --target "$TARGET" --output vibe-deb --distribution deb
+ bun run scripts/build.ts --target "$TARGET" --output vibe-deb --distribution deb

# Deb build step
- deno task build:deb "$VERSION" ${{ matrix.arch }} vibe-deb
+ bun run scripts/build-deb.ts "$VERSION" ${{ matrix.arch }} vibe-deb
```

## Test plan

- [x] YAML syntax validation passed
- [x] `pnpm run lint` passed
- [x] `pnpm run check` passed  
- [x] `pnpm run test` passed (253 tests)
- [ ] Beta Release workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.ai/code)