### PR TITLE
test: verify Socket Security app (do not merge)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
+    "tiny-invariant": "^1.3.3",
     "tsdown": "^0.20.1",
     "typescript": "^5.7.2"
   },


### PR DESCRIPTION
## Purpose

Throwaway PR to verify the Socket Security GitHub App (installed ~minutes ago) posts a dependency review comment when a PR touches `package.json`.

## Change

- `packages/core/package.json`: add `tiny-invariant` as devDep

## Expected

- `socket-security` bot comments with a dependency analysis table
- A `Socket Security` check appears in the checks list

## Notes

- Lockfile **not** updated due to unrelated pnpm `trustPolicy: no-downgrade` failures on existing transitive deps (`undici-types`, `vite`). CI will fail on `--frozen-lockfile`; this is fine for the test.
- Will be **closed without merging** once Socket's behavior is observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)