### PR TITLE
feat: add --version option to build script for beta releases

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -82,7 +82,7 @@ jobs:
         run: pnpm install --ignore-scripts
 
       - name: Build release binary
-        run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
+        run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary --version ${{ needs.prepare.outputs.version }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -192,6 +192,7 @@ const parseArgsOptions: ParseArgsConfig["options"] = {
   target: { type: "string" },
   distribution: { type: "string" },
   output: { type: "string" },
+  version: { type: "string" },
   "generate-version-only": { type: "boolean" },
 };
 
@@ -206,6 +207,7 @@ async function main(): Promise<void> {
     target?: string;
     distribution?: string;
     output?: string;
+    version?: string;
     "generate-version-only"?: boolean;
   };
 
@@ -243,10 +245,11 @@ async function main(): Promise<void> {
     buildEnv,
   };
 
-  const { version, repository } = await getPackageJsonInfo();
+  const pkgInfo = await getPackageJsonInfo();
+  const version = args.version ?? pkgInfo.version;
   const commitHash = await getGitCommitHash();
 
-  await generateBuildInfoFile(version, commitHash, repository, metadata);
+  await generateBuildInfoFile(version, commitHash, pkgInfo.repository, metadata);
 
   if (args["generate-version-only"]) {
     return;


### PR DESCRIPTION
## Summary

- Add `--version` option to `scripts/build.ts` to override package.json version
- Update `beta-release.yml` to pass beta version to build

## Problem

Beta binaries were showing `0.17.0+hash` instead of `0.17.0-beta.X+hash`:

```bash
vibe-beta -v
# Before: vibe 0.17.0+1a00486
# After:  vibe 0.17.0-beta.8+abc1234
```

## Changes

### `scripts/build.ts`
```typescript
// New option
const parseArgsOptions = {
  // ...
  version: { type: "string" },  // NEW
};

// Use provided version or fall back to package.json
const version = args.version ?? pkgInfo.version;
```

### `beta-release.yml`
```diff
- run: bun run scripts/build.ts --target ... --distribution binary
+ run: bun run scripts/build.ts --target ... --distribution binary --version ${{ needs.prepare.outputs.version }}
```

## Test plan

- [x] `pnpm run lint` passed
- [x] `pnpm run check` passed
- [x] `pnpm run test` passed (253 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)