### PR TITLE
fix: close trust system bypass via repo spoofing and migration fallback

### DIFF
--- a/packages/core/src/commands/verify.ts
+++ b/packages/core/src/commands/verify.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { getRepoInfoFromPath, getRepoRoot } from "../utils/git.ts";
 import { calculateFileHash } from "../utils/hash.ts";
 import { loadUserSettings } from "../utils/trust.ts";
+import { isRepoIdMatch } from "../utils/settings.ts";
 import { type AppContext, getGlobalContext } from "../context/index.ts";
 import { errorLog, log, type OutputOptions, successLog, warnLog } from "../utils/output.ts";
 
@@ -80,15 +81,7 @@ async function displayFileStatus(
   log(`Relative Path: ${repoInfo.relativePath}`, outputOpts);
 
   // Find entry in allow list using repository-based matching
-  const entry = settings.permissions.allow.find((item) => {
-    return (
-      item.relativePath === repoInfo.relativePath &&
-      ((item.repoId.remoteUrl &&
-        repoInfo.remoteUrl &&
-        item.repoId.remoteUrl === repoInfo.remoteUrl) ||
-        (item.repoId.repoRoot && repoInfo.repoRoot && item.repoId.repoRoot === repoInfo.repoRoot))
-    );
-  });
+  const entry = settings.permissions.allow.find((item) => isRepoIdMatch(item, repoInfo));
 
   if (!entry) {
     warnLog("Status: ⚠️  NOT TRUSTED");

--- a/packages/core/src/utils/git.test.ts
+++ b/packages/core/src/utils/git.test.ts
@@ -233,6 +233,18 @@ describe("normalizeRemoteUrl", () => {
     const result = normalizeRemoteUrl("git@gitlab.com:group/subgroup/repo.git");
     expect(result).toBe("gitlab.com/group/subgroup/repo");
   });
+
+  it("URL with @ in path does not strip path", () => {
+    // Regression: ^[^@]+@ used to greedily strip across /, normalizing
+    // https://attacker.com/legit@github.com/x/y to github.com/x/y.
+    const result = normalizeRemoteUrl("https://attacker.com/legit@github.com/user/repo.git");
+    expect(result).toBe("attacker.com/legit@github.com/user/repo");
+  });
+
+  it("URL with both credentials and @ in path", () => {
+    const result = normalizeRemoteUrl("https://user:pass@host.com/foo@bar/baz.git");
+    expect(result).toBe("host.com/foo@bar/baz");
+  });
 });
 
 describe("detectBrokenWorktreeLink", () => {

--- a/packages/core/src/utils/git.ts
+++ b/packages/core/src/utils/git.ts
@@ -248,8 +248,8 @@ export function normalizeRemoteUrl(url: string): string {
   // Remove protocol (https://, http://, ssh://)
   normalized = normalized.replace(/^[a-z]+:\/\//, "");
 
-  // Remove credentials if present (user:pass@host)
-  normalized = normalized.replace(/^[^@]+@/, "");
+  // Remove credentials if present (user:pass@host); avoid stripping across `/`
+  normalized = normalized.replace(/^[^@/]+@/, "");
 
   return normalized;
 }

--- a/packages/core/src/utils/settings.test.ts
+++ b/packages/core/src/utils/settings.test.ts
@@ -1,16 +1,17 @@
-import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   _internal,
   addTrustedPath,
+  isRepoIdMatch,
   isTrusted,
   loadUserSettings,
   removeTrustedPath,
   saveUserSettings,
 } from "./settings.ts";
-import { getRepoInfoFromPath } from "./git.ts";
+import { getRepoInfoFromPath, type RepoInfo } from "./git.ts";
 import { setupRealTestContext } from "../context/testing.ts";
 
 // Initialize test context with real Deno runtime for filesystem tests
@@ -26,13 +27,7 @@ async function findEntryByPath(
   const repoInfo = await getRepoInfoFromPath(filePath);
   if (!repoInfo) return undefined;
 
-  return settings.permissions.allow.find((e) => {
-    return (
-      e.relativePath === repoInfo.relativePath &&
-      ((e.repoId.remoteUrl && repoInfo.remoteUrl && e.repoId.remoteUrl === repoInfo.remoteUrl) ||
-        (e.repoId.repoRoot && repoInfo.repoRoot && e.repoId.repoRoot === repoInfo.repoRoot))
-    );
-  });
+  return settings.permissions.allow.find((e) => isRepoIdMatch(e, repoInfo));
 }
 
 describe("loadUserSettings", () => {
@@ -515,6 +510,314 @@ describe("getSettingsSchemaUrl", () => {
       const versionPart = versionMatch[1];
       const hasNoBuildMetadata = !versionPart.includes("+");
       expect(hasNoBuildMetadata).toBe(true);
+    }
+  });
+});
+
+describe("isRepoIdMatch", () => {
+  const baseRepoInfo: RepoInfo = {
+    remoteUrl: "github.com/example/repo",
+    repoRoot: "/path/to/repo",
+    relativePath: ".vibe.toml",
+  };
+
+  it("returns true when repoRoot and remoteUrl both match", () => {
+    const entry = {
+      repoId: { remoteUrl: "github.com/example/repo", repoRoot: "/path/to/repo" },
+      relativePath: ".vibe.toml",
+    };
+    expect(isRepoIdMatch(entry, baseRepoInfo)).toBe(true);
+  });
+
+  it("returns false when repoRoot mismatches (spoof regression)", () => {
+    // Even with same remoteUrl, a different repoRoot must not match.
+    // This is the #418 spoofing regression test.
+    const entry = {
+      repoId: { remoteUrl: "github.com/example/repo", repoRoot: "/different/path" },
+      relativePath: ".vibe.toml",
+    };
+    expect(isRepoIdMatch(entry, baseRepoInfo)).toBe(false);
+  });
+
+  it("returns false when remoteUrl mismatches", () => {
+    const entry = {
+      repoId: { remoteUrl: "github.com/attacker/repo", repoRoot: "/path/to/repo" },
+      relativePath: ".vibe.toml",
+    };
+    expect(isRepoIdMatch(entry, baseRepoInfo)).toBe(false);
+  });
+
+  it("returns true when both remoteUrl undefined and repoRoot matches (local-only)", () => {
+    const localRepoInfo: RepoInfo = {
+      repoRoot: "/path/to/repo",
+      relativePath: ".vibe.toml",
+    };
+    const entry = {
+      repoId: { repoRoot: "/path/to/repo" },
+      relativePath: ".vibe.toml",
+    };
+    expect(isRepoIdMatch(entry, localRepoInfo)).toBe(true);
+  });
+
+  it("returns false when stored remoteUrl defined but current undefined (downgrade)", () => {
+    const localRepoInfo: RepoInfo = {
+      repoRoot: "/path/to/repo",
+      relativePath: ".vibe.toml",
+    };
+    const entry = {
+      repoId: { remoteUrl: "github.com/example/repo", repoRoot: "/path/to/repo" },
+      relativePath: ".vibe.toml",
+    };
+    expect(isRepoIdMatch(entry, localRepoInfo)).toBe(false);
+  });
+
+  it("returns false when stored remoteUrl undefined but current defined (identity change)", () => {
+    const entry = {
+      repoId: { repoRoot: "/path/to/repo" },
+      relativePath: ".vibe.toml",
+    };
+    expect(isRepoIdMatch(entry, baseRepoInfo)).toBe(false);
+  });
+
+  it("returns false when relativePath mismatches", () => {
+    const entry = {
+      repoId: { remoteUrl: "github.com/example/repo", repoRoot: "/path/to/repo" },
+      relativePath: ".vibe.local.toml",
+    };
+    expect(isRepoIdMatch(entry, baseRepoInfo)).toBe(false);
+  });
+
+  it("returns false when stored entry missing repoRoot (defensive fail-closed)", () => {
+    const entry = {
+      repoId: { remoteUrl: "github.com/example/repo" },
+      relativePath: ".vibe.toml",
+    };
+    expect(isRepoIdMatch(entry, baseRepoInfo)).toBe(false);
+  });
+});
+
+describe("Migration security regressions (#418)", () => {
+  it("v1→v2 fallback for non-existent path produces empty hashes without skipHashCheck", async () => {
+    const v1Data = {
+      version: 1,
+      permissions: {
+        allow: ["/non/existent/path/that/does/not/exist.toml"],
+        deny: [],
+      },
+    };
+
+    const migrated = (await _internal.migrateSettings(v1Data)) as Awaited<
+      ReturnType<typeof loadUserSettings>
+    >;
+
+    expect(migrated.permissions.allow.length).toBe(1);
+    const entry = migrated.permissions.allow[0];
+    expect(entry.hashes).toEqual([]);
+    expect(entry.skipHashCheck).toBeUndefined();
+  });
+
+  it("v2→v3 success branch drops skipHashCheck:true carryover", async () => {
+    // Build a v2 entry with skipHashCheck: true. Path must be inside an actual
+    // git repo so the migration can resolve repoInfo (success branch).
+    const tempFile = join(process.cwd(), `.test-migration-v2-skip-${Date.now()}.tmp`);
+    await writeFile(tempFile, "test content");
+    try {
+      const v2Data = {
+        version: 2,
+        skipHashCheck: false,
+        permissions: {
+          allow: [{ path: tempFile, hashes: ["abc123"], skipHashCheck: true }],
+          deny: [],
+        },
+      };
+
+      const migrated = (await _internal.migrateSettings(v2Data)) as Awaited<
+        ReturnType<typeof loadUserSettings>
+      >;
+
+      expect(migrated.permissions.allow.length).toBe(1);
+      const entry = migrated.permissions.allow[0];
+      // The skipHashCheck: true carryover must NOT survive into v3.
+      expect(entry.skipHashCheck).toBeUndefined();
+      // hashes are preserved on the success path
+      expect(entry.hashes).toEqual(["abc123"]);
+    } finally {
+      await rm(tempFile).catch(() => {});
+    }
+  });
+
+  it("v2→v3 'no repoInfo' branch drops skipHashCheck:true carryover", async () => {
+    // Path under a non-git temp directory triggers the else branch
+    // (getRepoInfoFromPath returns null). The catch branch is unreachable in
+    // practice because getRepoInfoFromPath swallows errors. Both branches
+    // produce the same shape after the fix; this test exercises the
+    // reachable one.
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-test-migration-"));
+    const tempFile = join(tempDir, "config.toml");
+    await writeFile(tempFile, "test");
+    try {
+      const v2Data = {
+        version: 2,
+        skipHashCheck: false,
+        permissions: {
+          allow: [{ path: tempFile, hashes: ["abc123"], skipHashCheck: true }],
+          deny: [],
+        },
+      };
+
+      const migrated = (await _internal.migrateSettings(v2Data)) as Awaited<
+        ReturnType<typeof loadUserSettings>
+      >;
+
+      expect(migrated.permissions.allow.length).toBe(1);
+      const entry = migrated.permissions.allow[0];
+      expect(entry.skipHashCheck).toBeUndefined();
+    } finally {
+      await rm(tempDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("v1→v3 end-to-end with non-existent path: empty hashes, no skipHashCheck", async () => {
+    const v1Data = {
+      version: 1,
+      permissions: {
+        allow: ["/non/existent/path/that/does/not/exist.toml"],
+        deny: [],
+      },
+    };
+
+    const migrated = (await _internal.migrateSettings(v1Data)) as Awaited<
+      ReturnType<typeof loadUserSettings>
+    >;
+
+    expect(migrated.version).toBe(_internal.CURRENT_SCHEMA_VERSION);
+    expect(migrated.permissions.allow.length).toBe(1);
+    const entry = migrated.permissions.allow[0];
+    expect(entry.hashes).toEqual([]);
+    expect(entry.skipHashCheck).toBeUndefined();
+  });
+});
+
+describe("removeTrustedPath spoof prevention (#418)", () => {
+  let tempFile: string;
+
+  afterEach(async () => {
+    if (tempFile) {
+      try {
+        await rm(tempFile);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it("removing one entry leaves another with same relativePath but different repoRoot", async () => {
+    tempFile = join(process.cwd(), `.test-remove-spoof-${Date.now()}.tmp`);
+    await writeFile(tempFile, "content");
+
+    const repoInfo = await getRepoInfoFromPath(tempFile);
+    expect(repoInfo).not.toBeNull();
+    if (!repoInfo) return;
+
+    const FAKE_REPO_ROOT = "/some/other/repo/root/that/does/not/exist";
+
+    // Inject two entries that share relativePath but live in different repos.
+    const settings = await loadUserSettings();
+    const fakeOtherRepo = {
+      repoId: { remoteUrl: repoInfo.remoteUrl, repoRoot: FAKE_REPO_ROOT },
+      relativePath: repoInfo.relativePath,
+      hashes: ["fake-hash-other-repo"],
+    };
+    settings.permissions.allow.push(fakeOtherRepo);
+    await saveUserSettings(settings);
+
+    try {
+      // Trust the real entry too.
+      await addTrustedPath(tempFile);
+
+      // Remove via the real path.
+      await removeTrustedPath(tempFile);
+
+      // The real entry should be gone, the spoof-targeted entry must survive.
+      const after = await loadUserSettings();
+      const realEntry = after.permissions.allow.find(
+        (e) => e.repoId.repoRoot === repoInfo.repoRoot && e.relativePath === repoInfo.relativePath,
+      );
+      const otherEntry = after.permissions.allow.find(
+        (e) => e.repoId.repoRoot === FAKE_REPO_ROOT && e.relativePath === repoInfo.relativePath,
+      );
+      expect(realEntry).toBeUndefined();
+      expect(otherEntry).toBeDefined();
+    } finally {
+      // Cleanup runs even if assertions above fail, so the user's real
+      // settings.json is never left polluted.
+      const finalSettings = await loadUserSettings();
+      finalSettings.permissions.allow = finalSettings.permissions.allow.filter(
+        (e) => e.repoId.repoRoot !== FAKE_REPO_ROOT,
+      );
+      await saveUserSettings(finalSettings);
+    }
+  });
+
+  it("loadUserSettings strips skipHashCheck:true from migration-fallback artifacts only", async () => {
+    // Two legacy v3 entries from before #418:
+    //   - fallback artifact: hashes:[] + skipHashCheck:true (must be cleaned)
+    //   - manual opt-in: non-empty hashes + skipHashCheck:true (must be preserved)
+    const settings = await loadUserSettings();
+    const FAKE_REPO_ROOT_FALLBACK = "/some/legacy/fallback/repo/root";
+    const fallbackArtifact = {
+      repoId: { repoRoot: FAKE_REPO_ROOT_FALLBACK },
+      relativePath: ".vibe.toml",
+      hashes: [],
+      skipHashCheck: true as const,
+    };
+    const FAKE_REPO_ROOT_MANUAL = "/some/legacy/manual/repo/root";
+    const manualOptIn = {
+      repoId: { repoRoot: FAKE_REPO_ROOT_MANUAL },
+      relativePath: ".vibe.toml",
+      hashes: ["abcdef" + "0".repeat(58)],
+      skipHashCheck: true as const,
+    };
+    settings.permissions.allow.push(fallbackArtifact, manualOptIn);
+    await saveUserSettings(settings);
+
+    try {
+      const reloaded = await loadUserSettings();
+      const cleanedFallback = reloaded.permissions.allow.find(
+        (e) => e.repoId.repoRoot === FAKE_REPO_ROOT_FALLBACK,
+      );
+      const preservedManual = reloaded.permissions.allow.find(
+        (e) => e.repoId.repoRoot === FAKE_REPO_ROOT_MANUAL,
+      );
+      expect(cleanedFallback).toBeDefined();
+      expect(cleanedFallback!.skipHashCheck).toBeUndefined();
+      expect(preservedManual).toBeDefined();
+      expect(preservedManual!.skipHashCheck).toBe(true);
+    } finally {
+      const finalSettings = await loadUserSettings();
+      finalSettings.permissions.allow = finalSettings.permissions.allow.filter(
+        (e) =>
+          e.repoId.repoRoot !== FAKE_REPO_ROOT_FALLBACK &&
+          e.repoId.repoRoot !== FAKE_REPO_ROOT_MANUAL,
+      );
+      await saveUserSettings(finalSettings);
+    }
+  });
+
+  it("removeTrustedPath warns when no matching entry exists", async () => {
+    tempFile = join(process.cwd(), `.test-remove-warn-${Date.now()}.tmp`);
+    await writeFile(tempFile, "content");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      // Path is in repo but not trusted, so no matching entry.
+      await removeTrustedPath(tempFile);
+      const wasCalled = warnSpy.mock.calls.some((call) =>
+        String(call[0]).includes("No matching trust entry"),
+      );
+      expect(wasCalled).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
     }
   });
 });

--- a/packages/core/src/utils/settings.ts
+++ b/packages/core/src/utils/settings.ts
@@ -5,6 +5,7 @@ import { getRepoInfoFromPath, type RepoInfo } from "./git.ts";
 import { VERSION } from "../version.ts";
 import { type AppContext, getGlobalContext } from "../context/index.ts";
 import { getConfigDir, ensureConfigDir } from "./config-path.ts";
+import { warnLog } from "./output.ts";
 
 function getUserSettingsFile(ctx: AppContext = getGlobalContext()): string {
   return join(getConfigDir(ctx), "settings.json");
@@ -130,10 +131,10 @@ const migrations: Record<number, MigrationFn> = {
           const errorMessage = error instanceof Error ? error.message : String(error);
           console.warn(
             `Warning: Cannot calculate hash for ${path}: ${errorMessage}\n` +
-              `The path will be kept with hash checking disabled (skipHashCheck: true)`,
+              `The path will be kept with an empty hash list. ` +
+              `Run 'vibe trust' to re-trust this file.`,
           );
-          // Keep the path but disable hash checking instead of removing it
-          return { path, hashes: [], skipHashCheck: true };
+          return { path, hashes: [] };
         }
       }),
     );
@@ -163,7 +164,8 @@ const migrations: Record<number, MigrationFn> = {
           const repoInfo = await getRepoInfoFromPath(entry.path, ctx);
 
           if (repoInfo) {
-            // Successfully converted to repository-based entry
+            // Drop skipHashCheck:true carryover from v2 (could originate in
+            // the v1→v2 fallback) to prevent silent trust-bypass (security: #418).
             return {
               repoId: {
                 remoteUrl: repoInfo.remoteUrl,
@@ -171,12 +173,13 @@ const migrations: Record<number, MigrationFn> = {
               },
               relativePath: repoInfo.relativePath,
               hashes: entry.hashes,
-              skipHashCheck: entry.skipHashCheck,
+              ...(entry.skipHashCheck === false ? { skipHashCheck: false as const } : {}),
             };
           } else {
             // Not in a git repository - use fallback
             migrationWarnings.push(
-              `Cannot determine repository for ${entry.path}. ` + `Using directory as fallback.`,
+              `Cannot determine repository for ${entry.path}. ` +
+                `Using directory as fallback. Run 'vibe trust' to re-trust this file.`,
             );
             return {
               repoId: {
@@ -184,23 +187,21 @@ const migrations: Record<number, MigrationFn> = {
               },
               relativePath: basename(entry.path),
               hashes: entry.hashes,
-              skipHashCheck: entry.skipHashCheck,
+              ...(entry.skipHashCheck === false ? { skipHashCheck: false as const } : {}),
             };
           }
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           migrationWarnings.push(
             `Migration failed for ${entry.path}: ${errorMessage}. ` +
-              `Entry will be preserved with hash checking disabled.`,
+              `Entry preserved with empty hash list; run 'vibe trust' to re-trust.`,
           );
-          // Preserve entry with safe fallback
           return {
             repoId: {
               repoRoot: dirname(entry.path),
             },
             relativePath: basename(entry.path),
-            hashes: entry.hashes || [],
-            skipHashCheck: true,
+            hashes: [],
           };
         }
       }),
@@ -286,9 +287,23 @@ export async function loadUserSettings(
     // Schema validation
     const result = CurrentSettingsSchema.safeParse(migratedData);
     if (result.success) {
-      // Update file if migration was performed
+      // Strip skipHashCheck:true from migration-fallback artifacts written by
+      // older builds (#418). The marker is `hashes:[] && skipHashCheck:true`,
+      // which uniquely identifies entries created by the v1→v2 fallback that
+      // rode through into v3 with hash checking silently disabled. Manual
+      // configurations (non-empty hashes + skipHashCheck:true) are preserved.
+      let didCleanup = false;
+      for (const entry of result.data.permissions.allow) {
+        const isMigrationArtifact = entry.skipHashCheck === true && entry.hashes.length === 0;
+        if (isMigrationArtifact) {
+          delete entry.skipHashCheck;
+          didCleanup = true;
+        }
+      }
+
       const needsMigration = getSchemaVersion(rawData) !== CURRENT_SCHEMA_VERSION;
-      if (needsMigration) {
+      const needsWriteback = needsMigration || didCleanup;
+      if (needsWriteback) {
         await saveUserSettings(result.data, ctx);
       }
       return result.data;
@@ -347,6 +362,38 @@ export async function saveUserSettings(
 // ===== Helper Functions =====
 
 /**
+ * Strict identity match between a stored allow-list entry and current repo info.
+ * Returns true iff:
+ *   - relativePath matches
+ *   - repoRoot is defined on the entry AND equals repoInfo.repoRoot
+ *   - remoteUrl slot matches: both undefined, or both defined and equal
+ *
+ * The slot-equal remoteUrl check prevents spoofing attacks where an attacker
+ * configures a different local repo with the same git remote URL (security: #418).
+ */
+export function isRepoIdMatch(
+  entry: {
+    repoId: { remoteUrl?: string; repoRoot?: string };
+    relativePath: string;
+  },
+  repoInfo: RepoInfo,
+): boolean {
+  const isRelativePathMatch = entry.relativePath === repoInfo.relativePath;
+  if (!isRelativePathMatch) return false;
+
+  const hasStoredRepoRoot = entry.repoId.repoRoot !== undefined;
+  if (!hasStoredRepoRoot) return false;
+
+  const isRepoRootMatch = entry.repoId.repoRoot === repoInfo.repoRoot;
+  if (!isRepoRootMatch) return false;
+
+  const storedRemoteUrl = entry.repoId.remoteUrl ?? null;
+  const currentRemoteUrl = repoInfo.remoteUrl ?? null;
+  const isRemoteUrlSlotMatch = storedRemoteUrl === currentRemoteUrl;
+  return isRemoteUrlSlotMatch;
+}
+
+/**
  * Find a matching entry in the allow list based on repository information
  * @param allowList List of allowed entries
  * @param repoInfo Repository information to match
@@ -356,24 +403,7 @@ function findMatchingEntry(
   allowList: VibeSettings["permissions"]["allow"],
   repoInfo: RepoInfo,
 ): VibeSettings["permissions"]["allow"][number] | undefined {
-  return allowList.find((entry) => {
-    // Check relative path match
-    if (entry.relativePath !== repoInfo.relativePath) {
-      return false;
-    }
-
-    // Priority 1: Match by remote URL (if both have it)
-    if (entry.repoId.remoteUrl && repoInfo.remoteUrl) {
-      return entry.repoId.remoteUrl === repoInfo.remoteUrl;
-    }
-
-    // Priority 2: Match by repo root
-    if (entry.repoId.repoRoot && repoInfo.repoRoot) {
-      return entry.repoId.repoRoot === repoInfo.repoRoot;
-    }
-
-    return false;
-  });
+  return allowList.find((entry) => isRepoIdMatch(entry, repoInfo));
 }
 
 // ===== Public API =====
@@ -448,22 +478,22 @@ export async function removeTrustedPath(
   }
 
   // Find and remove matching entry
-  const allowIndex = settings.permissions.allow.findIndex((entry) => {
-    return (
-      entry.relativePath === repoInfo.relativePath &&
-      ((entry.repoId.remoteUrl &&
-        repoInfo.remoteUrl &&
-        entry.repoId.remoteUrl === repoInfo.remoteUrl) ||
-        (entry.repoId.repoRoot && repoInfo.repoRoot && entry.repoId.repoRoot === repoInfo.repoRoot))
-    );
-  });
+  const allowIndex = settings.permissions.allow.findIndex((entry) =>
+    isRepoIdMatch(entry, repoInfo),
+  );
 
   const isInAllowList = allowIndex !== -1;
   if (isInAllowList) {
     settings.permissions.allow.splice(allowIndex, 1);
+    await saveUserSettings(settings, ctx);
+    return;
   }
 
-  await saveUserSettings(settings, ctx);
+  warnLog(
+    `Warning: No matching trust entry found for ${path}. ` +
+      `If you recently added or removed a git remote, the entry may be stale. ` +
+      `Edit ${getUserSettingsFile(ctx)} manually if needed.`,
+  );
 }
 
 /**

--- a/packages/docs/src/content/docs/changelog.mdx
+++ b/packages/docs/src/content/docs/changelog.mdx
@@ -5,6 +5,22 @@ description: Version history and release notes for vibe
 
 All notable changes to vibe are documented here.
 
+## Unreleased
+
+### Security
+
+- **Trust system bypass fix (#418)** — repository identity matching is now strict: an entry is trusted only when both `repoRoot` matches AND the `remoteUrl` slot matches (both unset, or both set to the same value). Previously, matching on `remoteUrl` alone allowed an attacker to spoof a trusted repo by configuring `git remote.origin.url` on a malicious local repo.
+- **Migration fallbacks no longer set `skipHashCheck: true`** — the v1→v2 and v2→v3 migration fallbacks previously preserved entries with hash verification disabled when migration helpers failed. Migrated entries now keep an empty hash list and require `vibe trust` to be re-run.
+- **Stale `skipHashCheck: true` cleanup** — `loadUserSettings` now strips lingering `skipHashCheck: true` flags from existing v3 entries written by older builds.
+- **`normalizeRemoteUrl` credential strip** — fixed a regex bug where `^[^@]+@` greedily matched across `/`, allowing `https://attacker.com/legit@github.com/x/y` to normalize to `github.com/x/y`.
+
+### Behavior changes
+
+- Adding or removing a `git remote` on a previously trusted repository now requires re-running `vibe trust`.
+- `vibe untrust` now warns when no matching trust entry is found, instead of silently doing nothing.
+
+---
+
 ## v1.2.0
 
 **Released:** 2026-04-27

--- a/packages/docs/src/content/docs/ja/changelog.mdx
+++ b/packages/docs/src/content/docs/ja/changelog.mdx
@@ -5,6 +5,22 @@ description: vibeのバージョン履歴とリリースノート
 
 vibeの主要な変更はここに記録されています。
 
+## 未リリース
+
+### セキュリティ
+
+- **Trust システムのバイパス修正 (#418)** — リポジトリの同一性判定を厳格化しました。`repoRoot` が一致し、かつ `remoteUrl` のスロット (両方未設定、または両方が同一値) が一致する場合のみ trust 対象として扱います。従来は `remoteUrl` のみで一致判定していたため、攻撃者が悪意あるローカルリポジトリの `git remote.origin.url` を細工することで、trust 済みリポジトリになりすますことが可能でした。
+- **マイグレーションフォールバックが `skipHashCheck: true` を設定しないように修正** — v1→v2 / v2→v3 のマイグレーション失敗時、従来はハッシュ検証を無効化して entry を保持していました。修正後は空のハッシュリストで保持し、`vibe trust` の再実行を要求します。
+- **既存 v3 entry の `skipHashCheck: true` クリーンアップ** — `loadUserSettings` で、旧バージョンが書き込んだ `skipHashCheck: true` を読み込み時に除去します。
+- **`normalizeRemoteUrl` の認証情報ストリップ修正** — `^[^@]+@` が `/` を跨いで貪欲にマッチするバグを修正しました。これにより `https://attacker.com/legit@github.com/x/y` が `github.com/x/y` に正規化される問題を解消しました。
+
+### 挙動の変更
+
+- trust 済みリポジトリに `git remote` を追加・削除すると、`vibe trust` の再実行が必要になります。
+- `vibe untrust` で一致する trust entry が見つからない場合、従来は無言で終了していましたが、警告を表示するようになりました。
+
+---
+
 ## v1.2.0
 
 **リリース日:** 2026年4月27日


### PR DESCRIPTION
## Summary

Closes #418 — a HIGH severity vulnerability where an attacker could bypass `vibe`'s trust system by:
1. Configuring a malicious local repo's `git remote.origin.url` to match a trusted entry, then placing a crafted `.vibe.toml` at the same `relativePath`.
2. Combining that with v1→v2 / v2→v3 migration fallbacks that silently set `skipHashCheck: true`, which disabled the hash gate entirely.

This PR closes both: identity matching is now strict-AND (`repoRoot` must match AND `remoteUrl` slot must match), migration fallbacks no longer silently disable hash checking, and a defense-in-depth load-time cleanup strips legacy `skipHashCheck:true` artifacts. Also fixes a related `normalizeRemoteUrl` credential-strip regex bug that allowed `https://attacker.com/legit@github.com/x/y` to collide with `github.com/x/y`.

## Test Plan

- [x] Added 8 unit tests for new `isRepoIdMatch` helper covering the spoof regression, downgrade attempts, identity-change attempts, and defensive fail-closed for missing `repoRoot`.
- [x] Added 4 migration regression tests (v1→v2 fallback, v2→v3 success-with-skipHashCheck, v2→v3 no-repoInfo branch, v1→v3 end-to-end) confirming `skipHashCheck:true` is never carried forward and `hashes:[]` is set on fallback.
- [x] Added 2 `removeTrustedPath` tests (spoof prevention + no-match warning).
- [x] Added 1 `loadUserSettings` test asserting only migration-fallback artifacts (`hashes:[] && skipHashCheck:true`) are cleaned, while manual opt-in entries (non-empty hashes + `skipHashCheck:true`) are preserved.
- [x] Added 2 `normalizeRemoteUrl` regression tests for the credential-strip greedy match.
- [x] All existing tests still pass except `Hash history FIFO`, a pre-existing flake reproducible on `develop` (not introduced by this PR).
- [x] `pnpm run ci`, `pnpm run check:docs`, `pnpm run check:video` all pass.

## Checklist

- [x] Tests added/updated
- [x] `pnpm run check:all` passes (modulo pre-existing FIFO flake)
- [x] Docs updated (CHANGELOG entries in `changelog.mdx` + `ja/changelog.mdx` documenting the security fix and behavior changes)

Fixes #418