### PR TITLE
feat: support windows robocopy strategy

### DIFF
--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -53,20 +53,24 @@ flowchart TD
     C -->|Yes| D[NativeCloneStrategy]
     C -->|No| E{rsync available?}
     E -->|Yes| F[RsyncStrategy]
-    E -->|No| G[StandardStrategy]
+    E -->|No| K{Windows?}
+    K -->|Yes| L[RobocopyStrategy]
+    K -->|No| G[StandardStrategy]
 
     D --> H[clonefile / FICLONE]
     F --> I[rsync -a]
+    L --> M[robocopy /E /MT]
     G --> J[recursive copy]
 ```
 
 ### 戦略選択
 
-| 戦略                | プラットフォーム                 | 説明                           |
-| ------------------- | -------------------------------- | ------------------------------ |
-| NativeCloneStrategy | macOS (APFS)、Linux (Btrfs, XFS) | Copy-on-Write による即時コピー |
-| RsyncStrategy       | Unix 系                          | rsync による効率的なコピー     |
-| StandardStrategy    | すべて                           | 再帰的なファイル単位コピー     |
+| 戦略                | プラットフォーム                 | 説明                                |
+| ------------------- | -------------------------------- | ----------------------------------- |
+| NativeCloneStrategy | macOS (APFS)、Linux (Btrfs, XFS) | Copy-on-Write による即時コピー      |
+| RsyncStrategy       | Unix 系                          | rsync による効率的なコピー          |
+| RobocopyStrategy    | Windows                          | robocopy によるマルチスレッドコピー |
+| StandardStrategy    | すべて                           | 再帰的なファイル単位コピー          |
 
 ## クリーン戦略
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,20 +53,24 @@ flowchart TD
     C -->|Yes| D[NativeCloneStrategy]
     C -->|No| E{rsync available?}
     E -->|Yes| F[RsyncStrategy]
-    E -->|No| G[StandardStrategy]
+    E -->|No| K{Windows?}
+    K -->|Yes| L[RobocopyStrategy]
+    K -->|No| G[StandardStrategy]
 
     D --> H[clonefile / FICLONE]
     F --> I[rsync -a]
+    L --> M[robocopy /E /MT]
     G --> J[recursive copy]
 ```
 
 ### Strategy Selection
 
-| Strategy            | Platform                         | Description                           |
-| ------------------- | -------------------------------- | ------------------------------------- |
-| NativeCloneStrategy | macOS (APFS), Linux (Btrfs, XFS) | Uses Copy-on-Write for instant copies |
-| RsyncStrategy       | Unix-like                        | Uses rsync for efficient copying      |
-| StandardStrategy    | All                              | Recursive file-by-file copy           |
+| Strategy            | Platform                         | Description                               |
+| ------------------- | -------------------------------- | ----------------------------------------- |
+| NativeCloneStrategy | macOS (APFS), Linux (Btrfs, XFS) | Uses Copy-on-Write for instant copies     |
+| RsyncStrategy       | Unix-like                        | Uses rsync for efficient copying          |
+| RobocopyStrategy    | Windows                          | Uses robocopy with multi-threaded copying |
+| StandardStrategy    | All                              | Recursive file-by-file copy               |
 
 ## Clean Strategy
 

--- a/packages/core/src/utils/copy/strategies/index.ts
+++ b/packages/core/src/utils/copy/strategies/index.ts
@@ -1,4 +1,5 @@
 export { CloneStrategy } from "./clone.ts";
 export { NativeCloneStrategy } from "./native-clone.ts";
+export { RobocopyStrategy } from "./robocopy.ts";
 export { RsyncStrategy } from "./rsync.ts";
 export { StandardStrategy } from "./standard.ts";

