### PR TITLE
chore: update Nix flake to 1.4.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,25 +8,25 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     let
-      version = "1.4.0";
+      version = "1.4.1";
 
       # Platform-specific binary names and SHA-256 hashes
       platforms = {
         x86_64-linux = {
           artifact = "vibe-linux-x64";
-          hash = "sha256-UB+0S/uobr3IqcJcyEQ5VsXPTHhRu0qycPJKV3EjvEY=";
+          hash = "sha256-v+LGCqzpsHcZNHyPtpUY1igbvd92N3P+hk4Q3ROwYoc=";
         };
         aarch64-linux = {
           artifact = "vibe-linux-arm64";
-          hash = "sha256-Z0CM+mmlhS7KMgXt/HFJ84Ukv1v4arUO3FcFa4zjxM4=";
+          hash = "sha256-FYvVpNumlEW401UGiDNmWOowGFQUJ+IXdwo4IRs0I/8=";
         };
         x86_64-darwin = {
           artifact = "vibe-darwin-x64";
-          hash = "sha256-b4HZKRU5MkVofhhDJTI5XcBeDqnuWG6xutumtdRN5IY=";
+          hash = "sha256-Gv+a1OpEWH+YjIL/dlq02f2HAxEzJIBQoFv8E6UPClE=";
         };
         aarch64-darwin = {
           artifact = "vibe-darwin-arm64";
-          hash = "sha256-7K9NyBNnY214uvlL+lDh26OfaMEcAS9PBbYOAOFjWxI=";
+          hash = "sha256-Vuo8x1Kp+hmaxi3lMgftID16whYQ9H7bz0svSz+enzs=";
         };
       };
     in


### PR DESCRIPTION
Manual recovery of the orphan branch pushed by the failed `update-nix` job in [run 25063456387](https://github.com/kexi/vibe/actions/runs/25063456387). Brings v1.4.1's `flake.nix` / `flake.lock` into `develop`.

The PAT now has `Pull requests: Write`, so the next release should complete the update-nix flow automatically (no workflow change required).