### PR TITLE
fix: add --ignore-scripts to pnpm install in release workflows

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -79,7 +79,7 @@ jobs:
           MISE_HTTP_TIMEOUT: "120"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Build release binary
         run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           MISE_HTTP_TIMEOUT: "120"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Build release binary
         run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
@@ -74,7 +74,7 @@ jobs:
           path: .
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Rebuild with deb distribution metadata
         run: |


### PR DESCRIPTION
## Summary

- Fix node-pty compilation error: `node-gyp: not found`
- Added `--ignore-scripts` to skip native module compilation

Fixes https://github.com/kexi/vibe/actions/runs/21559133601

## Error

```
node_modules/node-pty install: sh: 1: node-gyp: not found
ELIFECYCLE  Command failed.
```

## Changes

```diff
- run: pnpm install
+ run: pnpm install --ignore-scripts
```

Applied to:
- `beta-release.yml` (build job)
- `release.yml` (build and build-deb jobs)

🤖 Generated with [Claude Code](https://claude.ai/code)