### PR TITLE
docs: fix zsh setup example in v1.6.0 changelog

### DIFF
--- a/packages/docs/src/content/docs/changelog.mdx
+++ b/packages/docs/src/content/docs/changelog.mdx
@@ -11,7 +11,7 @@ All notable changes to vibe are documented here.
 
 ### Added
 
-- Zsh shell autocompletion for `vibe`. Run `vibe shell-setup --shell zsh --with-completion | source` (or add the line to `~/.zshrc`) to get tab completion for subcommands, flags, local branch names on `vibe start <Tab>`, and worktree branch names on `vibe jump <Tab>`. See [Shell Setup](/setup/) and [`vibe shell-setup`](/commands/shell-setup/) for details.
+- Zsh shell autocompletion for `vibe`. Add `autoload -Uz compinit && compinit` and `eval "$(vibe shell-setup --shell zsh --with-completion)"` to `~/.zshrc` (in that order — `compinit` must run before the `eval`) to get tab completion for subcommands, flags, local branch names on `vibe start <Tab>`, and worktree branch names on `vibe jump <Tab>`. See [Shell Setup](/setup/) and [`vibe shell-setup`](/commands/shell-setup/) for details.
 
 ---
 

--- a/packages/docs/src/content/docs/ja/changelog.mdx
+++ b/packages/docs/src/content/docs/ja/changelog.mdx
@@ -11,7 +11,7 @@ vibeの主要な変更はここに記録されています。
 
 ### 追加
 
-- `vibe` の zsh シェル補完を追加しました。`vibe shell-setup --shell zsh --with-completion | source` を実行する（または `~/.zshrc` に追記する）と、サブコマンド・フラグ・`vibe start <Tab>` のローカルブランチ名・`vibe jump <Tab>` の worktree ブランチ名がタブ補完されます。詳細は [シェル設定](/ja/setup/) と [`vibe shell-setup`](/ja/commands/shell-setup/) を参照。
+- `vibe` の zsh シェル補完を追加しました。`~/.zshrc` に `autoload -Uz compinit && compinit` と `eval "$(vibe shell-setup --shell zsh --with-completion)"` をこの順で追記する（`compinit` を `eval` より前に呼ぶ必要があります）と、サブコマンド・フラグ・`vibe start <Tab>` のローカルブランチ名・`vibe jump <Tab>` の worktree ブランチ名がタブ補完されます。詳細は [シェル設定](/ja/setup/) と [`vibe shell-setup`](/ja/commands/shell-setup/) を参照。
 
 ---
 


### PR DESCRIPTION
## Summary
- The v1.6.0 changelog entries (EN + JA) reused fish's `... | source` pattern for the zsh example. That doesn't work — zsh's `source` does not read from stdin, and the script also needs `compinit` loaded before `compdef` can register.
- Rewrites both entries to the canonical zsh form: `autoload -Uz compinit && compinit` followed by `eval "$(vibe shell-setup --shell zsh --with-completion)"`, matching what `setup.mdx` and `commands/shell-setup.mdx` already document.

## Test plan
- [x] `pnpm run check:docs` — astro check 0 errors / 0 warnings / 0 hints
- [x] Manually verified the new snippet works in `zsh -fc 'source <(...)'` smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)