### PR TITLE
chore: release v0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-monorepo",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "type": "module",
   "description": "Monorepo for vibe CLI - Git worktree management tool",

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-core",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-core",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Core components for Vibe - Runtime abstraction, types, errors, and context",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-native",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Native clone operations for vibe CLI (clonefile on macOS, FICLONE on Linux)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Git worktree helper CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Patch release v0.18.1 to re-publish npm and JSR packages with CI fixes

## Changes
- Version bump: 0.18.0 → 0.18.1 (all packages)

## Related
- CI fix PR: #298

## Release Checklist
- [ ] Merge this PR to develop
- [ ] Create GitHub Release with tag `v0.18.1`
- [ ] Verify npm publish workflow succeeds
- [ ] Verify JSR publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)