### PR TITLE
fix: ignore auto-generated Astro files in root Prettier check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Auto-generated files
+packages/docs/.astro/


### PR DESCRIPTION
## Summary
- ルートの `prettier --check .` が `packages/docs/.astro/` の自動生成ファイルを検出してフォーマットエラーになる問題を修正
- ルートに `.prettierignore` を追加し、`packages/docs/.astro/` を除外

## Details
`packages/docs/.prettierignore` には既に `.astro/` が含まれていましたが、ルートから `prettier --check .` を実行した場合はルートの `.prettierignore` が参照されるため効果がありませんでした。

## Test plan
- [x] `pnpm run fmt:check` がパスすることを確認
- [x] `pnpm run check:all` の実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)