### PR TITLE
chore: release v1.5.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-monorepo",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "description": "Monorepo for vibe CLI - Git worktree management tool",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-core",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Core components for Vibe - Runtime abstraction, types, errors, and context",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/docs/src/content/docs/changelog.mdx
+++ b/packages/docs/src/content/docs/changelog.mdx
@@ -5,6 +5,16 @@ description: Version history and release notes for vibe
 
 All notable changes to vibe are documented here.
 
+## v1.5.0
+
+**Released:** 2026-05-16
+
+### Added
+
+- Fish shell autocompletion for `vibe`. Run `vibe shell-setup --shell fish --with-completion | source` (or add the line to `~/.config/fish/config.fish`) to get tab completion for subcommands, flags, local branch names on `vibe start <Tab>`, and worktree branch names on `vibe jump <Tab>`. See [Shell Setup](/setup/) and [`vibe shell-setup`](/commands/shell-setup/) for details.
+
+---
+
 ## v1.4.3
 
 **Released:** 2026-05-12

--- a/packages/docs/src/content/docs/ja/changelog.mdx
+++ b/packages/docs/src/content/docs/ja/changelog.mdx
@@ -5,6 +5,16 @@ description: vibeのバージョン履歴とリリースノート
 
 vibeの主要な変更はここに記録されています。
 
+## v1.5.0
+
+**リリース日:** 2026年5月16日
+
+### 追加
+
+- `vibe` の fish シェル補完を追加しました。`vibe shell-setup --shell fish --with-completion | source` を実行する（または `~/.config/fish/config.fish` に追記する）と、サブコマンド・フラグ・`vibe start <Tab>` のローカルブランチ名・`vibe jump <Tab>` の worktree ブランチ名がタブ補完されます。詳細は [シェル設定](/ja/setup/) と [`vibe shell-setup`](/ja/commands/shell-setup/) を参照。
+
+---
+
 ## v1.4.3
 
 **リリース日:** 2026年5月12日

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-native",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Native clone operations for vibe CLI (clonefile on macOS, FICLONE on Linux)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Git worktree helper CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Release version 1.5.0

## Checklist

- [x] Version updated in package.json
- [x] Version synced to all package.json files
- [x] Changelog updated (packages/docs/src/content/docs/changelog.mdx + ja/changelog.mdx)
- [ ] CI checks passing

---

After merging this PR:
1. Create a PR from `develop` to `main`
2. Merge the `develop` → `main` PR
3. Create a GitHub Release with tag `v1.5.0`
4. CI will automatically publish to npm and JSR