### PR TITLE
fix: use fully qualified tap name for brew upgrade command

### DIFF
--- a/packages/core/src/commands/upgrade.ts
+++ b/packages/core/src/commands/upgrade.ts
@@ -192,7 +192,7 @@ async function detectInstallMethod(ctx: AppContext): Promise<InstallMethod> {
 function getUpgradeCommand(method: InstallMethod): string | null {
   switch (method) {
     case "homebrew":
-      return "brew upgrade vibe";
+      return "brew upgrade kexi/tap/vibe";
     case "jsr":
       return "deno install -A --global jsr:@kexi/vibe";
     case "deb":

--- a/packages/docs/src/content/docs/commands/upgrade.mdx
+++ b/packages/docs/src/content/docs/commands/upgrade.mdx
@@ -52,7 +52,7 @@ vibe 0.8.0
 A new version is available: 0.8.1
 
 To upgrade:
-  brew upgrade vibe
+  brew upgrade kexi/tap/vibe
 
 Release notes:
   https://github.com/kexi/vibe/releases/tag/v0.8.1
@@ -64,7 +64,7 @@ vibe automatically detects how it was installed and shows the appropriate upgrad
 
 | Method   | Upgrade Command                            |
 | -------- | ------------------------------------------ |
-| Homebrew | `brew upgrade vibe`                        |
+| Homebrew | `brew upgrade kexi/tap/vibe`               |
 | mise     | `mise upgrade vibe`                        |
 | npm      | `npm install -g @kexi/vibe`                |
 | Bun      | `bun add -g @kexi/vibe`                    |

--- a/packages/docs/src/content/docs/ja/commands/upgrade.mdx
+++ b/packages/docs/src/content/docs/ja/commands/upgrade.mdx
@@ -52,7 +52,7 @@ vibe 0.8.0
 A new version is available: 0.8.1
 
 To upgrade:
-  brew upgrade vibe
+  brew upgrade kexi/tap/vibe
 
 Release notes:
   https://github.com/kexi/vibe/releases/tag/v0.8.1
@@ -64,7 +64,7 @@ vibeはインストール方法を自動検出し、適切なアップグレー�
 
 | 方法     | アップグレードコマンド                     |
 | -------- | ------------------------------------------ |
-| Homebrew | `brew upgrade vibe`                        |
+| Homebrew | `brew upgrade kexi/tap/vibe`               |
 | mise     | `mise upgrade vibe`                        |
 | npm      | `npm install -g @kexi/vibe`                |
 | Bun      | `bun add -g @kexi/vibe`                    |

--- a/packages/video/src/scenes/UpgradeCommand.tsx
+++ b/packages/video/src/scenes/UpgradeCommand.tsx
@@ -19,7 +19,7 @@ export const UpgradeCommand: React.FC = () => {
     { text: "A new version is available: 0.13.0", color: COLORS.success, delay: 12 },
     { text: "", delay: 18 },
     { text: "To upgrade:", color: COLORS.text, delay: 24 },
-    { text: "  brew upgrade vibe", color: COLORS.info, delay: 30 },
+    { text: "  brew upgrade kexi/tap/vibe", color: COLORS.info, delay: 30 },
     { text: "", delay: 36 },
     { text: "Release notes:", color: COLORS.text, delay: 42 },
     { text: "  https://github.com/kexi/vibe/releases/tag/v0.13.0", color: COLORS.info, delay: 48 },


### PR DESCRIPTION
## Summary
- `vibe upgrade` コマンドが Homebrew ユーザーに `brew upgrade vibe` を提案していたが、vibe はカスタム tap (`kexi/tap`) 経由で配布されているため `brew upgrade kexi/tap/vibe` に修正
- コアコマンド、英語/日本語ドキュメント、デモ動画シーンの4ファイルを一括修正
- `brew install kexi/tap/vibe` と統一性が取れた

## Test plan
- [x] `pnpm run check:all` が全て通過（254テスト全パス、lint/format/typecheck OK）
- [ ] `vibe upgrade` を Homebrew 環境で実行し、`brew upgrade kexi/tap/vibe` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)