### PR TITLE
fix(ci): resolve JSR and npm publish failures for v0.18.0

### DIFF
--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -71,7 +71,9 @@ jobs:
           echo "Generated packages/core/src/version.ts with VERSION = \"$VERSION\" for JSR distribution"
 
       - name: Validate JSR package
-        run: npx jsr publish --dry-run --allow-dirty
+        working-directory: packages/core
+        run: npx jsr publish --dry-run --allow-dirty --allow-slow-types
 
       - name: Publish to JSR
-        run: npx jsr publish --allow-dirty
+        working-directory: packages/core
+        run: npx jsr publish --allow-dirty --allow-slow-types

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -1,0 +1,17 @@
+{
+  "name": "@kexi/vibe-core",
+  "version": "0.18.0",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/kexi/vibe",
+  "exports": {
+    ".": "./src/index.ts",
+    "./runtime": "./src/runtime/index.ts",
+    "./types": "./src/types/config.ts",
+    "./errors": "./src/errors/index.ts",
+    "./context": "./src/context/index.ts",
+    "./context/testing": "./src/context/testing.ts"
+  },
+  "imports": {
+    "zod": "npm:zod@^3.23.0"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-core",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Core components for Vibe - Runtime abstraction, types, errors, and context",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Sync `packages/core/package.json` version from 0.17.0 to 0.18.0 (npm publish failure fix)
- Create `packages/core/jsr.json` for JSR configuration (deno.json was removed during Bun migration)
- Add `working-directory: packages/core` to JSR publish workflow
- Add `--allow-slow-types` flag to handle type inference warnings

## Related Issues
- npm publish failure: https://github.com/kexi/vibe/actions/runs/13118920839/job/36613017598
- JSR publish failure: https://github.com/kexi/vibe/actions/runs/13118920839/job/36613017607

## Test plan
- [x] `bun run scripts/sync-version.ts --check` passes
- [x] `npx jsr publish --dry-run --allow-dirty --allow-slow-types` succeeds in `packages/core`
- [x] `pnpm run lint && pnpm run check && pnpm run test` all pass

🤖 Generated with [Claude Code](https://claude.ai/code)