### PR TITLE
fix: use HOMEBREW_TAP_TOKEN PAT in update-nix to bypass GHA PR-create restriction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,9 +276,6 @@ jobs:
     if: github.event.action == 'released'
     needs: release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     concurrency:
       group: update-nix
       cancel-in-progress: false
@@ -287,6 +284,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: develop
+          # PAT (not GITHUB_TOKEN) so gh pr create is not blocked by the
+          # repo-level "Allow GitHub Actions to create pull requests" setting.
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -348,7 +348,7 @@ jobs:
 
       - name: Open PR and merge
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.value }}"
           # Suffix with run_id and run_attempt so re-runs and concurrent releases


### PR DESCRIPTION
## Summary

- v1.4.0's release run [25062655698](https://github.com/kexi/vibe/actions/runs/25062655698) showed the previous fix (#427) was incomplete: with `GITHUB_TOKEN`, `gh pr create` is rejected by GitHub with `GitHub Actions is not permitted to create or approve pull requests`. This is the repo-level setting **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests**, which is independent of the workflow's `pull-requests: write` permission.
- `HOMEBREW_TAP_TOKEN` was extended to grant write access to `kexi/vibe`. Switch back to using it: PAT-based auth bypasses the GHA repo-level restriction. Drop the now-unused job-level `permissions:` block.

## Behavior change vs PR #427

- Merging the auto-generated PR with a PAT will trigger `beta-release.yml` (it watches `push: develop`). With `GITHUB_TOKEN`, the trigger was suppressed. Beta builds will run after every release; this matches the original behavior before #427.

## Outstanding from v1.4.0

- The failed v1.4.0 run already pushed `chore/update-nix-flake-1.4.0-25062655698-1` to remote with the v1.4.0 flake update. Whether to manually open and merge that PR (so v1.4.0's `develop` flake reflects the v1.4.0 binaries) is a separate decision — see follow-up.

## Test plan

- [ ] Merge this PR
- [ ] Cut a throwaway prerelease, or wait for the next stable release, and confirm `update-nix` opens a PR and merges
- [ ] Confirm `chore/update-nix-flake-*` branch is deleted on success