### PR TITLE
chore: sync develop to main

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - name: Download artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -110,7 +110,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -138,7 +138,7 @@ jobs:
             target: bun-linux-arm64
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -177,7 +177,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -207,7 +207,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - run: echo "All builds completed successfully"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - name: Checkout
@@ -58,7 +58,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - name: Deploy to GitHub Pages

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - name: Verify release targets main branch

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - name: Verify release targets main branch
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -124,7 +124,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -194,7 +194,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - name: Verify release targets main branch
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -177,7 +177,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - name: Download artifacts
@@ -302,7 +302,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/flake.nix
+++ b/flake.nix
@@ -8,25 +8,25 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     let
-      version = "1.5.2";
+      version = "1.6.0";
 
       # Platform-specific binary names and SHA-256 hashes
       platforms = {
         x86_64-linux = {
           artifact = "vibe-linux-x64";
-          hash = "sha256-mSXqWSgChiAQGBixv1VUlnIq04EepcW/9G+IVfJoRlY=";
+          hash = "sha256-uyepiJGCOhNOaySw4v2VrWdLcO/bpjB0Ghx2/wE6ywQ=";
         };
         aarch64-linux = {
           artifact = "vibe-linux-arm64";
-          hash = "sha256-2XjspOVZCRFdxZaZ6lY+p241Q4zUUnZikR6AOUPxEqg=";
+          hash = "sha256-tqrwaeZIHcv7uRUd9CZzt7TbS1mY53RhzIpW5J0iKAU=";
         };
         x86_64-darwin = {
           artifact = "vibe-darwin-x64";
-          hash = "sha256-TZjIzq/8mpzyhTV3W4CHd0wJeyr2rmLWpMpJsPBtaz4=";
+          hash = "sha256-dvMNWQlv/jFPnNXaJVfJ0qQcCBF+x2MrpF5aEei2Fz4=";
         };
         aarch64-darwin = {
           artifact = "vibe-darwin-arm64";
-          hash = "sha256-1RvE+9O+wuhg87BZFACt/eUdHXPQj2YmsDGQM6NBT8o=";
+          hash = "sha256-OBWXsztaefIP21y2pDYJYXY7KqXNs9D8bGPJB2qJ6pA=";
         };
       };
     in

