### PR TITLE
docs: add recipes section for external tool integrations

### DIFF
--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -86,6 +86,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           autogenerate: { directory: "commands" },
         },
         {
+          label: "Recipes",
+          translations: { ja: "レシピ集" },
+          autogenerate: { directory: "recipes" },
+        },
+        {
           label: "Security",
           translations: { ja: "セキュリティ" },
           autogenerate: { directory: "security" },

--- a/packages/docs/src/content/docs/ja/recipes/cmux.mdx
+++ b/packages/docs/src/content/docs/ja/recipes/cmux.mdx
@@ -1,0 +1,20 @@
+---
+title: cmux
+description: 新しいWorktreeでcmuxワークスペースを開く
+sidebar:
+  order: 2
+---
+
+作成したばかりのWorktreeを指す[cmux](https://github.com/kexi/cmux)ワークスペースを新規に開きます。
+
+```toml
+[hooks]
+post_start = ['cmux new-workspace --cwd "$VIBE_WORKTREE_PATH"']
+```
+
+これだけで、`vibe start`のたびにWorktreeパスがcmuxに渡されます。
+
+## 注意点
+
+- `post_start`は新しいWorktree**内**で実行されるため、`--cwd "$VIBE_WORKTREE_PATH"`は厳密には冗長ですが、後で別のフックフェーズに移したときに動作を明確にしておくために残してあります。
+- 非対話シェルの`PATH`にcmuxがない場合は絶対パスを指定してください: `'/usr/local/bin/cmux new-workspace --cwd "$VIBE_WORKTREE_PATH"'`

--- a/packages/docs/src/content/docs/ja/recipes/direnv.mdx
+++ b/packages/docs/src/content/docs/ja/recipes/direnv.mdx
@@ -1,0 +1,22 @@
+---
+title: direnv
+description: 新しいWorktreeで.envrcを自動許可する
+sidebar:
+  order: 4
+---
+
+プロジェクトで[direnv](https://direnv.net)を使っていてWorktreeに`.envrc`をコピーしている場合、direnvは`direnv allow`を実行するまで読み込みをブロックします。これを自動化します:
+
+```toml
+[copy]
+files = [".envrc"]
+
+[hooks]
+post_start = ['direnv allow .']
+```
+
+`post_start`は新しいWorktree内で実行されるため、`.`だけで十分です。
+
+:::caution
+`direnv allow`はシェルの完全な権限で`.envrc`を実行します。チェックアウトするブランチのすべてのコミットを信頼できるリポジトリでのみ有効化してください。
+:::

--- a/packages/docs/src/content/docs/ja/recipes/index.mdx
+++ b/packages/docs/src/content/docs/ja/recipes/index.mdx
@@ -1,0 +1,20 @@
+---
+title: レシピ集
+description: vibeと他ツールを連携させるための短いコピペ可能なスニペット集
+sidebar:
+  order: 1
+---
+
+「vibeで○○もやりたい」というよくあるワークフロー向けの、最小限の`.vibe.toml`スニペット集です。
+
+各レシピは意図的に小さく、既存の設定にそのままコピペできる1〜2行のTOMLで構成されています。フックの完全なリファレンスは [フック](/ja/configuration/hooks/) を参照してください。
+
+## ラインナップ
+
+- [cmux](/ja/recipes/cmux/) — 新しいWorktreeでcmuxワークスペースを開く
+- [tmux](/ja/recipes/tmux/) — tmuxペインを新しいWorktreeに分割する
+- [direnv](/ja/recipes/direnv/) — 新しいWorktreeで自動的に`direnv allow`する
+
+:::tip
+レシピで使うのは公式の環境変数（`VIBE_WORKTREE_PATH`、`VIBE_ORIGIN_PATH`）と`sh`互換構文のみなので、macOSとLinuxでそのまま動作します。
+:::

--- a/packages/docs/src/content/docs/ja/recipes/tmux.mdx
+++ b/packages/docs/src/content/docs/ja/recipes/tmux.mdx
@@ -1,0 +1,31 @@
+---
+title: tmux
+description: tmuxペインを新しいWorktreeに分割する
+sidebar:
+  order: 3
+---
+
+現在のtmuxウィンドウを水平分割し、新しいWorktreeのディレクトリで開きます。
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux split-window -h -c "$VIBE_WORKTREE_PATH"']
+```
+
+`[ -n "$TMUX" ] &&` のガードがあるので、tmuxの外で`vibe start`を実行した場合はフックが何もしません。同じ設定がどこでも動きます。
+
+## バリエーション
+
+分割ではなく新しいウィンドウを開く場合:
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux new-window -c "$VIBE_WORKTREE_PATH"']
+```
+
+垂直分割の場合:
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux split-window -v -c "$VIBE_WORKTREE_PATH"']
+```

--- a/packages/docs/src/content/docs/recipes/cmux.mdx
+++ b/packages/docs/src/content/docs/recipes/cmux.mdx
@@ -1,0 +1,20 @@
+---
+title: cmux
+description: Open a cmux workspace in the new worktree
+sidebar:
+  order: 2
+---
+
+Open a new [cmux](https://github.com/kexi/cmux) workspace pointing at the freshly created worktree.
+
+```toml
+[hooks]
+post_start = ['cmux new-workspace --cwd "$VIBE_WORKTREE_PATH"']
+```
+
+That's it — every `vibe start` will hand the worktree path to cmux.
+
+## Notes
+
+- `post_start` runs **inside** the new worktree, so `--cwd "$VIBE_WORKTREE_PATH"` is technically redundant but keeps the command unambiguous if you later move it to a different hook phase.
+- If cmux is not on your `PATH` in non-interactive shells, use an absolute path: `'/usr/local/bin/cmux new-workspace --cwd "$VIBE_WORKTREE_PATH"'`.

--- a/packages/docs/src/content/docs/recipes/direnv.mdx
+++ b/packages/docs/src/content/docs/recipes/direnv.mdx
@@ -1,0 +1,22 @@
+---
+title: direnv
+description: Auto-allow .envrc in the new worktree
+sidebar:
+  order: 4
+---
+
+If your project uses [direnv](https://direnv.net) and you copy `.envrc` into worktrees, direnv blocks loading until you run `direnv allow`. Automate that:
+
+```toml
+[copy]
+files = [".envrc"]
+
+[hooks]
+post_start = ['direnv allow .']
+```
+
+`post_start` runs inside the new worktree, so a bare `.` is enough.
+
+:::caution
+`direnv allow` runs the `.envrc` with full shell privileges. Only enable this in repositories where you trust every commit on the branch you're checking out.
+:::

--- a/packages/docs/src/content/docs/recipes/index.mdx
+++ b/packages/docs/src/content/docs/recipes/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Recipes
+description: Short, copy-pasteable snippets that integrate vibe with other tools
+sidebar:
+  order: 1
+---
+
+A collection of minimal `.vibe.toml` snippets for common "I want vibe to also do X" workflows.
+
+Each recipe is intentionally small — one or two lines of TOML you can paste into your existing config. For full hook reference, see [Hooks](/configuration/hooks/).
+
+## What's here
+
+- [cmux](/recipes/cmux/) — open a cmux workspace in the new worktree
+- [tmux](/recipes/tmux/) — split a tmux pane into the new worktree
+- [direnv](/recipes/direnv/) — auto-`direnv allow` the new worktree
+
+:::tip
+Recipes only use documented environment variables (`VIBE_WORKTREE_PATH`, `VIBE_ORIGIN_PATH`) and `sh`-compatible syntax, so they work on macOS and Linux out of the box.
+:::

--- a/packages/docs/src/content/docs/recipes/tmux.mdx
+++ b/packages/docs/src/content/docs/recipes/tmux.mdx
@@ -1,0 +1,31 @@
+---
+title: tmux
+description: Split a tmux pane into the new worktree
+sidebar:
+  order: 3
+---
+
+Split the current tmux window horizontally into the new worktree's directory.
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux split-window -h -c "$VIBE_WORKTREE_PATH"']
+```
+
+The `[ -n "$TMUX" ] &&` guard makes the hook a no-op when you run `vibe start` outside of tmux, so the same config works everywhere.
+
+## Variants
+
+Open a new window instead of splitting:
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux new-window -c "$VIBE_WORKTREE_PATH"']
+```
+
+Vertical split:
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux split-window -v -c "$VIBE_WORKTREE_PATH"']
+```


### PR DESCRIPTION
## Summary

Adds a new "Recipes" section under `packages/docs/src/content/docs/recipes/` (and the Japanese mirror under `ja/recipes/`) containing minimal, copy-pasteable `.vibe.toml` snippets for integrating vibe with external tools (cmux, tmux, direnv).

The existing `configuration/hooks.mdx` "Common Patterns" section covers package-manager-flavored setups (Node/Bun/Docker/submodules). Recipes is intentionally separate and task-oriented: "I want vibe to also do X with tool Y" — each recipe is one or two lines of TOML plus a short note, not a feature reference.

Sidebar entry is added between Commands and Security via `autogenerate: { directory: "recipes" }`.

## Test Plan

- [x] `pnpm run check:docs` passes (lint / prettier / `astro check` — 0 errors, 0 warnings, 0 hints)
- [x] `pnpm -C packages/docs dev` started; verified the following pages return 200 and render the expected `<h1>` + code block:
  - `/recipes/`, `/recipes/cmux/`, `/recipes/tmux/`, `/recipes/direnv/`
  - `/ja/recipes/`, `/ja/recipes/cmux/`
- [ ] `pnpm run check:all` passes (docs-only change; relying on CI for core/video)

## Checklist

- [ ] Tests added/updated — N/A (docs only)
- [ ] `pnpm run check:all` passes — `check:docs` verified locally; full suite to be verified by CI
- [x] Docs updated (if needed)

Fixes #