### PR TITLE
chore: add YAML frontmatter globs to .claude/rules files

### DIFF
--- a/.claude/rules/ci-cd-workflows.md
+++ b/.claude/rules/ci-cd-workflows.md
@@ -1,8 +1,8 @@
+---
+globs: "**/.github/workflows/*.yml"
+---
+
 # CI/CD Workflow Rules
-
-## Glob Pattern
-
-`**/.github/workflows/*.yml`
 
 ## Tool Setup Requirements
 

--- a/.claude/rules/docs-i18n.md
+++ b/.claude/rules/docs-i18n.md
@@ -1,8 +1,8 @@
+---
+globs: "packages/docs/src/content/docs/**/*.mdx"
+---
+
 # Documentation i18n Synchronization Rules
-
-## Glob Pattern
-
-`packages/docs/src/content/docs/**/*.mdx`
 
 ## Directory Structure
 

--- a/.claude/rules/markdown.md
+++ b/.claude/rules/markdown.md
@@ -1,8 +1,8 @@
+---
+globs: "**/*.md"
+---
+
 # Markdown File Synchronization Rules
-
-## Glob Pattern
-
-`**/*.md`
 
 ## Naming Convention
 

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,8 +1,8 @@
+---
+globs: "packages/core/src/**/*.ts"
+---
+
 # Security Rules
-
-## Glob Pattern
-
-`packages/core/src/**/*.ts`
 
 ## Guidelines
 


### PR DESCRIPTION
## Summary

- `.claude/rules/` の4ファイルで `## Glob Pattern` Markdownセクションを正しいYAMLフロントマター (`globs` フィールド) に置換
- 対象: `ci-cd-workflows.md`, `markdown.md`, `docs-i18n.md`, `security.md`
- これによりClaude Codeがファイルパターンに基づくルールフィルタリングを正しく適用できるようになる

## Test plan

- [x] `pnpm run check:all` 全チェック通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)