### PR TITLE
chore: merge develop into main (Node 24 publish-jobs fix)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -135,7 +135,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Download all artifacts
@@ -173,12 +173,15 @@ jobs:
 
           echo "Version validation passed: $TAG_VERSION"
 
-      - name: Upgrade npm to a version that supports trusted publishing
-        # --force avoids the known npm self-upgrade race (e.g. ENOENT on
-        # @npmcli/arborist's promise-retry) caused by the bundled npm replacing
-        # its own modules mid-install. Pin to npm@11 so trusted publishing is
-        # available without chasing a moving "latest" target.
-        run: npm install -g --force npm@11
+      - name: Verify npm version (trusted publishing requires npm >= 11.5)
+        # Node 24 ships with npm 11.x which already supports OIDC trusted
+        # publishing. The previous workaround of `npm install -g npm@latest`
+        # was unstable -- the bundled npm 10.x in Node 22.22 was missing
+        # @npmcli/arborist's promise-retry dependency and could not self-
+        # upgrade. Switching to Node 24 sidesteps the self-upgrade entirely.
+        run: |
+          npm --version
+          node --version
 
       - name: Publish @kexi/vibe-native
         working-directory: packages/native
@@ -202,7 +205,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Validate version consistency
@@ -262,12 +265,15 @@ jobs:
         working-directory: packages/npm
         run: pnpm run build
 
-      - name: Upgrade npm to a version that supports trusted publishing
-        # --force avoids the known npm self-upgrade race (e.g. ENOENT on
-        # @npmcli/arborist's promise-retry) caused by the bundled npm replacing
-        # its own modules mid-install. Pin to npm@11 so trusted publishing is
-        # available without chasing a moving "latest" target.
-        run: npm install -g --force npm@11
+      - name: Verify npm version (trusted publishing requires npm >= 11.5)
+        # Node 24 ships with npm 11.x which already supports OIDC trusted
+        # publishing. The previous workaround of `npm install -g npm@latest`
+        # was unstable -- the bundled npm 10.x in Node 22.22 was missing
+        # @npmcli/arborist's promise-retry dependency and could not self-
+        # upgrade. Switching to Node 24 sidesteps the self-upgrade entirely.
+        run: |
+          npm --version
+          node --version
 
       - name: Publish @kexi/vibe
         working-directory: packages/npm


### PR DESCRIPTION
Brings #451 (Node 24 for publish jobs) onto main so a v1.5.2 recovery release can succeed.