### PR TITLE
fix: place --force flag before worktree path in removeWorktree

### DIFF
--- a/packages/core/src/services/worktree/operations.ts
+++ b/packages/core/src/services/worktree/operations.ts
@@ -66,10 +66,11 @@ export async function removeWorktree(
 ): Promise<void> {
   const { worktreePath, force = false } = options;
 
-  const args = ["worktree", "remove", worktreePath];
+  const args = ["worktree", "remove"];
   if (force) {
     args.push("--force");
   }
+  args.push(worktreePath);
 
   await runGitCommand(args, ctx);
 }


### PR DESCRIPTION
## Summary

`removeWorktree()` in `operations.ts` appended `--force` after the worktree path, producing `git worktree remove <path> --force` instead of the canonical `git worktree remove --force <path>`. This could fail with strict git argument parsing.

Aligns the argument ordering with the correct implementation already used in `clean.ts`.

**Affected call sites:**
- `start.ts:344` — Overwrite existing worktree
- `start.ts:662` — Branch conflict force remove

## Test Plan

- `pnpm run check:all` passes (all 409 tests pass)
- Verified that `clean.ts` (including Claude Code hooks path) already uses the correct ordering and is unaffected

## Checklist

- [ ] Tests added/updated
- [x] `pnpm run check:all` passes
- [ ] Docs updated (if needed)