### PR TITLE
fix: add pnpm install step to release workflows

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -78,6 +78,9 @@ jobs:
         env:
           MISE_HTTP_TIMEOUT: "120"
 
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Build release binary
         run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
         env:
           MISE_HTTP_TIMEOUT: "120"
 
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Build release binary
         run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
 
@@ -69,6 +72,9 @@ jobs:
         with:
           name: ${{ matrix.binary }}
           path: .
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Rebuild with deb distribution metadata
         run: |


### PR DESCRIPTION
## Summary

- Fix Beta Release workflow failure: dependencies not installed before build
- Added `pnpm install` step to all build jobs in release workflows

Fixes https://github.com/kexi/vibe/actions/runs/21559102362

## Error

```
error: Could not resolve: "smol-toml". Maybe you need to "bun install"?
error: Could not resolve: "zod". Maybe you need to "bun install"?
error: Could not resolve: "fast-glob". Maybe you need to "bun install"?
```

## Changes

### `.github/workflows/beta-release.yml`
```diff
+ - name: Install dependencies
+   run: pnpm install
+
  - name: Build release binary
```

### `.github/workflows/release.yml`
Added `pnpm install` to:
- `build` job (before Build release binary)
- `build-deb` job (before Rebuild with deb distribution metadata)

## Test plan

- [x] YAML syntax validation passed
- [ ] Beta Release workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.ai/code)