### PR TITLE
feat: support remote branch checkout in vibe start via DWIM

### DIFF
--- a/packages/core/src/commands/start.test.ts
+++ b/packages/core/src/commands/start.test.ts
@@ -869,6 +869,7 @@ describe("startCommand --claude-code-worktree-hook mode", () => {
   function createWorktreeHookContext(options: {
     stdinData?: string;
     branchExists?: boolean;
+    remoteBranchExists?: boolean;
     worktreeListOutput?: string;
     repoRoot?: string;
     repoName?: string;
@@ -877,6 +878,7 @@ describe("startCommand --claude-code-worktree-hook mode", () => {
   }) {
     const {
       branchExists = false,
+      remoteBranchExists = false,
       repoRoot = "/tmp/mock-repo",
       repoName = "mock-repo",
       vibeTomlContent,
@@ -976,13 +978,14 @@ describe("startCommand --claude-code-worktree-hook mode", () => {
           // Mock: git show-ref --verify (branch exists check)
           const isShowRefVerify = args.includes("show-ref") && args.includes("--verify");
           if (isShowRefVerify) {
+            const refArg = args.find((a) => a.startsWith("refs/"));
+            const isRemoteRef = refArg?.startsWith("refs/remotes/") ?? false;
+            const exists = isRemoteRef ? remoteBranchExists : branchExists;
             return Promise.resolve({
-              code: branchExists ? 0 : 1,
-              success: branchExists,
+              code: exists ? 0 : 1,
+              success: exists,
               stdout: new Uint8Array(),
-              stderr: branchExists
-                ? new Uint8Array()
-                : new TextEncoder().encode("fatal: bad ref\n"),
+              stderr: exists ? new Uint8Array() : new TextEncoder().encode("fatal: bad ref\n"),
             } as RunResult);
           }
 
@@ -1252,6 +1255,34 @@ describe("startCommand --claude-code-worktree-hook mode", () => {
     expect(getExitCode()).toBeNull();
     const hasExistingPath = stdoutOutput.some((line) => line === existingPath);
     expect(hasExistingPath).toBe(true);
+  });
+
+  it("uses existing remote branch via DWIM when local branch does not exist", async () => {
+    const { ctx, getExitCode, stdoutOutput } = createWorktreeHookContext({
+      stdinData: JSON.stringify({ name: "remote-only-branch" }),
+      branchExists: false,
+      remoteBranchExists: true,
+    });
+
+    let worktreeAddArgs: string[] = [];
+    const originalRun = ctx.runtime.process.run;
+    ctx.runtime.process.run = (opts) => {
+      const args = opts.args as string[];
+      const isWorktreeAdd = args.includes("worktree") && args.includes("add");
+      if (isWorktreeAdd) {
+        worktreeAddArgs = [...args];
+      }
+      return originalRun(opts);
+    };
+
+    await startCommand("", { worktreeHook: true, quiet: true }, ctx);
+
+    expect(getExitCode()).toBeNull();
+    // Should use `git worktree add <path> <branch>` (DWIM form, no -b flag)
+    expect(worktreeAddArgs).not.toContain("-b");
+    expect(worktreeAddArgs).toContain("remote-only-branch");
+    const hasPath = stdoutOutput.some((line) => line.includes("remote-only-branch"));
+    expect(hasPath).toBe(true);
   });
 
   it("reuses existing worktree when same-branch conflict at target path", async () => {

--- a/packages/core/src/services/worktree/validator.ts
+++ b/packages/core/src/services/worktree/validator.ts
@@ -4,7 +4,12 @@
  * Provides validation for branch and worktree operations.
  */
 
-import { branchExists, findWorktreeByBranch, getWorktreeByPath } from "../../utils/git.ts";
+import {
+  branchExists,
+  remoteBranchExists,
+  findWorktreeByBranch,
+  getWorktreeByPath,
+} from "../../utils/git.ts";
 import { type AppContext, getGlobalContext } from "../../context/index.ts";
 
 /**
@@ -53,7 +58,8 @@ export async function validateBranchForWorktree(
     };
   }
 
-  const exists = await branchExists(branchName, ctx);
+  const localExists = await branchExists(branchName, ctx);
+  const exists = localExists || (await remoteBranchExists(branchName, "origin", ctx));
 
   return {
     isValid: true,

--- a/packages/core/src/utils/git.ts
+++ b/packages/core/src/utils/git.ts
@@ -166,6 +166,22 @@ export async function branchExists(
   }
 }
 
+export async function remoteBranchExists(
+  branchName: string,
+  remote: string = "origin",
+  ctx: AppContext = getGlobalContext(),
+): Promise<boolean> {
+  try {
+    await runGitCommand(
+      ["show-ref", "--verify", "--quiet", `refs/remotes/${remote}/${branchName}`],
+      ctx,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function revisionExists(
   ref: string,
   ctx: AppContext = getGlobalContext(),


### PR DESCRIPTION
## Summary

- `vibe start <branch>` がリモートにのみ存在するブランチ（PR ブランチ等）を自動検出し、`git worktree add` の DWIM 機能を利用してローカル追跡ブランチを自動作成するよう改善
- `remoteBranchExists()` 関数を `git.ts` に新規追加
- `validateBranchForWorktree()` にリモートブランチのフォールバック判定を追加

## Background

従来、`vibe start feature/hoge` は常にローカルブランチの有無のみを確認しており、リモートにのみ存在するブランチ（例: 他のメンバーが作成した PR ブランチ）に対して worktree を作成しようとすると、`git worktree add -b` による新規作成が試みられ、同名のリモートブランチが存在するためエラーとなっていた。

## Changes

| File | Change |
|---|---|
| `packages/core/src/utils/git.ts` | `remoteBranchExists()` 関数を追加 |
| `packages/core/src/services/worktree/validator.ts` | ローカルにブランチがない場合にリモート (`origin`) も確認するフォールバックを追加 |
| `packages/core/src/commands/start.test.ts` | テストモックの `show-ref` をローカル/リモート区別対応に修正、リモートブランチ DWIM テストを追加 |

## Test plan

- [x] 既存テスト全 409 件が合格することを確認
- [x] リモートにのみブランチが存在する場合に `-b` フラグなしの DWIM 形式で worktree が作成されるテストを追加・合格
- [x] 実際のリポジトリでリモートにのみ存在するブランチに対して `vibe start` を実行し動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)