### PR TITLE
fix: display clean success messages in green to avoid appearing as errors

### DIFF
--- a/packages/core/src/commands/clean.ts
+++ b/packages/core/src/commands/clean.ts
@@ -13,7 +13,7 @@ import { loadVibeConfig } from "../utils/config.ts";
 import { type HookTrackerInfo, runHooks } from "../utils/hooks.ts";
 import { confirm } from "../utils/prompt.ts";
 import { ProgressTracker } from "../utils/progress.ts";
-import { log, type OutputOptions, verboseLog } from "../utils/output.ts";
+import { type OutputOptions, successLog, verboseLog } from "../utils/output.ts";
 import { loadUserSettings } from "../utils/settings.ts";
 import {
   cleanupStaleTrash,
@@ -186,7 +186,7 @@ export async function cleanCommand(
 
     // Early check: if worktree is already removed (another process finished), exit gracefully
     if (worktreeInfo === null) {
-      log("Worktree already removed.", outputOpts);
+      successLog("Worktree already removed.", outputOpts);
       console.log(`cd '${mainPath}'`);
       return;
     }
@@ -268,7 +268,7 @@ export async function cleanCommand(
       );
     }
 
-    log(`Worktree ${currentWorktreePath} has been removed.`, outputOpts);
+    successLog(`Worktree ${currentWorktreePath} has been removed.`, outputOpts);
 
     // Determine whether to delete branch
     // Priority: CLI option > config > default (false)
@@ -285,7 +285,7 @@ export async function cleanCommand(
     if (shouldDeleteBranch && currentBranch) {
       try {
         await runGitCommand(["-C", mainPath, "branch", "-d", currentBranch], ctx);
-        log(`Branch ${currentBranch} has been deleted.`, outputOpts);
+        successLog(`Branch ${currentBranch} has been deleted.`, outputOpts);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         console.error(`Warning: Could not delete branch ${currentBranch}: ${errorMessage}`);

--- a/packages/core/src/utils/output.test.ts
+++ b/packages/core/src/utils/output.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { errorLog, log, type OutputOptions, verboseLog } from "./output.ts";
+import { errorLog, log, type OutputOptions, successLog, verboseLog } from "./output.ts";
 
 describe("output utilities", () => {
   let messages: string[];
@@ -57,6 +57,26 @@ describe("output utilities", () => {
     it("suppresses message when quiet is true even if verbose is true", () => {
       const options: OutputOptions = { verbose: true, quiet: true };
       verboseLog("test message", options);
+      expect(messages).toEqual([]);
+    });
+  });
+
+  describe("successLog", () => {
+    it("outputs message with green color when quiet is false", () => {
+      const options: OutputOptions = { quiet: false };
+      successLog("success message", options);
+      expect(messages).toEqual(["\x1b[32msuccess message\x1b[0m"]);
+    });
+
+    it("outputs message with green color when quiet is undefined", () => {
+      const options: OutputOptions = {};
+      successLog("success message", options);
+      expect(messages).toEqual(["\x1b[32msuccess message\x1b[0m"]);
+    });
+
+    it("suppresses message when quiet is true", () => {
+      const options: OutputOptions = { quiet: true };
+      successLog("success message", options);
       expect(messages).toEqual([]);
     });
   });

--- a/packages/core/src/utils/output.ts
+++ b/packages/core/src/utils/output.ts
@@ -26,6 +26,20 @@ export function verboseLog(message: string, options: OutputOptions): void {
   }
 }
 
+const GREEN = "\x1b[32m";
+const RESET = "\x1b[0m";
+
+/**
+ * Log a success message to stderr with green color.
+ * Uses stderr because stdout is reserved for shell commands (eval pattern).
+ */
+export function successLog(message: string, options: OutputOptions): void {
+  const shouldLog = !options.quiet;
+  if (shouldLog) {
+    console.error(`${GREEN}${message}${RESET}`);
+  }
+}
+
 /**
  * Log an error or warning message to stderr.
  * Always outputs regardless of quiet mode, as errors should never be suppressed.


### PR DESCRIPTION
## Summary
- `vibe clean` の成功メッセージが一部ターミナルで赤色表示される問題を修正
- `successLog()` 関数を追加し、成功メッセージにANSI緑色を付与
- stdout はシェルコマンド用に予約されているため、stderr への出力は維持しつつ色で区別

## Test plan
- [x] `output.test.ts` に `successLog` のテスト3件追加（通常出力・quiet未指定・quiet時の抑制）
- [x] `clean.test.ts` の既存テスト4件がパスすることを確認
- [x] ESLint / Prettier / TypeScript 型チェック全てパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)