### PR TITLE
chore: harden supply chain defenses against npm compromise patterns

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -20,6 +20,10 @@ jobs:
       should_release: ${{ steps.check.outputs.should_release }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Determine beta version
@@ -72,6 +76,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -153,6 +161,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
@@ -175,6 +187,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         env:
@@ -27,6 +31,10 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         env:
@@ -44,6 +52,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         env:
@@ -65,6 +77,10 @@ jobs:
   deno-smoke-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
@@ -93,6 +109,10 @@ jobs:
             name: windows-x64
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         env:
@@ -117,6 +137,10 @@ jobs:
           - arch: arm64
             target: bun-linux-arm64
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         env:
@@ -152,6 +176,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -178,6 +206,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         env:
@@ -229,6 +261,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         env:
@@ -251,6 +287,10 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
@@ -261,4 +301,8 @@ jobs:
     needs: [build-binaries, build-deb, build-native]
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - run: echo "All builds completed successfully"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -53,6 +57,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - name: Verify release targets main branch
         run: |
           if [ "${{ github.event.release.target_commitish }}" != "main" ]; then

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,6 +13,10 @@ jobs:
   verify-versions:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - name: Verify release targets main branch
         run: |
           if [ "${{ github.event.release.target_commitish }}" != "main" ]; then
@@ -50,6 +54,10 @@ jobs:
     needs: verify-versions
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -82,6 +90,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -111,6 +123,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -169,6 +185,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -239,6 +259,6 @@ jobs:
 
       - name: Publish @kexi/vibe
         working-directory: packages/npm
-        run: pnpm publish --access public --provenance --no-git-checks
+        run: pnpm publish --access public --provenance --no-git-checks --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
   verify-branch:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - name: Verify release targets main branch
         if: github.event.action == 'released'
         run: |
@@ -45,6 +49,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -104,6 +112,10 @@ jobs:
             binary: vibe-linux-arm64
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -144,6 +156,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
@@ -160,6 +176,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -281,6 +301,10 @@ jobs:
       cancel-in-progress: false
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: develop

--- a/docs/SECURITY_CHECKLIST.ja.md
+++ b/docs/SECURITY_CHECKLIST.ja.md
@@ -49,9 +49,17 @@ vibe CLIツールの包括的なセキュリティチェックリストです。
 
 ## 8. サプライチェーン攻撃
 
-- **リスク**: 侵害された依存関係による脆弱性の導入
-- **対策**: ロックファイル固定 + `pnpm audit` + パッケージ公開後最低1日の待機ポリシー
-- **適用**: CIでのロックファイル検証 + `--frozen-lockfile` + `--ignore-scripts`
+- **リスク**: 上流パッケージの侵害、悪意あるライフサイクルスクリプト、ビルドランナーからの情報窃取、publish トークンの奪取など — 例: [TanStack npm 侵害事例 (2026-05-11)](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)
+- **対策** (多層防御):
+  - **レジストリ強化**: Takumi Guard プロキシ (`.github/actions/setup-takumi-guard`) が既知マルウェアを遮断。`pnpm-workspace.yaml` の `minimumReleaseAge: 4320` (72 時間) で新規公開直後のバージョンを隔離
+  - **非標準ソース禁止**: `blockExoticSubdeps: true` で `github:user/repo`・`file:`・`http:` などレジストリ外依存を依存グラフ全域で拒否（自己伝播ペイロード `optionalDependencies: github:<sha>` を無効化）
+  - **ライフサイクルスクリプト既定オフ**: `strictDepBuilds: true` + 明示的な `only-built-dependencies` 許可リスト（現在 `node-pty` のみ、`.npmrc` を参照）。CI の全 `pnpm install` / `pnpm publish` に `--ignore-scripts`
+  - **信頼レベル単調性**: `trustPolicy: no-downgrade` でパッケージが低信頼状態に遷移した場合にインストールを中断
+  - **ロックファイル固定**: 全 CI install ステップで `--frozen-lockfile`
+  - **ワークフロー完全性**: サードパーティ Actions は完全コミット SHA に固定 (`pinact-verify` job が未固定参照をブロック)。`.mise.toml` のツールも patch まで固定
+  - **ランナー egress 可視化**: 全 job に `step-security/harden-runner` (audit モード) を配置し、外向き通信と `/proc` アクセスを記録。Shai-Hulud 系マルウェアが用いる `*.getsession.org` などの C2 を検知可能に
+  - **公開時の出所証明**: 全リリースで `npm publish --provenance` を有効化し OIDC 署名された attestation を付与
+- **適用**: CI の `pinact-verify` job + 全 CI install で `pnpm install --frozen-lockfile --ignore-scripts` + `pnpm publish ... --ignore-scripts` + 各リリース後の Harden-Runner Insights レビュー
 
 ## 9. 安全でない一時ファイル作成
 

--- a/docs/SECURITY_CHECKLIST.md
+++ b/docs/SECURITY_CHECKLIST.md
@@ -49,9 +49,17 @@ A comprehensive security checklist for the vibe CLI tool. Each category includes
 
 ## 8. Supply Chain Attacks
 
-- **Risk**: Compromised dependencies introducing vulnerabilities
-- **Mitigation**: Lockfile pinning + `pnpm audit` + minimum 1-day package age policy
-- **Enforcement**: CI lockfile verification + `--frozen-lockfile` + `--ignore-scripts`
+- **Risk**: Compromised upstream packages, malicious lifecycle scripts, exfiltration from build runners, or hijacked publish tokens — see e.g. the [TanStack npm compromise (2026-05-11)](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)
+- **Mitigation** (layered):
+  - **Registry hardening**: Takumi Guard proxy (`.github/actions/setup-takumi-guard`) intercepts known-malicious packages; `minimumReleaseAge: 4320` (72 h) quarantine in `pnpm-workspace.yaml` blocks freshly published versions
+  - **No exotic sources**: `blockExoticSubdeps: true` rejects `github:user/repo`, `file:`, `http:` and other non-registry dependencies anywhere in the graph (defeats the wormable `optionalDependencies: github:<sha>` technique)
+  - **Lifecycle scripts off by default**: `strictDepBuilds: true` + explicit `only-built-dependencies` allowlist (currently `node-pty` only, see `.npmrc`); `--ignore-scripts` on every `pnpm install` and `pnpm publish` invocation in CI
+  - **Trust monotonicity**: `trustPolicy: no-downgrade` aborts installation when a package transitions to a less-trusted state
+  - **Lockfile pinning**: `--frozen-lockfile` in every CI install step
+  - **Workflow integrity**: All third-party GitHub Actions pinned to full commit SHA (`pinact-verify` job blocks unpinned references); tool versions pinned to full patch in `.mise.toml`
+  - **Runner egress visibility**: `step-security/harden-runner` (audit mode) on every job logs outbound network traffic and `/proc` access, surfacing exfiltration channels such as the `*.getsession.org` C2 used by Shai-Hulud
+  - **Publish provenance**: `npm publish --provenance` on every release for OIDC-signed attestation
+- **Enforcement**: `pinact-verify` CI job + `pnpm install --frozen-lockfile --ignore-scripts` in CI + `pnpm publish ... --ignore-scripts` + Harden-Runner Insights review after each release
 
 ## 9. Unsafe Temp File Creation
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,18 @@ minimumReleaseAgeExclude:
   - fontkitten
   - "@types/*"
   - tsdown
+
+# Block non-registry sources (github:user/repo, file:, http:, etc.) anywhere in
+# the dependency graph. Prevents the wormable optionalDependencies: github:<sha>
+# payload technique used in the 2026-05-11 TanStack npm compromise.
+blockExoticSubdeps: true
+
+# Refuse to run lifecycle scripts for any dependency by default. The
+# `onlyBuiltDependencies` allowlist of packages that may run install scripts
+# is intentionally kept in `.npmrc` (`only-built-dependencies[]=node-pty`) so
+# legacy `npm`/`yarn` consumers honour the same allowlist.
+strictDepBuilds: true
+
+# Fail the install if a package transitions to a less-trusted state
+# (e.g. signed -> unsigned, public -> private) between resolutions.
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary

Layered supply chain defenses informed by the [2026-05-11 TanStack npm compromise](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem), where attackers chained a `pull_request_target` cache poisoning, a `~2.3 MB` obfuscated post-install payload, and OIDC token extraction from runner memory (`/proc/<pid>/mem`) to publish 84 malicious versions across 42 packages. None of those specific paths are reachable here today, but several adjacent gaps remained:

- **`pnpm-workspace.yaml`**: add `blockExoticSubdeps: true` (rejects the wormable `optionalDependencies: github:<sha>` technique the attacker used to spread the payload), `strictDepBuilds: true` (lifecycle scripts off by default; the existing `only-built-dependencies[]=node-pty` in `.npmrc` remains the single allowlist), and `trustPolicy: no-downgrade` (aborts on signed→unsigned, public→private transitions).
- **Harden-Runner (audit mode)** on every job across the 7 workflows: gives outbound traffic and `/proc` access visibility in the Actions Insights tab — would have surfaced the `*.getsession.org` C2 used by Shai-Hulud-style exfiltration. Audit is non-blocking; intended as a stepping stone toward `block` mode after one or two releases of telemetry.
- **`publish-npm.yml`**: add `--ignore-scripts` to the `@kexi/vibe` publish step for parity with `publish-native` and as defense-in-depth against a hijacked `prepublishOnly` (the workflow already runs `pnpm run build` explicitly).
- **`docs/SECURITY_CHECKLIST.md` / `.ja.md`**: rewrite section 8 to document the layered model and reference the TanStack postmortem.

Out of scope (deliberately deferred): npm Trusted Publishing (OIDC) migration, CodeQL / OpenSSF Scorecard, Dependabot npm ecosystem, and promoting Harden-Runner from `audit` to `block`.

## Test Plan

- [x] `mise exec -- pinact run --check` passes (Harden-Runner v2.19.1 pinned to full SHA `a5ad31d6...`)
- [x] `pnpm install --frozen-lockfile --ignore-scripts` succeeds; `pnpm config list` confirms `block-exotic-subdeps=true`, `strict-dep-builds=true`, `trust-policy=no-downgrade` are recognised
- [x] `pnpm run check:all` green (lint / format / typecheck / 451 tests / docs / video)
- [ ] After merge: inspect Harden-Runner Insights on the next CI run and confirm no unexpected egress destinations

## Checklist

- [x] Tests added/updated (no new code paths; existing 451 tests cover behaviour and pass)
- [x] `pnpm run check:all` passes
- [x] Docs updated (if needed)

Fixes #