### PR TITLE
fix(ci): add missing pnpm install steps for JSR and npm publish

### DIFF
--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -19,6 +19,9 @@ jobs:
         env:
           MISE_HTTP_TIMEOUT: "120"
 
+      - name: Install dependencies
+        run: pnpm install --filter @kexi/vibe-core
+
       - name: Validate version consistency
         shell: bash
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -187,8 +187,7 @@ jobs:
           echo "Version validation passed: $TAG_VERSION"
 
       - name: Install dependencies
-        working-directory: packages/npm
-        run: pnpm install --ignore-scripts
+        run: pnpm install
 
       - name: Generate version.ts for npm
         run: |


### PR DESCRIPTION
## Summary
- JSR publish: Add `pnpm install --filter @kexi/vibe-core` to install zod dependency
- npm publish: Change to full `pnpm install` for monorepo dependencies (fast-glob, @nodelib/*, etc.)

## Problem
- JSR publish failed with: `Could not find "zod" in a node_modules folder`
- npm publish failed with: `merge2 is located in node_modules but is not included in inlineOnly option`

Both failures were caused by missing dependencies that weren't installed in the CI workflow.

## Test plan
- [ ] Merge this PR
- [ ] Re-run v0.18.1 release workflows
- [ ] Verify JSR and npm publish succeed

🤖 Generated with [Claude Code](https://claude.ai/code)