### PR TITLE
fix: harden fastRemoveDirectory against TOCTOU symlink attacks (#417)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Thumbs.db
 
 # Claude
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Environment
 .env

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -81,12 +81,16 @@ export interface RuntimeFS {
   rename(src: string, dest: string): Promise<void>;
 
   /**
-   * Get file/directory information
+   * Get file/directory information, following symlinks.
+   * If `path` is a symlink, returns info about the link target.
+   * For symlink-aware checks, use `lstat` instead.
    */
   stat(path: string): Promise<FileInfo>;
 
   /**
-   * Get file/directory information, following symlinks
+   * Get file/directory information without following symlinks.
+   * If `path` is a symlink, returns info about the link itself (with `isSymlink: true`),
+   * NOT the link target.
    */
   lstat(path: string): Promise<FileInfo>;
 

--- a/packages/core/src/utils/fast-remove.test.ts
+++ b/packages/core/src/utils/fast-remove.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
-import { mkdtemp, writeFile, rm, mkdir, stat } from "node:fs/promises";
+import { mkdtemp, writeFile, rm, mkdir, stat, lstat, symlink, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -10,6 +10,9 @@ import {
   SYSTEM_TRASH_DISPLAY_PATH,
 } from "./fast-remove.ts";
 import { setupRealTestContext } from "../context/testing.ts";
+
+const isWindows = process.platform === "win32";
+const itUnix = isWindows ? it.skip : it;
 
 // Initialize test context with real Deno runtime for filesystem tests
 beforeAll(async () => {
@@ -222,5 +225,187 @@ describe("fast-remove", () => {
     } catch {
       // Directory may already be deleted
     }
+  });
+
+  // ===== Security: TOCTOU symlink-attack regression tests for issue #417 =====
+
+  itUnix("fastRemoveDirectory rejects symlink to directory", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-test-"));
+    // "Sensitive" directory that must survive untouched.
+    const sensitiveDir = join(tempDir, "sensitive");
+    await mkdir(sensitiveDir);
+    const sensitiveFile = join(sensitiveDir, "secret.txt");
+    await writeFile(sensitiveFile, "do-not-delete");
+
+    // Symlink masquerading as a worktree.
+    const linkPath = join(tempDir, "worktree-link");
+    await symlink(sensitiveDir, linkPath);
+
+    const result = await fastRemoveDirectory(linkPath);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toContain("symlink");
+
+    // Sensitive directory and file must still be intact.
+    const sensitiveContent = await readFile(sensitiveFile, "utf8");
+    expect(sensitiveContent).toBe("do-not-delete");
+
+    // The symlink itself should still exist (we refused, didn't remove it).
+    const linkInfo = await lstat(linkPath);
+    expect(linkInfo.isSymbolicLink()).toBe(true);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  itUnix("fastRemoveDirectory rejects symlink to file", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-test-"));
+    const targetFile = join(tempDir, "target.txt");
+    await writeFile(targetFile, "file-content");
+
+    const linkPath = join(tempDir, "link-to-file");
+    await symlink(targetFile, linkPath);
+
+    const result = await fastRemoveDirectory(linkPath);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain("symlink");
+
+    // Original file must remain.
+    const fileContent = await readFile(targetFile, "utf8");
+    expect(fileContent).toBe("file-content");
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("fastRemoveDirectory rejects regular file", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-test-"));
+    const filePath = join(tempDir, "just-a-file.txt");
+    await writeFile(filePath, "content");
+
+    const result = await fastRemoveDirectory(filePath);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain("not a directory");
+
+    // File must still exist.
+    const content = await readFile(filePath, "utf8");
+    expect(content).toBe("content");
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  itUnix("fastRemoveDirectory rejects broken symlink (not treated as not-found)", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-test-"));
+    const nonexistentTarget = join(tempDir, "does-not-exist");
+    const brokenLink = join(tempDir, "broken-link");
+    await symlink(nonexistentTarget, brokenLink);
+
+    const result = await fastRemoveDirectory(brokenLink);
+
+    // A broken symlink must NOT silently report success; it must be refused
+    // as a symlink (lstat sees the link, even though stat would not).
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain("symlink");
+
+    // The link itself should still exist.
+    const linkInfo = await lstat(brokenLink);
+    expect(linkInfo.isSymbolicLink()).toBe(true);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  itUnix("fastRemoveDirectory rejects when parent directory is a symlink", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-test-"));
+    // Real parent and a real worktree directory inside it.
+    const realParent = join(tempDir, "real-parent");
+    await mkdir(realParent);
+    const realWorktree = join(realParent, "worktree");
+    await mkdir(realWorktree);
+    await writeFile(join(realWorktree, "marker.txt"), "preserve-me");
+
+    // Symlinked alias for the parent directory.
+    const linkedParent = join(tempDir, "linked-parent");
+    await symlink(realParent, linkedParent);
+    const targetViaLink = join(linkedParent, "worktree");
+
+    const result = await fastRemoveDirectory(targetViaLink);
+
+    expect(result.success).toBe(false);
+    // Error should mention parent symlink (we reject before reaching rename).
+    expect(result.error?.message).toContain("parent");
+
+    // Real worktree and its content must still exist.
+    const markerContent = await readFile(join(realWorktree, "marker.txt"), "utf8");
+    expect(markerContent).toBe("preserve-me");
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  itUnix(
+    "fastRemoveDirectory succeeds when a deeper ancestor (not the immediate parent) is a symlink",
+    async () => {
+      // The check is intentionally scoped to the immediate parent. Deeper-
+      // ancestor swaps require attacker write access higher up the tree and
+      // are out of #417's threat model. This test pins that behavior so we
+      // don't accidentally re-introduce a false-positive on legitimate paths
+      // whose grandparent (or above) is a symlink (e.g. macOS `/var` →
+      // `/private/var`).
+      const tempDir = await mkdtemp(join(tmpdir(), "vibe-test-"));
+      const realGrandparent = join(tempDir, "real-grandparent");
+      await mkdir(realGrandparent);
+      const parent = join(realGrandparent, "parent");
+      await mkdir(parent);
+      const worktree = join(parent, "worktree");
+      await mkdir(worktree);
+      await writeFile(join(worktree, "marker.txt"), "ok");
+
+      // Symlinked alias for the *grandparent*; the immediate parent of the
+      // worktree (under the symlinked path) is still a real directory.
+      const linkedGrandparent = join(tempDir, "linked-grandparent");
+      await symlink(realGrandparent, linkedGrandparent);
+      const targetViaSymlinkedGrandparent = join(linkedGrandparent, "parent", "worktree");
+
+      const result = await fastRemoveDirectory(targetViaSymlinkedGrandparent);
+
+      expect(result.success).toBe(true);
+
+      // The original (real) worktree path should no longer exist.
+      let exists = true;
+      try {
+        await stat(worktree);
+      } catch {
+        exists = false;
+      }
+      expect(exists).toBe(false);
+
+      await rm(tempDir, { recursive: true, force: true });
+    },
+  );
+
+  itUnix("cleanupStaleTrash skips symlink named .vibe-trash-*", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-test-"));
+    // Sensitive directory that must survive.
+    const sensitiveDir = join(tempDir, "sensitive");
+    await mkdir(sensitiveDir);
+    const sensitiveFile = join(sensitiveDir, "important.txt");
+    await writeFile(sensitiveFile, "keep-me");
+
+    // Plant a symlink under a .vibe-trash-* name pointing at the sensitive dir.
+    const malicious = join(tempDir, ".vibe-trash-99999-aaaaaaaaaaaaaaaa");
+    await symlink(sensitiveDir, malicious);
+
+    await cleanupStaleTrash(tempDir);
+
+    // Wait briefly: if the cleanup were to (incorrectly) spawn a delete, it
+    // would happen here. We then verify the sensitive content is still intact.
+    await new Promise((r) => setTimeout(r, 250));
+
+    const sensitiveContent = await readFile(sensitiveFile, "utf8");
+    expect(sensitiveContent).toBe("keep-me");
+
+    // The symlink may or may not still exist (it's not load-bearing for the
+    // security property), but the *target* must be untouched.
+    await rm(tempDir, { recursive: true, force: true });
   });
 });

--- a/packages/core/src/utils/fast-remove.ts
+++ b/packages/core/src/utils/fast-remove.ts
@@ -1,6 +1,8 @@
 import { dirname, join } from "node:path";
 import { type AppContext, getGlobalContext } from "../context/index.ts";
+import { FileSystemError } from "../errors/index.ts";
 import { getNativeTrashAdapter, type NativeTrashAdapter } from "../native/index.ts";
+import type { FileInfo } from "../runtime/types.ts";
 import { type OutputOptions, verboseLog } from "./output.ts";
 
 /**
@@ -10,9 +12,17 @@ import { type OutputOptions, verboseLog } from "./output.ts";
  */
 export const SYSTEM_TRASH_DISPLAY_PATH = "~/.Trash";
 
-/** Pattern to detect control characters that could cause issues in shell/AppleScript */
+/**
+ * Pattern to detect characters that could cause issues in shell/AppleScript.
+ *
+ * Includes:
+ * - C0 control characters (\x00-\x1f) and DEL (\x7f)
+ * - U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR), which are
+ *   AppleScript line terminators and would let an attacker break out of
+ *   the quoted string in `tell application "Finder" to delete POSIX file "..."`.
+ */
 // eslint-disable-next-line no-control-regex
-const CONTROL_CHARS_PATTERN = /[\x00-\x1f\x7f]/;
+const CONTROL_CHARS_PATTERN = /[\x00-\x1f\x7f\u2028\u2029]/;
 
 /** Cached native trash adapter instance */
 let cachedNativeTrashAdapter: NativeTrashAdapter | null | undefined;
@@ -35,8 +45,13 @@ async function getTrashAdapter(): Promise<NativeTrashAdapter | null> {
   return cachedNativeTrashAdapter;
 }
 
-/** Length of UUID suffix used in trash directory names for uniqueness */
-const TRASH_UUID_LENGTH = 8;
+/**
+ * Length of UUID suffix used in trash directory names for uniqueness.
+ *
+ * 16 hex chars (64 bits of entropy) make pre-planting attacks via name
+ * enumeration computationally infeasible.
+ */
+const TRASH_UUID_LENGTH = 16;
 
 export interface FastRemoveResult {
   success: boolean;
@@ -63,7 +78,73 @@ export function isFastRemoveSupported(): boolean {
  * Generate a unique trash directory name
  */
 function generateTrashName(): string {
-  return `.vibe-trash-${Date.now()}-${crypto.randomUUID().slice(0, TRASH_UUID_LENGTH)}`;
+  return `.vibe-trash-${Date.now()}-${crypto.randomUUID().replace(/-/g, "").slice(0, TRASH_UUID_LENGTH)}`;
+}
+
+/**
+ * Result of validating a removal target.
+ */
+type ValidationResult =
+  | { valid: true; info: FileInfo }
+  | { valid: false; reason: "not-found" | "symlink" | "not-directory" };
+
+/**
+ * Validate that `targetPath` is a removable directory (not a symlink, not a file).
+ *
+ * Uses `lstat` (not `stat`) so we never follow symlinks while checking — a
+ * symlinked path must be rejected, not silently dereferenced.
+ */
+async function validateRemovalTarget(
+  targetPath: string,
+  ctx: AppContext,
+): Promise<ValidationResult> {
+  let info: FileInfo;
+  try {
+    info = await ctx.runtime.fs.lstat(targetPath);
+  } catch (error) {
+    const isMissing = ctx.runtime.errors.isNotFound(error);
+    if (isMissing) {
+      return { valid: false, reason: "not-found" };
+    }
+    throw error;
+  }
+
+  const isSymlinkTarget = info.isSymlink === true;
+  if (isSymlinkTarget) {
+    return { valid: false, reason: "symlink" };
+  }
+
+  const isNotDirectory = !info.isDirectory;
+  if (isNotDirectory) {
+    return { valid: false, reason: "not-directory" };
+  }
+
+  return { valid: true, info };
+}
+
+/**
+ * Verify that the immediate parent directory is a real directory and not
+ * itself a symlink. The relevant attack is "attacker swaps the worktree's
+ * parent with a symlink redirecting subsequent operations" — a single `lstat`
+ * on the parent string detects this directly.
+ *
+ * We deliberately do NOT compare `realPath(parentDir) === parentDir` here:
+ * legitimate setups (macOS `/tmp` → `/private/tmp`, `/var/folders/...`,
+ * Windows 8.3 short-name expansion, APFS case-insensitive casing) routinely
+ * produce a different `realPath` for completely benign paths and would
+ * cause false-positives. Deeper-ancestor swaps require attacker write
+ * access higher up the tree, which is outside the practical threat model
+ * for #417 (and the post-rename verification still catches any
+ * race-window exploits).
+ */
+async function isParentSafe(parentDir: string, ctx: AppContext): Promise<boolean> {
+  try {
+    const info = await ctx.runtime.fs.lstat(parentDir);
+    const isSafe = !info.isSymlink && info.isDirectory;
+    return isSafe;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -75,7 +156,12 @@ function generateTrashName(): string {
  *
  * On Deno (fallback): Uses osascript on macOS
  *
- * Returns true if successful, false otherwise
+ * Returns true if successful, false otherwise.
+ *
+ * SECURITY: Callers MUST validate `targetPath` with `validateRemovalTarget`
+ * immediately before calling this function. Both code paths below
+ * (native trash adapter and AppleScript fallback) trust the caller to have
+ * verified that the path is a real directory and not a symlink.
  */
 async function moveToSystemTrash(
   targetPath: string,
@@ -107,15 +193,39 @@ async function moveToSystemTrash(
 /**
  * Move a directory to macOS Trash using Finder (via osascript)
  * This is used as a fallback when native module is not available (Deno runtime)
+ *
+ * SECURITY: Finder's `delete POSIX file` may follow the leaf symlink (deleting
+ * the link target instead of the link). To defend against TOCTOU symlink
+ * swaps, we `lstat` the leaf (must be a real directory) and the immediate
+ * parent (must not be a symlink) before invoking Finder.
  */
 async function moveToMacOSTrashViaAppleScript(
   targetPath: string,
   ctx: AppContext,
 ): Promise<boolean> {
   try {
-    // Reject paths with control characters to prevent injection attacks
+    // Reject paths with control characters or AppleScript line separators
+    // to prevent injection attacks
     const hasControlChars = CONTROL_CHARS_PATTERN.test(targetPath);
     if (hasControlChars) {
+      return false;
+    }
+
+    // Defense against TOCTOU symlink swap right before invoking Finder.
+    // Finder's `delete POSIX file` may follow the leaf symlink; we must ensure
+    // the leaf is a real directory and the immediate parent is not a symlink.
+    let leafInfo: FileInfo;
+    try {
+      leafInfo = await ctx.runtime.fs.lstat(targetPath);
+    } catch {
+      return false;
+    }
+    const isLeafSafe = !leafInfo.isSymlink && leafInfo.isDirectory;
+    if (!isLeafSafe) {
+      return false;
+    }
+    const parentSafe = await isParentSafe(dirname(targetPath), ctx);
+    if (!parentSafe) {
       return false;
     }
 
@@ -189,7 +299,63 @@ function getTempDir(ctx: AppContext): string {
 }
 
 /**
- * Fast remove a directory by moving it to trash or temp location
+ * Map a `validateRemovalTarget` failure reason to a `FileSystemError` operation
+ * suitable for inclusion in the result. The `"not-found"` case is handled by
+ * the caller (idempotent success) and is excluded from the reason type here.
+ */
+const OPERATION_BY_REASON: Record<"symlink" | "not-directory", string> = {
+  symlink: "remove (refusing symlink)",
+  "not-directory": "remove (not a directory)",
+};
+
+function operationForInvalid(reason: "symlink" | "not-directory"): string {
+  return OPERATION_BY_REASON[reason];
+}
+
+/**
+ * Re-validate the target before each external sink. Returns:
+ * - `null` if the caller should continue (target is valid)
+ * - A terminal `FastRemoveResult` otherwise (success for not-found, failure
+ *   for symlink/non-directory)
+ */
+async function checkBeforeSink(
+  targetPath: string,
+  ctx: AppContext,
+): Promise<FastRemoveResult | null> {
+  const result = await validateRemovalTarget(targetPath, ctx);
+  if (result.valid) {
+    return null;
+  }
+  if (result.reason === "not-found") {
+    return { success: true, trashedPath: undefined };
+  }
+  return {
+    success: false,
+    error: new FileSystemError(operationForInvalid(result.reason), targetPath),
+  };
+}
+
+/**
+ * Re-validate the immediate parent directory before each external sink that
+ * may resolve through it (rename, native trash, AppleScript). Returns `null`
+ * if safe; a terminal failure result otherwise.
+ */
+async function checkParentBeforeSink(
+  targetPath: string,
+  ctx: AppContext,
+): Promise<FastRemoveResult | null> {
+  const safe = await isParentSafe(dirname(targetPath), ctx);
+  if (safe) {
+    return null;
+  }
+  return {
+    success: false,
+    error: new FileSystemError("remove (parent is symlink)", targetPath),
+  };
+}
+
+/**
+ * Fast remove a directory by moving it to trash or temp location.
  *
  * Strategy (in order of preference):
  * 1. Native trash (via @kexi/vibe-native on Node.js)
@@ -199,9 +365,27 @@ function getTempDir(ctx: AppContext): string {
  * 3. /tmp + background delete (Linux without desktop, SSH sessions)
  * 4. Parent directory fallback (cross-device scenarios)
  *
- * Note: If targetPath is a symlink, the symlink itself is removed/moved,
- * not the target it points to. This is the expected behavior for cleaning
- * up worktrees which should not affect the original repository.
+ * SECURITY (issue #417): Defends against TOCTOU symlink-swap attacks where an
+ * attacker with write access to the worktree's parent directory could replace
+ * the worktree path with a symlink to a sensitive location between checks and
+ * rename/trash invocations.
+ *
+ * Defense-in-depth measures:
+ * - Symlinks are refused outright (returns `{success: false}`); a symlinked
+ *   target must never reach `rename`, the native trash adapter, or `osascript`.
+ * - Non-directories (regular files, sockets, etc.) are refused.
+ * - A fresh `lstat` check is performed immediately before each external sink
+ *   (system trash, temp-dir rename, parent-dir rename) to shrink the TOCTOU
+ *   window to its theoretical minimum.
+ * - Before each rename or native-trash invocation, the immediate parent
+ *   directory is `lstat`ed to ensure it is a real directory (not a symlink).
+ *   This catches the case where an attacker swaps the worktree's parent with
+ *   a symlink redirecting subsequent operations. (Deeper-ancestor swaps
+ *   require attacker write access higher up the tree, beyond the practical
+ *   threat model.)
+ * - After each rename, the destination is re-`lstat`ed; if a symlink is now
+ *   present (TOCTOU detected during the rename), we attempt to roll back and
+ *   skip the background deletion entirely.
  *
  * @param targetPath The directory to remove
  * @param ctx Application context
@@ -214,13 +398,23 @@ export async function fastRemoveDirectory(
   outputOpts: OutputOptions = {},
 ): Promise<FastRemoveResult> {
   try {
-    // Early check: if target doesn't exist, treat as success (idempotent)
-    const targetExists = await ctx.runtime.fs.exists(targetPath);
-    if (!targetExists) {
-      return { success: true, trashedPath: undefined };
+    // Pre-flight validation: lstat (no symlink follow), reject symlinks and non-dirs
+    const initialResult = await checkBeforeSink(targetPath, ctx);
+    if (initialResult !== null) {
+      return initialResult;
     }
 
-    // Try system trash first (native module on Node.js, osascript on macOS Deno)
+    // Try system trash first (native module on Node.js, osascript on macOS Deno).
+    // Re-validate immediately before invocation (defense-in-depth against TOCTOU)
+    // and ensure the immediate parent is not a symlink.
+    const trashRecheckResult = await checkBeforeSink(targetPath, ctx);
+    if (trashRecheckResult !== null) {
+      return trashRecheckResult;
+    }
+    const trashParentResult = await checkParentBeforeSink(targetPath, ctx);
+    if (trashParentResult !== null) {
+      return trashParentResult;
+    }
     const movedToTrash = await moveToSystemTrash(targetPath, ctx, outputOpts);
     if (movedToTrash) {
       return { success: true, trashedPath: SYSTEM_TRASH_DISPLAY_PATH };
@@ -231,18 +425,52 @@ export async function fastRemoveDirectory(
     const trashName = generateTrashName();
     const tempDir = getTempDir(ctx);
     const tempTrashPath = join(tempDir, trashName);
+    const parentDir = dirname(targetPath);
 
     // Step 1: Try to rename to temp directory first
     // This is preferred because /tmp is cleaned on reboot
+    let usedTempPath = false;
     try {
+      // Re-validate target and parent immediately before rename
+      const tempRecheckResult = await checkBeforeSink(targetPath, ctx);
+      if (tempRecheckResult !== null) {
+        return tempRecheckResult;
+      }
+      const tempParentResult = await checkParentBeforeSink(targetPath, ctx);
+      if (tempParentResult !== null) {
+        return tempParentResult;
+      }
+
       await ctx.runtime.fs.rename(targetPath, tempTrashPath);
+      usedTempPath = true;
+
+      // Post-rename verification: did we actually move a real directory, or
+      // did a TOCTOU swap convert the destination into a symlink? Treat any
+      // validation throw as a TOCTOU detection so we don't orphan the temp dir.
+      let postValid = false;
+      try {
+        const postRename = await validateRemovalTarget(tempTrashPath, ctx);
+        postValid = postRename.valid;
+      } catch {
+        postValid = false;
+      }
+      if (!postValid) {
+        return await handleToctouRollback(targetPath, tempTrashPath, ctx);
+      }
+
       spawnBackgroundDelete(tempTrashPath, ctx);
       return { success: true, trashedPath: tempTrashPath };
     } catch (tempError) {
-      // Cross-device link error (EXDEV) - fall back to parent directory
+      // If the rename itself succeeded but a later step threw, we already
+      // returned above. Here `tempError` is from rename or the recheck.
+      if (usedTempPath) {
+        throw tempError;
+      }
+
+      // Cross-device link error (EXDEV) - fall back to parent directory.
       // This occurs when targetPath and /tmp are on different filesystems
-      // (e.g., Docker volumes, network mounts, separate partitions)
-      // Check error message since Deno doesn't have a specific CrossDeviceLink error type
+      // (e.g., Docker volumes, network mounts, separate partitions).
+      // Check error message since Deno doesn't have a specific CrossDeviceLink error type.
       const errorMessage = String(tempError);
       const isCrossDeviceError =
         errorMessage.includes("cross-device") || errorMessage.includes("EXDEV");
@@ -252,9 +480,32 @@ export async function fastRemoveDirectory(
     }
 
     // Step 2: Fallback to parent directory (same filesystem)
-    const parentDir = dirname(targetPath);
     const fallbackTrashPath = join(parentDir, trashName);
+
+    // Re-validate target and parent immediately before rename
+    const fallbackRecheckResult = await checkBeforeSink(targetPath, ctx);
+    if (fallbackRecheckResult !== null) {
+      return fallbackRecheckResult;
+    }
+    const fallbackParentResult = await checkParentBeforeSink(targetPath, ctx);
+    if (fallbackParentResult !== null) {
+      return fallbackParentResult;
+    }
+
     await ctx.runtime.fs.rename(targetPath, fallbackTrashPath);
+
+    // Post-rename verification: same TOCTOU defense as the temp-dir path —
+    // wrap in try/catch so a thrown lstat error doesn't orphan the renamed dir.
+    let postFallbackValid = false;
+    try {
+      const postFallback = await validateRemovalTarget(fallbackTrashPath, ctx);
+      postFallbackValid = postFallback.valid;
+    } catch {
+      postFallbackValid = false;
+    }
+    if (!postFallbackValid) {
+      return await handleToctouRollback(targetPath, fallbackTrashPath, ctx);
+    }
 
     // Spawn detached background process for deletion
     spawnBackgroundDelete(fallbackTrashPath, ctx);
@@ -273,18 +524,70 @@ export async function fastRemoveDirectory(
 }
 
 /**
+ * Handle a TOCTOU detection after a rename: attempt to roll back so the
+ * caller's filesystem is left in a recoverable state. NEVER spawn the
+ * background delete in this case — the destination is now a symlink to
+ * an attacker-chosen path.
+ */
+async function handleToctouRollback(
+  originalPath: string,
+  destPath: string,
+  ctx: AppContext,
+): Promise<FastRemoveResult> {
+  try {
+    await ctx.runtime.fs.rename(destPath, originalPath);
+    return {
+      success: false,
+      error: new FileSystemError("remove (TOCTOU detected)", originalPath),
+    };
+  } catch (rollbackError) {
+    const cause = rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError));
+    return {
+      success: false,
+      error: new FileSystemError(
+        `remove (TOCTOU detected, rollback failed; manual recovery required at ${destPath})`,
+        originalPath,
+        cause,
+      ),
+    };
+  }
+}
+
+/**
  * Clean up stale .vibe-trash-* directories from a single directory
+ *
+ * SECURITY: Symlinks named `.vibe-trash-*` are skipped and never passed to
+ * `spawnBackgroundDelete`. Otherwise an attacker could plant a symlink to a
+ * sensitive directory under the parent and trick `rm -rf` into recursing
+ * through the link.
  */
 async function cleanupTrashInDir(dir: string, ctx: AppContext): Promise<void> {
   const { runtime } = ctx;
   try {
     for await (const entry of runtime.fs.readDir(dir)) {
-      const isVibeTrash = entry.isDirectory && entry.name.startsWith(".vibe-trash-");
-      if (isVibeTrash) {
-        const trashPath = join(dir, entry.name);
-        // Spawn detached background process for cleanup
-        spawnBackgroundDelete(trashPath, ctx);
+      const isVibeTrash =
+        entry.isDirectory && !entry.isSymlink && entry.name.startsWith(".vibe-trash-");
+      if (!isVibeTrash) {
+        continue;
       }
+
+      const trashPath = join(dir, entry.name);
+
+      // Re-check via lstat: readDir's flags can race with the filesystem; a
+      // symlink swapped in after enumeration must still be skipped.
+      let info: FileInfo;
+      try {
+        info = await runtime.fs.lstat(trashPath);
+      } catch {
+        continue;
+      }
+      const isSafeTarget = info.isDirectory && !info.isSymlink;
+      if (!isSafeTarget) {
+        continue;
+      }
+
+      // Spawn detached background process for cleanup
+      spawnBackgroundDelete(trashPath, ctx);
     }
   } catch {
     // Ignore errors - directory might not exist or be inaccessible


### PR DESCRIPTION
## Summary

Fixes #417 (Severity: High). Defends against Time-Of-Check / Time-Of-Use symlink-swap attacks in `fastRemoveDirectory`. Previously, an attacker with write access to a worktree's parent directory could replace the target between the existence check and the rename/trash invocation, redirecting the operation to an attacker-chosen location.

Defense-in-depth changes:

- Replace `exists()` with `lstat()`-based `validateRemovalTarget`; refuse symlinks and non-directories outright.
- Re-validate the leaf and immediate parent (`lstat`, not `realPath` string compare) immediately before each external sink: native trash adapter, AppleScript fallback, temp-dir rename, parent-dir rename.
- After each rename, re-`lstat` the destination; on TOCTOU detection, roll back and skip background deletion entirely.
- Harden `moveToMacOSTrashViaAppleScript` with leaf+parent `lstat` checks (Finder may follow leaf symlinks).
- Extend `CONTROL_CHARS_PATTERN` to cover U+2028 / U+2029 (AppleScript line terminators).
- Filter symlinks from `cleanupStaleTrash` `readDir` enumeration and re-`lstat` each candidate before spawning `rm -rf`.
- Bump trash-name UUID suffix from 8 to 16 hex chars (64 bits).
- Fix inverted JSDoc on `RuntimeFS.lstat` / `stat`; the security claim depends on `lstat` NOT following symlinks.

Behavior change for callers: `fastRemoveDirectory` now returns `{success: false}` for symlink / non-directory targets. The single production caller (`removeWorktree` in `clean.ts`) already falls back to `git worktree remove` on `success: false`, preserving graceful behavior for any legitimate path.

## Test Plan

- [x] Added 7 regression tests in `fast-remove.test.ts`:
  - rejects symlink to directory (sensitive target survives intact)
  - rejects symlink to file
  - rejects regular file
  - rejects broken symlink (not silently treated as not-found)
  - rejects when immediate parent is a symlink
  - succeeds when only a deeper ancestor is a symlink (regression guard for macOS `/var → /private/var` etc.)
  - `cleanupStaleTrash` skips `.vibe-trash-*` symlinks
- [x] `pnpm run check:all` passes (lint + typecheck + 416/416 tests + docs Astro check + video typecheck)
- [x] Independent code review and security audit performed; all CRITICAL/HIGH findings resolved with no new issues introduced.

## Checklist

- [x] Tests added/updated
- [x] `pnpm run check:all` passes
- [x] Docs updated (if needed) — N/A (no command/option changes; only internal security hardening)

Fixes #417