### PR TITLE
chore: release v0.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-monorepo",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "private": true,
   "type": "module",
   "description": "Monorepo for vibe CLI - Git worktree management tool",

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-core",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-core",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Core components for Vibe - Runtime abstraction, types, errors, and context",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-native",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Native clone operations for vibe CLI (clonefile on macOS, FICLONE on Linux)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Git worktree helper CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Patch release v0.18.2 with CI fixes included in the release tag.

## Changes
- Version bump: 0.18.1 → 0.18.2 (all packages)
- Includes CI fixes from #298 and #300

## Why v0.18.2?
v0.18.1 CI workflows failed because `gh run rerun` uses the code at the release tag, not the latest develop. This release includes all CI fixes in the tag itself.

🤖 Generated with [Claude Code](https://claude.ai/code)