### PR TITLE
fix(ci): add --ignore-scripts to pnpm install in publish workflows

### DIFF
--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -20,7 +20,7 @@ jobs:
           MISE_HTTP_TIMEOUT: "120"
 
       - name: Install dependencies
-        run: pnpm install --filter @kexi/vibe-core
+        run: pnpm install --filter @kexi/vibe-core --ignore-scripts
 
       - name: Validate version consistency
         shell: bash

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -187,7 +187,7 @@ jobs:
           echo "Version validation passed: $TAG_VERSION"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Generate version.ts for npm
         run: |


### PR DESCRIPTION
## Summary
Add `--ignore-scripts` flag to `pnpm install` commands in publish workflows.

## Problem
```
node_modules/node-pty install: sh: 1: node-gyp: not found
```

The `node-pty` package tries to build native bindings but `node-gyp` is not available in CI.

## Solution
Use `--ignore-scripts` to skip postinstall scripts that require native compilation. The publish workflows don't need these native modules.

🤖 Generated with [Claude Code](https://claude.ai/code)