--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -86,6 +86,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           autogenerate: { directory: "commands" },
         },
         {
+          label: "Recipes",
+          translations: { ja: "レシピ集" },
+          autogenerate: { directory: "recipes" },
+        },
+        {
           label: "Security",
           translations: { ja: "セキュリティ" },
           autogenerate: { directory: "security" },

--- a/packages/docs/src/content/docs/ja/recipes/cmux.mdx
+++ b/packages/docs/src/content/docs/ja/recipes/cmux.mdx
@@ -1,0 +1,20 @@
+---
+title: cmux
+description: 新しいWorktreeでcmuxワークスペースを開く
+sidebar:
+  order: 2
+---
+
+作成したばかりのWorktreeを指す[cmux](https://github.com/kexi/cmux)ワークスペースを新規に開きます。
+
+```toml
+[hooks]
+post_start = ['cmux new-workspace --cwd "$VIBE_WORKTREE_PATH"']
+```
+
+これだけで、`vibe start`のたびにWorktreeパスがcmuxに渡されます。
+
+## 注意点
+
+- `post_start`は新しいWorktree**内**で実行されるため、`--cwd "$VIBE_WORKTREE_PATH"`は厳密には冗長ですが、後で別のフックフェーズに移したときに動作を明確にしておくために残してあります。
+- 非対話シェルの`PATH`にcmuxがない場合は絶対パスを指定してください: `'/usr/local/bin/cmux new-workspace --cwd "$VIBE_WORKTREE_PATH"'`

--- a/packages/docs/src/content/docs/ja/recipes/direnv.mdx
+++ b/packages/docs/src/content/docs/ja/recipes/direnv.mdx
@@ -1,0 +1,22 @@
+---
+title: direnv
+description: 新しいWorktreeで.envrcを自動許可する
+sidebar:
+  order: 4
+---
+
+プロジェクトで[direnv](https://direnv.net)を使っていてWorktreeに`.envrc`をコピーしている場合、direnvは`direnv allow`を実行するまで読み込みをブロックします。これを自動化します:
+
+```toml
+[copy]
+files = [".envrc"]
+
+[hooks]
+post_start = ['direnv allow .']
+```
+
+`post_start`は新しいWorktree内で実行されるため、`.`だけで十分です。
+
+:::caution
+`direnv allow`はシェルの完全な権限で`.envrc`を実行します。チェックアウトするブランチのすべてのコミットを信頼できるリポジトリでのみ有効化してください。
+:::

--- a/packages/docs/src/content/docs/ja/recipes/index.mdx
+++ b/packages/docs/src/content/docs/ja/recipes/index.mdx
@@ -1,0 +1,20 @@
+---
+title: レシピ集
+description: vibeと他ツールを連携させるための短いコピペ可能なスニペット集
+sidebar:
+  order: 1
+---
+
+「vibeで○○もやりたい」というよくあるワークフロー向けの、最小限の`.vibe.toml`スニペット集です。
+
+各レシピは意図的に小さく、既存の設定にそのままコピペできる1〜2行のTOMLで構成されています。フックの完全なリファレンスは [フック](/ja/configuration/hooks/) を参照してください。
+
+## ラインナップ
+
+- [cmux](/ja/recipes/cmux/) — 新しいWorktreeでcmuxワークスペースを開く
+- [tmux](/ja/recipes/tmux/) — tmuxペインを新しいWorktreeに分割する
+- [direnv](/ja/recipes/direnv/) — 新しいWorktreeで自動的に`direnv allow`する
+
+:::tip
+レシピで使うのは公式の環境変数（`VIBE_WORKTREE_PATH`、`VIBE_ORIGIN_PATH`）と`sh`互換構文のみなので、macOSとLinuxでそのまま動作します。
+:::

--- a/packages/docs/src/content/docs/ja/recipes/tmux.mdx
+++ b/packages/docs/src/content/docs/ja/recipes/tmux.mdx
@@ -1,0 +1,31 @@
+---
+title: tmux
+description: tmuxペインを新しいWorktreeに分割する
+sidebar:
+  order: 3
+---
+
+現在のtmuxウィンドウを水平分割し、新しいWorktreeのディレクトリで開きます。
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux split-window -h -c "$VIBE_WORKTREE_PATH"']
+```
+
+`[ -n "$TMUX" ] &&` のガードがあるので、tmuxの外で`vibe start`を実行した場合はフックが何もしません。同じ設定がどこでも動きます。
+
+## バリエーション
+
+分割ではなく新しいウィンドウを開く場合:
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux new-window -c "$VIBE_WORKTREE_PATH"']
+```
+
+垂直分割の場合:
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux split-window -v -c "$VIBE_WORKTREE_PATH"']
+```

--- a/packages/docs/src/content/docs/recipes/cmux.mdx
+++ b/packages/docs/src/content/docs/recipes/cmux.mdx
@@ -1,0 +1,20 @@
+---
+title: cmux
+description: Open a cmux workspace in the new worktree
+sidebar:
+  order: 2
+---
+
+Open a new [cmux](https://github.com/kexi/cmux) workspace pointing at the freshly created worktree.
+
+```toml
+[hooks]
+post_start = ['cmux new-workspace --cwd "$VIBE_WORKTREE_PATH"']
+```
+
+That's it — every `vibe start` will hand the worktree path to cmux.
+
+## Notes
+
+- `post_start` runs **inside** the new worktree, so `--cwd "$VIBE_WORKTREE_PATH"` is technically redundant but keeps the command unambiguous if you later move it to a different hook phase.
+- If cmux is not on your `PATH` in non-interactive shells, use an absolute path: `'/usr/local/bin/cmux new-workspace --cwd "$VIBE_WORKTREE_PATH"'`.

--- a/packages/docs/src/content/docs/recipes/direnv.mdx
+++ b/packages/docs/src/content/docs/recipes/direnv.mdx
@@ -1,0 +1,22 @@
+---
+title: direnv
+description: Auto-allow .envrc in the new worktree
+sidebar:
+  order: 4
+---
+
+If your project uses [direnv](https://direnv.net) and you copy `.envrc` into worktrees, direnv blocks loading until you run `direnv allow`. Automate that:
+
+```toml
+[copy]
+files = [".envrc"]
+
+[hooks]
+post_start = ['direnv allow .']
+```
+
+`post_start` runs inside the new worktree, so a bare `.` is enough.
+
+:::caution
+`direnv allow` runs the `.envrc` with full shell privileges. Only enable this in repositories where you trust every commit on the branch you're checking out.
+:::

--- a/packages/docs/src/content/docs/recipes/index.mdx
+++ b/packages/docs/src/content/docs/recipes/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Recipes
+description: Short, copy-pasteable snippets that integrate vibe with other tools
+sidebar:
+  order: 1
+---
+
+A collection of minimal `.vibe.toml` snippets for common "I want vibe to also do X" workflows.
+
+Each recipe is intentionally small — one or two lines of TOML you can paste into your existing config. For full hook reference, see [Hooks](/configuration/hooks/).
+
+## What's here
+
+- [cmux](/recipes/cmux/) — open a cmux workspace in the new worktree
+- [tmux](/recipes/tmux/) — split a tmux pane into the new worktree
+- [direnv](/recipes/direnv/) — auto-`direnv allow` the new worktree
+
+:::tip
+Recipes only use documented environment variables (`VIBE_WORKTREE_PATH`, `VIBE_ORIGIN_PATH`) and `sh`-compatible syntax, so they work on macOS and Linux out of the box.
+:::

--- a/packages/docs/src/content/docs/recipes/tmux.mdx
+++ b/packages/docs/src/content/docs/recipes/tmux.mdx
@@ -1,0 +1,31 @@
+---
+title: tmux
+description: Split a tmux pane into the new worktree
+sidebar:
+  order: 3
+---
+
+Split the current tmux window horizontally into the new worktree's directory.
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux split-window -h -c "$VIBE_WORKTREE_PATH"']
+```
+
+The `[ -n "$TMUX" ] &&` guard makes the hook a no-op when you run `vibe start` outside of tmux, so the same config works everywhere.
+
+## Variants
+
+Open a new window instead of splitting:
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux new-window -c "$VIBE_WORKTREE_PATH"']
+```
+
+Vertical split:
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux split-window -v -c "$VIBE_WORKTREE_PATH"']
+```


### PR DESCRIPTION
## Summary

Promotes the current `develop` to `main` without a version bump. Picks up docs and chore changes accumulated since v1.6.0.

## Changes

- docs: add Recipes section with cmux / tmux / direnv integration snippets (#464)
- chore(deps): bump `step-security/harden-runner` 2.19.1 → 2.19.3 (#463)
- chore: update Nix flake to 1.6.0 (#462)

## Test Plan

- [x] All upstream PRs (#462, #463, #464) merged green into develop
- [ ] CI on this PR passes before merge

## Checklist

- [x] Tests added/updated — N/A (docs/chore only)
- [ ] `pnpm run check:all` passes (verified per-PR on develop; relying on CI here)
- [x] Docs updated (if needed)

Fixes #