### PR TITLE
fix: install vibe-beta as separate command without conflicts

### DIFF
--- a/Formula/vibe-beta.rb
+++ b/Formula/vibe-beta.rb
@@ -4,7 +4,6 @@ class VibeBeta < Formula
   version "VERSION_PLACEHOLDER"
   license "MIT"
 
-  conflicts_with "vibe", because: "both install the same binary"
 
   on_macos do
     on_arm do
@@ -34,7 +33,7 @@ class VibeBeta < Formula
     binary_name = "vibe-linux-arm64" if OS.linux? && Hardware::CPU.arm?
     binary_name = "vibe-linux-x64" if OS.linux? && Hardware::CPU.intel?
 
-    bin.install binary_name => "vibe"
+    bin.install binary_name => "vibe-beta"
   end
 
   def caveats
@@ -44,11 +43,11 @@ class VibeBeta < Formula
         brew install kexi/tap/vibe
 
       Add this to your .zshrc:
-        vibe() { eval "$(command vibe "$@")" }
+        vibe-beta() { eval "$(command vibe-beta "$@")" }
     EOS
   end
 
   test do
-    system "#{bin}/vibe", "--help"
+    system "#{bin}/vibe-beta", "--help"
   end
 end


### PR DESCRIPTION
## Summary

- Remove `conflicts_with` directive - `vibe` と `vibe-beta` は共存可能に
- Install binary as `vibe-beta` instead of `vibe`
- Update caveats and test to use `vibe-beta`

## Before
```bash
brew install kexi/tap/vibe-beta  # conflicts with vibe
vibe -v  # ← same command as stable
```

## After
```bash
brew install kexi/tap/vibe       # stable: vibe command
brew install kexi/tap/vibe-beta  # beta: vibe-beta command
# Both can be installed simultaneously!
```

🤖 Generated with [Claude Code](https://claude.ai/code)