### PR TITLE
chore: add GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Run `vibe start feature-branch`
+        2. ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened. Include error messages if any.
+    validations:
+      required: true
+
+  - type: textarea
+    id: version
+    attributes:
+      label: "Output of `vibe --version`"
+      description: "Run `vibe --version` and paste the full output."
+      placeholder: |
+        vibe 1.1.0+c5965c8
+        Platform: darwin-arm64 (bun-darwin-arm64)
+        Distribution: binary
+        Built: 2026-03-08T07:46:07.424Z (github-actions)
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, logs, or screenshots.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve? What's the motivation?
+      placeholder: "I'm always frustrated when ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or examples.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+  Thanks for submitting a PR! Please read the guidelines:
+
+  - PR title format: `<type>: <description>`
+    Types: feat, fix, docs, refactor, test, chore
+  - Target branch: `develop` (never push directly to main)
+  - Run `pnpm run check:all` before submitting
+-->
+
+## Summary
+
+<!--
+  Describe what you changed and why.
+  Link related issues if any (e.g., "Related to #123").
+-->
+
+## Test Plan
+
+<!--
+  How did you verify your changes work correctly?
+  Examples:
+  - Added unit tests in `packages/core/src/...`
+  - Ran `pnpm run test` and all tests pass
+  - Manually tested with `vibe start <branch>`
+-->
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] `pnpm run check:all` passes
+- [ ] Docs updated (if needed)
+
+Fixes #


### PR DESCRIPTION
## Summary

Add standardized GitHub templates to streamline contributions:
- **PR template** (`PULL_REQUEST_TEMPLATE.md`): summary, test plan, and checklist sections
- **Bug report** (`ISSUE_TEMPLATE/bug_report.yml`): YAML form with `vibe --version` output field
- **Feature request** (`ISSUE_TEMPLATE/feature_request.yml`): YAML form with problem/solution structure
- **Config** (`ISSUE_TEMPLATE/config.yml`): allows blank issues

## Test Plan

- Verified YAML syntax is valid
- Templates will appear on GitHub PR/issue creation screens

## Checklist

- [x] `pnpm run check:all` passes
- [x] Docs updated (if needed)

Fixes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)