### PR TITLE
fix(ci): force npm self-upgrade and pin to npm@11

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -174,7 +174,11 @@ jobs:
           echo "Version validation passed: $TAG_VERSION"
 
       - name: Upgrade npm to a version that supports trusted publishing
-        run: npm install -g npm@latest
+        # --force avoids the known npm self-upgrade race (e.g. ENOENT on
+        # @npmcli/arborist's promise-retry) caused by the bundled npm replacing
+        # its own modules mid-install. Pin to npm@11 so trusted publishing is
+        # available without chasing a moving "latest" target.
+        run: npm install -g --force npm@11
 
       - name: Publish @kexi/vibe-native
         working-directory: packages/native
@@ -259,7 +263,11 @@ jobs:
         run: pnpm run build
 
       - name: Upgrade npm to a version that supports trusted publishing
-        run: npm install -g npm@latest
+        # --force avoids the known npm self-upgrade race (e.g. ENOENT on
+        # @npmcli/arborist's promise-retry) caused by the bundled npm replacing
+        # its own modules mid-install. Pin to npm@11 so trusted publishing is
+        # available without chasing a moving "latest" target.
+        run: npm install -g --force npm@11
 
       - name: Publish @kexi/vibe
         working-directory: packages/npm


### PR DESCRIPTION
## Summary

The v1.5.0 publish workflow failed at the `npm install -g npm@latest` self-upgrade step with `Cannot find module 'promise-retry'` -- a known npm self-upgrade race where the bundled npm replaces its own modules mid-install and momentarily breaks @npmcli/arborist.

Two changes:

- Add `--force` so the new npm overwrites the half-installed state instead of bailing out.
- Pin to `npm@11` instead of `@latest`. npm 11 already has trusted publishing, and pinning avoids future surprises from a moving `latest` target.

Applied to both `publish-native` and `publish-cli` jobs in `publish-npm.yml`.

Failing run: https://github.com/kexi/vibe/actions/runs/25944134191/job/76268834274

## Test plan

- Manual smoke after merge: delete the v1.5.0 release + tag, recreate the release targeting `main` (after this fix lands), and confirm both `publish-native` and `publish-cli` succeed.