### PR TITLE
feat: add versioned Homebrew formula for beta releases

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -233,8 +233,34 @@ jobs:
             exit 1
           fi
 
+          # Generate versioned formula (e.g., vibe@2.0.0-beta.1.rb)
+          # Compute Homebrew class_s-compatible class name via Ruby
+          CLASSNAME=$(ruby -e "
+            v = '${VERSION}'.capitalize
+            v = v.gsub(/[-_.\s]([a-zA-Z0-9])/) { Regexp.last_match(1).upcase }
+            puts v
+          ")
+
+          VERSIONED_FORMULA="vibe@${VERSION}.rb"
+
+          cp "vibe-source/Formula/vibe-versioned.rb" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/CLASSNAME_PLACEHOLDER/$CLASSNAME/g" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/SHA256_DARWIN_ARM64/${{ steps.sha256.outputs.darwin_arm64 }}/g" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/SHA256_DARWIN_X64/${{ steps.sha256.outputs.darwin_x64 }}/g" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/SHA256_LINUX_ARM64/${{ steps.sha256.outputs.linux_arm64 }}/g" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/SHA256_LINUX_X64/${{ steps.sha256.outputs.linux_x64 }}/g" "Formula/${VERSIONED_FORMULA}"
+
+          # Verify all placeholders were replaced
+          if grep -q "PLACEHOLDER" "Formula/${VERSIONED_FORMULA}"; then
+            echo "Error: Placeholders not replaced in versioned formula"
+            grep "PLACEHOLDER" "Formula/${VERSIONED_FORMULA}"
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/vibe-beta.rb
+          git add "Formula/${VERSIONED_FORMULA}"
           git commit -m "Update vibe-beta to $VERSION"
           git push --quiet https://x-access-token:${GH_TOKEN}@github.com/kexi/homebrew-tap.git HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,11 +232,15 @@ jobs:
           git add "Formula/${FORMULA_TEMPLATE}"
 
           # Generate versioned formula for stable releases only
-          # Pre-release versions (e.g., 2.0.0-beta.1) are not compatible with
-          # Homebrew's @version naming convention (class_s expects digits after @)
+          # Beta versions are handled by beta-release.yml
           IS_PRERELEASE="${{ github.event.release.prerelease }}"
           if [ "$IS_PRERELEASE" != "true" ]; then
-            CLASSNAME=$(echo "$VERSION" | tr -d '.')
+            # Compute Homebrew class_s-compatible class name via Ruby
+            CLASSNAME=$(ruby -e "
+              v = '${VERSION}'.capitalize
+              v = v.gsub(/[-_.\s]([a-zA-Z0-9])/) { Regexp.last_match(1).upcase }
+              puts v
+            ")
             VERSIONED_FORMULA="vibe@${VERSION}.rb"
 
             cp "../vibe-source/Formula/vibe-versioned.rb" "Formula/${VERSIONED_FORMULA}"


### PR DESCRIPTION
## Summary

- Add versioned formula generation (`vibe@{VERSION}.rb`) to `beta-release.yml`, enabling `brew install kexi/tap/vibe@2.0.0-beta.1`
- Unify class name computation in `release.yml` to use Ruby's `class_s`-compatible logic instead of `tr -d '.'`
- Update comments to reflect that beta versions are now handled by `beta-release.yml`

## Details

PR #373 implemented versioned formulae for stable releases only, excluding beta due to concerns about Homebrew's `class_s` compatibility. Investigation confirmed that `class_s("vibe@2.0.0-beta.1")` produces `VibeAT200Beta1` — a valid Ruby class name.

The Ruby one-liner mirrors Homebrew's `class_s` logic:
```ruby
v = version.capitalize
v = v.gsub(/[-_.\s]([a-zA-Z0-9])/) { Regexp.last_match(1).upcase }
```

Results:
- `2.0.0-beta.1` → `200Beta1` ✅
- `1.1.0` → `110` ✅

### User-facing install commands

```bash
# Latest stable
brew install kexi/tap/vibe

# Specific stable version
brew install kexi/tap/vibe@1.1.0

# Latest beta
brew install kexi/tap/vibe-beta

# Specific beta version (NEW!)
brew install kexi/tap/vibe@2.0.0-beta.1
```

## Test plan

- [x] `pnpm run check:all` passes
- [ ] Verify Ruby one-liner produces correct class names for both stable and beta versions
- [ ] Verify generated formula has no remaining `PLACEHOLDER` values after substitution
- [ ] Confirm `brew install kexi/tap/vibe@{beta-version}` works after next beta release

🤖 Generated with [Claude Code](https://claude.com/claude-code)