### PR TITLE
fix: correct vibe-versioned.rb template path in beta workflow

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -243,7 +243,7 @@ jobs:
 
           VERSIONED_FORMULA="vibe@${VERSION}.rb"
 
-          cp "vibe-source/Formula/vibe-versioned.rb" "Formula/${VERSIONED_FORMULA}"
+          cp "../vibe-source/Formula/vibe-versioned.rb" "Formula/${VERSIONED_FORMULA}"
           sed -i "s/CLASSNAME_PLACEHOLDER/$CLASSNAME/g" "Formula/${VERSIONED_FORMULA}"
           sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" "Formula/${VERSIONED_FORMULA}"
           sed -i "s/SHA256_DARWIN_ARM64/${{ steps.sha256.outputs.darwin_arm64 }}/g" "Formula/${VERSIONED_FORMULA}"


### PR DESCRIPTION
## Summary

- Fix `cp` path for `vibe-versioned.rb` template in `beta-release.yml` — the command runs after `cd homebrew-tap`, so needs `../` prefix to reach the `vibe-source` checkout directory

## Context

CI run [#22956952218](https://github.com/kexi/vibe/actions/runs/22956952218) failed with:
```
cp: cannot stat 'vibe-source/Formula/vibe-versioned.rb': No such file or directory
```

## Test plan

- [x] `pnpm run check:all` passes
- [ ] Next beta release CI succeeds (versioned formula generated correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)