### PR TITLE
fix(homebrew): remove conflicts_with vibe-beta

### DIFF
--- a/Formula/vibe.rb
+++ b/Formula/vibe.rb
@@ -4,8 +4,6 @@ class Vibe < Formula
   version "VERSION_PLACEHOLDER"
   license "MIT"
 
-  conflicts_with "vibe-beta", because: "both install the same binary"
-
   on_macos do
     on_arm do
       url "https://github.com/kexi/vibe/releases/download/vVERSION_PLACEHOLDER/vibe-darwin-arm64"


### PR DESCRIPTION
## Summary
- vibeとvibe-betaの`conflicts_with`設定を削除
- 両パッケージは異なるバイナリ名（`vibe` vs `vibe-beta`）を使用するため、実際の競合なし
- これにより両パッケージの同時インストールが可能に

## Test plan
- [x] `ruby -c Formula/vibe.rb` で構文チェック済み
- [ ] Homebrew環境でvibeとvibe-betaの同時インストールを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)