### PR TITLE
chore: reorganize CLAUDE.md and .claude/rules/ for long-session persistence

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,17 @@
+# Git Workflow Rules
+
+## Branch Strategy
+
+- `main`: Release versions only
+- `develop`: Main development branch
+- Topic branches should be created from `develop`
+- **IMPORTANT**: Never push directly to `main` or `develop` branches
+- PRs must always target the `develop` branch
+
+## PR/Commit Guidelines
+
+- **IMPORTANT**: Before creating a PR, always run `pnpm run check:all` and ensure all checks pass
+- **Title format**: `<type>: <description>`
+  - Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+- Write in English
+- Follow GNU Coding Standards

--- a/.claude/rules/markdown.md
+++ b/.claude/rules/markdown.md
@@ -1,5 +1,9 @@
 # Markdown File Synchronization Rules
 
+## Glob Pattern
+
+`**/*.md`
+
 ## Naming Convention
 
 - `*.md` - English version (default)

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,14 @@
+# Security Rules
+
+## Glob Pattern
+
+`packages/core/src/**/*.ts`
+
+## Guidelines
+
+- SHA-256 based configuration trust mechanism
+- Use Node.js `spawn` (avoid shell string execution)
+- Path validation with `validatePath()`
+- Shell output escaping with `escapeShellPath()` for all `cd` output
+- ESLint security plugin (`eslint-plugin-security`) and custom `vibe-security` rules for static analysis
+- See [docs/SECURITY_CHECKLIST.md](docs/SECURITY_CHECKLIST.md) for the full 13-category CLI security checklist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,28 +49,3 @@ packages/core/src/
 ├── types/      # TypeScript type definitions
 └── errors/     # Error handling
 ```
-
-## Branch Strategy
-
-- `main`: Release versions only
-- `develop`: Main development branch
-- Topic branches should be created from `develop`
-- **IMPORTANT**: Never push directly to `main` or `develop` branches
-- PRs must always target the `develop` branch
-
-## PR/Commit Guidelines
-
-- **IMPORTANT**: Before creating a PR, always run `pnpm run check:all` and ensure all checks pass
-- **Title format**: `<type>: <description>`
-  - Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
-- Write in English
-- Follow GNU Coding Standards
-
-## Security
-
-- SHA-256 based configuration trust mechanism
-- Use Node.js `spawn` (avoid shell string execution)
-- Path validation with `validatePath()`
-- Shell output escaping with `escapeShellPath()` for all `cd` output
-- ESLint security plugin (`eslint-plugin-security`) and custom `vibe-security` rules for static analysis
-- See [docs/SECURITY_CHECKLIST.md](docs/SECURITY_CHECKLIST.md) for the full 13-category CLI security checklist


### PR DESCRIPTION
## Summary
- Move Branch Strategy, PR/Commit Guidelines, and Security sections from `CLAUDE.md` to `.claude/rules/` so they persist as system prompts throughout long sessions
- Create `git-workflow.md` (always loaded) and `security.md` (loaded only when editing `packages/core/src/**/*.ts`)
- Add glob pattern `**/*.md` to `markdown.md` for conditional loading instead of always-on

## Context
Based on [Zenn article best practices](https://zenn.dev/cureapp/articles/65c9a99d22ce2b): CLAUDE.md is injected as a user message and loses influence in longer sessions, while `.claude/rules/` stays in the system prompt.

## Test plan
- [x] `pnpm run check:all` passes
- [ ] Verify rules load correctly in new Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)