### PR TITLE
chore: merge develop into main (CI fix for v1.5.0 publish)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -174,7 +174,11 @@ jobs:
           echo "Version validation passed: $TAG_VERSION"
 
       - name: Upgrade npm to a version that supports trusted publishing
-        run: npm install -g npm@latest
+        # --force avoids the known npm self-upgrade race (e.g. ENOENT on
+        # @npmcli/arborist's promise-retry) caused by the bundled npm replacing
+        # its own modules mid-install. Pin to npm@11 so trusted publishing is
+        # available without chasing a moving "latest" target.
+        run: npm install -g --force npm@11
 
       - name: Publish @kexi/vibe-native
         working-directory: packages/native
@@ -259,7 +263,11 @@ jobs:
         run: pnpm run build
 
       - name: Upgrade npm to a version that supports trusted publishing
-        run: npm install -g npm@latest
+        # --force avoids the known npm self-upgrade race (e.g. ENOENT on
+        # @npmcli/arborist's promise-retry) caused by the bundled npm replacing
+        # its own modules mid-install. Pin to npm@11 so trusted publishing is
+        # available without chasing a moving "latest" target.
+        run: npm install -g --force npm@11
 
       - name: Publish @kexi/vibe
         working-directory: packages/npm


### PR DESCRIPTION
## Summary

Brings #447 (CI fix for npm self-upgrade failure that blocked v1.5.0 publish) onto main so the publish workflow can be re-triggered with the fixed step.

After merging this PR, recover the v1.5.0 release:

1. Delete the v1.5.0 GitHub release and tag.
2. Re-create the release targeting `main` -- this fires a fresh workflow run that picks up the fixed `publish-npm.yml`.