### PR TITLE
chore: merge develop into main (v1.6.0 changelog fix)

### DIFF
--- a/packages/docs/src/content/docs/changelog.mdx
+++ b/packages/docs/src/content/docs/changelog.mdx
@@ -11,7 +11,7 @@ All notable changes to vibe are documented here.
 
 ### Added
 
-- Zsh shell autocompletion for `vibe`. Run `vibe shell-setup --shell zsh --with-completion | source` (or add the line to `~/.zshrc`) to get tab completion for subcommands, flags, local branch names on `vibe start <Tab>`, and worktree branch names on `vibe jump <Tab>`. See [Shell Setup](/setup/) and [`vibe shell-setup`](/commands/shell-setup/) for details.
+- Zsh shell autocompletion for `vibe`. Add `autoload -Uz compinit && compinit` and `eval "$(vibe shell-setup --shell zsh --with-completion)"` to `~/.zshrc` (in that order — `compinit` must run before the `eval`) to get tab completion for subcommands, flags, local branch names on `vibe start <Tab>`, and worktree branch names on `vibe jump <Tab>`. See [Shell Setup](/setup/) and [`vibe shell-setup`](/commands/shell-setup/) for details.
 
 ---
 

--- a/packages/docs/src/content/docs/ja/changelog.mdx
+++ b/packages/docs/src/content/docs/ja/changelog.mdx
@@ -11,7 +11,7 @@ vibeの主要な変更はここに記録されています。
 
 ### 追加
 
-- `vibe` の zsh シェル補完を追加しました。`vibe shell-setup --shell zsh --with-completion | source` を実行する（または `~/.zshrc` に追記する）と、サブコマンド・フラグ・`vibe start <Tab>` のローカルブランチ名・`vibe jump <Tab>` の worktree ブランチ名がタブ補完されます。詳細は [シェル設定](/ja/setup/) と [`vibe shell-setup`](/ja/commands/shell-setup/) を参照。
+- `vibe` の zsh シェル補完を追加しました。`~/.zshrc` に `autoload -Uz compinit && compinit` と `eval "$(vibe shell-setup --shell zsh --with-completion)"` をこの順で追記する（`compinit` を `eval` より前に呼ぶ必要があります）と、サブコマンド・フラグ・`vibe start <Tab>` のローカルブランチ名・`vibe jump <Tab>` の worktree ブランチ名がタブ補完されます。詳細は [シェル設定](/ja/setup/) と [`vibe shell-setup`](/ja/commands/shell-setup/) を参照。
 
 ---
 


### PR DESCRIPTION
## Summary
- Brings the v1.6.0 changelog zsh-example fix (PR #460) from `develop` to `main` so the live release notes show the correct setup snippet.
- This is a follow-up to the v1.6.0 develop→main merge (#459). No code changes — docs only.

## Test plan
- [x] PR #460 merged to `develop` with `pnpm run check:docs` clean