--- a/packages/core/src/utils/copy/strategies/robocopy.ts
+++ b/packages/core/src/utils/copy/strategies/robocopy.ts
@@ -1,0 +1,110 @@
+import { dirname } from "node:path";
+import { detectCapabilities } from "../detector.ts";
+import type { CopyStrategy } from "../types.ts";
+import { validatePath } from "../validation.ts";
+import { runtime } from "../../../runtime/index.ts";
+
+/**
+ * Robocopy-based copy strategy for Windows.
+ * Uses multi-threaded copying (/MT flag) for efficient directory operations.
+ *
+ * Important: robocopy exit codes 0-7 indicate success:
+ *   0: No files copied, no errors
+ *   1: One or more files copied
+ *   2: Extra files/dirs detected (not an error)
+ *   3: Combination of 1+2
+ *   4: Mismatched files/dirs detected
+ *   5-7: Combinations of above
+ *   8+: Errors occurred
+ */
+export class RobocopyStrategy implements CopyStrategy {
+  readonly name = "robocopy" as const;
+
+  async isAvailable(): Promise<boolean> {
+    const capabilities = await detectCapabilities();
+    return capabilities.robocopyAvailable;
+  }
+
+  /**
+   * Copy a single file using robocopy.
+   * Note: CopyService always uses StandardStrategy for single file copies,
+   * so this is primarily for interface compliance.
+   */
+  async copyFile(src: string, dest: string): Promise<void> {
+    validatePath(src);
+    validatePath(dest);
+
+    const srcDir = dirname(src);
+    const destDir = dirname(dest);
+    const fileName = src.split(/[\\/]/).pop()!;
+
+    // Ensure destination directory exists
+    await runtime.fs.mkdir(destDir, { recursive: true }).catch(() => {});
+
+    const result = await runtime.process.run({
+      cmd: "robocopy",
+      args: [
+        srcDir,
+        destDir,
+        fileName,
+        "/COPY:DAT",
+        "/DCOPY:DAT",
+        "/NFL",
+        "/NDL",
+        "/NJH",
+        "/NJS",
+        "/NC",
+        "/NS",
+        "/NP",
+      ],
+      stderr: "piped",
+    });
+
+    // robocopy exit codes: 0-7 = success, 8+ = error
+    if (result.code >= 8) {
+      const stderr = new TextDecoder().decode(result.stderr);
+      throw new Error(`Robocopy file copy failed: ${src} -> ${dest}: ${stderr}`);
+    }
+  }
+
+  async copyDirectory(src: string, dest: string): Promise<void> {
+    validatePath(src);
+    validatePath(dest);
+
+    // Ensure parent directory exists
+    const parentDir = dirname(dest);
+    await runtime.fs.mkdir(parentDir, { recursive: true }).catch(() => {});
+
+    // /E: Copy subdirectories including empty ones
+    // /MT: Multi-threaded copying (default 8 threads)
+    // /COPY:DAT: Copy Data, Attributes, Timestamps
+    // /DCOPY:DAT: Copy Directory Data, Attributes, Timestamps
+    // /NFL /NDL /NJH /NJS /NC /NS /NP: Suppress output for performance
+    // Note: /PURGE and /MIR are intentionally NOT used to prevent data loss
+    const result = await runtime.process.run({
+      cmd: "robocopy",
+      args: [
+        src,
+        dest,
+        "/E",
+        "/MT",
+        "/COPY:DAT",
+        "/DCOPY:DAT",
+        "/NFL",
+        "/NDL",
+        "/NJH",
+        "/NJS",
+        "/NC",
+        "/NS",
+        "/NP",
+      ],
+      stderr: "piped",
+    });
+
+    // robocopy exit codes: 0-7 = success, 8+ = error
+    if (result.code >= 8) {
+      const stderr = new TextDecoder().decode(result.stderr);
+      throw new Error(`Robocopy directory copy failed: ${src} -> ${dest}: ${stderr}`);
+    }
+  }
+}

--- a/packages/core/src/utils/copy/types.ts
+++ b/packages/core/src/utils/copy/types.ts
@@ -1,7 +1,7 @@
 /**
  * Copy strategy type identifier
  */
-export type CopyStrategyType = "clonefile" | "clone" | "rsync" | "standard";
+export type CopyStrategyType = "clonefile" | "clone" | "rsync" | "robocopy" | "standard";
 
 /**
  * Interface for copy strategies
@@ -34,4 +34,6 @@ export interface CopyCapabilities {
   cloneSupported: boolean;
   /** Whether rsync command is available */
   rsyncAvailable: boolean;
+  /** Whether robocopy command is available (Windows) */
+  robocopyAvailable: boolean;
 }


### PR DESCRIPTION
## Summary

Add Windows `robocopy` strategy for efficient multi-threaded directory copying, complementing existing CoW (APFS/Btrfs/XFS) and rsync strategies.

- Implement `RobocopyStrategy` using `/E /MT /COPY:DAT /DCOPY:DAT` flags for multi-threaded copying with metadata preservation
- Add robocopy availability detection in `detector.ts` (Windows-only, with capability caching)
- Handle robocopy-specific exit codes (0-7 = success, 8+ = error); intentionally avoid destructive flags (`/PURGE`, `/MIR`)

### Strategy selection priority (Windows)

| Operation | Priority |
|-----------|----------|
| Directory copy | Robocopy (multi-threaded) > Standard |
| File copy | Always Standard (runtime API) |

## Test plan

- [x] Robocopy availability detection on Windows
- [x] Single file copy with content validation
- [x] Directory copy with nested structure
- [x] Empty directory preservation (`/E` flag)
- [x] Non-Windows platforms return `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)