### PR TITLE
fix(ci): switch publish jobs to Node 24 to sidestep broken bundled npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -135,7 +135,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Download all artifacts
@@ -173,12 +173,15 @@ jobs:
 
           echo "Version validation passed: $TAG_VERSION"
 
-      - name: Upgrade npm to a version that supports trusted publishing
-        # --force avoids the known npm self-upgrade race (e.g. ENOENT on
-        # @npmcli/arborist's promise-retry) caused by the bundled npm replacing
-        # its own modules mid-install. Pin to npm@11 so trusted publishing is
-        # available without chasing a moving "latest" target.
-        run: npm install -g --force npm@11
+      - name: Verify npm version (trusted publishing requires npm >= 11.5)
+        # Node 24 ships with npm 11.x which already supports OIDC trusted
+        # publishing. The previous workaround of `npm install -g npm@latest`
+        # was unstable -- the bundled npm 10.x in Node 22.22 was missing
+        # @npmcli/arborist's promise-retry dependency and could not self-
+        # upgrade. Switching to Node 24 sidesteps the self-upgrade entirely.
+        run: |
+          npm --version
+          node --version
 
       - name: Publish @kexi/vibe-native
         working-directory: packages/native
@@ -202,7 +205,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Validate version consistency
@@ -262,12 +265,15 @@ jobs:
         working-directory: packages/npm
         run: pnpm run build
 
-      - name: Upgrade npm to a version that supports trusted publishing
-        # --force avoids the known npm self-upgrade race (e.g. ENOENT on
-        # @npmcli/arborist's promise-retry) caused by the bundled npm replacing
-        # its own modules mid-install. Pin to npm@11 so trusted publishing is
-        # available without chasing a moving "latest" target.
-        run: npm install -g --force npm@11
+      - name: Verify npm version (trusted publishing requires npm >= 11.5)
+        # Node 24 ships with npm 11.x which already supports OIDC trusted
+        # publishing. The previous workaround of `npm install -g npm@latest`
+        # was unstable -- the bundled npm 10.x in Node 22.22 was missing
+        # @npmcli/arborist's promise-retry dependency and could not self-
+        # upgrade. Switching to Node 24 sidesteps the self-upgrade entirely.
+        run: |
+          npm --version
+          node --version
 
       - name: Publish @kexi/vibe
         working-directory: packages/npm


### PR DESCRIPTION
## Summary

The previous fix in #447 pinned `npm install -g --force npm@11`, but the failure persists on v1.5.1 publish (run 25944715833) — the bundled npm 10.x in Node 22.22.x is missing `@npmcli/arborist`'s `promise-retry` dependency, so even `--force` self-upgrade fails before the new npm can take over.

Switch to Node 24 in both `publish-native` and `publish-cli` jobs. Node 24 ships with npm 11.x bundled, which already supports OIDC trusted publishing — no self-upgrade needed. The mise-managed Node version (`.mise.toml` pins 24.13.0) and the publish jobs now agree.

Failing runs: [v1.5.0 publish](https://github.com/kexi/vibe/actions/runs/25944134191), [v1.5.1 publish](https://github.com/kexi/vibe/actions/runs/25944715833).

## Test plan

- After merge, recover v1.5.1 as v1.5.2 (or re-trigger v1.5.1 publish) — confirm `publish-native` and `publish-cli` both succeed end-to-end with Node 24 + bundled npm 11.x.