### PR TITLE
feat: build vibe from source in Nix (default) with CI and docs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,9 +3,19 @@ name: Nix
 on:
   push:
     branches: [main, develop]
-    paths:
+    paths: &nix-paths
       - "flake.nix"
       - "flake.lock"
+      # The source build compiles these, so changes here can break it.
+      - "packages/native/**"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - ".github/workflows/nix.yml"
+  # Also run on PRs so a stale pnpm hash or a native-crate change that breaks
+  # the source build is caught before merge, not only on the post-merge push.
+  pull_request:
+    branches: [main, develop]
+    paths: *nix-paths
 
 jobs:
   nix-build:
@@ -25,8 +35,24 @@ jobs:
       - name: Check flake
         run: nix flake check
 
-      - name: Build
-        run: nix build
+      - name: Build native module from source
+        run: nix build .#vibe-native
+
+      - name: Build from source
+        run: nix build .#fromSource
 
       - name: Smoke test
         run: ./result/bin/vibe --help
+
+      # ubuntu-latest is FHS, so `--help` succeeds even if the binary kept a
+      # non-Nix interpreter — which would fail on NixOS. Assert the interpreter
+      # was patched into the Nix store so the NixOS failure mode can't pass
+      # silently.
+      - name: Assert Nix-store ELF interpreter
+        run: |
+          interp=$(nix run nixpkgs#patchelf -- --print-interpreter result/bin/vibe)
+          echo "interpreter: $interp"
+          case "$interp" in
+            /nix/store/*) echo "OK: interpreter is in the Nix store" ;;
+            *) echo "::error::ELF interpreter is not in /nix/store ($interp); the binary would not run on NixOS"; exit 1 ;;
+          esac

--- a/flake.nix
+++ b/flake.nix
@@ -10,23 +10,30 @@
     let
       version = "1.6.0";
 
-      # Platform-specific binary names and SHA-256 hashes
+      # Platform-specific metadata.
+      # - artifact/hash: prebuilt release binary (packages.default)
+      # - napiNode: filename the runtime's literal require() expects for the
+      #   N-API native module (see packages/core/src/runtime/node/native.ts)
       platforms = {
         x86_64-linux = {
           artifact = "vibe-linux-x64";
           hash = "sha256-uyepiJGCOhNOaySw4v2VrWdLcO/bpjB0Ghx2/wE6ywQ=";
+          napiNode = "vibe-native.linux-x64-gnu.node";
         };
         aarch64-linux = {
           artifact = "vibe-linux-arm64";
           hash = "sha256-tqrwaeZIHcv7uRUd9CZzt7TbS1mY53RhzIpW5J0iKAU=";
+          napiNode = "vibe-native.linux-arm64-gnu.node";
         };
         x86_64-darwin = {
           artifact = "vibe-darwin-x64";
           hash = "sha256-dvMNWQlv/jFPnNXaJVfJ0qQcCBF+x2MrpF5aEei2Fz4=";
+          napiNode = "vibe-native.darwin-x64.node";
         };
         aarch64-darwin = {
           artifact = "vibe-darwin-arm64";
           hash = "sha256-OBWXsztaefIP21y2pDYJYXY7KqXNs9D8bGPJB2qJ6pA=";
+          napiNode = "vibe-native.darwin-arm64.node";
         };
       };
     in
@@ -35,9 +42,190 @@
         pkgs = nixpkgs.legacyPackages.${system};
         platformInfo = platforms.${system};
         isLinux = pkgs.lib.hasSuffix "-linux" system;
+
+        # ---- Source build (nixpkgs-style: compile everything from source) ----
+
+        # Pin pnpm to the repo's own version (package.json `packageManager`).
+        # nixpkgs' pnpm_10 (10.33.4) writes the newer v11 store (a binary
+        # `index.db`), which nixpkgs fetchPnpmDeps only round-trips correctly at
+        # fetcherVersion >= 4 (unavailable here, max 3); the result is a mangled
+        # index and ERR_PNPM_NO_OFFLINE_TARBALL at build time. 10.26.2 writes the
+        # v10 store that fetcherVersion 3 handles, and matches the lockfile.
+        pnpmPinned = pkgs.pnpm_10.override {
+          version = "10.26.2";
+          hash = "sha256-Y7UKS6Fc3iAAbdul2eIf1iPiPwlMn2O7FfaGsOSWrtY=";
+        };
+
+        # N-API native module (Copy-on-Write clone helpers). napi-rs emits a
+        # cdylib that the runtime loads as `<napiNode>`; we build the crate with
+        # plain cargo (napi-build sets the link flags) and rename the resulting
+        # shared object to the name the runtime's literal require() expects.
+        vibe-native = pkgs.rustPlatform.buildRustPackage {
+          pname = "vibe-native";
+          version = "0.12.0"; # packages/native/Cargo.toml
+          src = ./packages/native;
+          cargoLock.lockFile = ./packages/native/Cargo.lock;
+
+          # No Rust tests are meant to run without a Node host.
+          doCheck = false;
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out
+            lib=$(find . \( -name 'libvibe_native.so' -o -name 'libvibe_native.dylib' \) -type f | head -n1)
+            if [ -z "$lib" ]; then
+              echo "vibe-native: built shared object not found" >&2
+              exit 1
+            fi
+            cp "$lib" "$out/${platformInfo.napiNode}"
+            runHook postInstall
+          '';
+        };
+
+        # Deterministic stand-in for scripts/build.ts version generation, which
+        # shells out to git (unavailable in the sandbox) and stamps a wall-clock
+        # build time (non-reproducible). The commit comes from the flake's own
+        # revision instead of git, preserving the `<version>+<commit>` provenance
+        # that scripts/build.ts produces.
+        commitRev = self.shortRev or self.dirtyShortRev or "unknown";
+        versionFile = pkgs.writeText "version.ts" ''
+          // This file is provided by the Nix build (see flake.nix).
+          export interface BuildInfo {
+            version: string;
+            repository: string;
+            platform: string;
+            arch: string;
+            target: string;
+            distribution: string;
+            buildTime: string;
+            buildEnv: string;
+          }
+
+          export const BUILD_INFO: BuildInfo = {
+            version: "${version}+${commitRev}",
+            repository: "git+https://github.com/kexi/vibe.git",
+            platform: "${if isLinux then "linux" else "darwin"}",
+            arch: "${if pkgs.lib.hasPrefix "x86_64" system then "x64" else "arm64"}",
+            target: "${system}",
+            distribution: "nix",
+            buildTime: "",
+            buildEnv: "nix",
+          };
+
+          // Backwards compatibility
+          export const VERSION = BUILD_INFO.version;
+          export const REPOSITORY_URL = BUILD_INFO.repository;
+        '';
+
+        # pnpm-workspace.yaml carries supply-chain policies (trustPolicy,
+        # minimumReleaseAge) that re-verify packages against the npm registry at
+        # install time. They depend on wall-clock time and live registry trust
+        # state, so inside the pure build sandbox they are non-deterministic and
+        # fail the fixed-output pnpm fetch (the host pnpm cache that masks this
+        # locally is not visible). Integrity for the Nix build is instead pinned
+        # by the fetch output hash + the frozen lockfile, so strip just those two
+        # registry-time policies from a build-only copy of the source, shared by
+        # both the fetch and the compile so they stay consistent.
+        nixSrc = pkgs.runCommandLocal "vibe-src" { } ''
+          cp -r ${self} $out
+          chmod -R +w $out
+          ${pkgs.yq-go}/bin/yq -i \
+            'del(.trustPolicy) | del(.minimumReleaseAge) | del(.minimumReleaseAgeExclude)' \
+            $out/pnpm-workspace.yaml
+        '';
+
+        vibe-source = pkgs.stdenv.mkDerivation (finalAttrs: {
+          pname = "vibe";
+          inherit version;
+          src = nixSrc;
+
+          # The CLI binary only needs the root project (main.ts) and
+          # @kexi/vibe-core; the other workspaces (docs/video/e2e) pull in heavy,
+          # platform-specific trees (astro, remotion, pagefind) that bloat and
+          # destabilise the fetch without contributing to the binary. Restrict
+          # both the fetch and the offline install to just these two projects.
+          pnpmWorkspaces = [
+            "vibe-monorepo"
+            "@kexi/vibe-core"
+          ];
+
+          pnpmDeps = pkgs.fetchPnpmDeps {
+            inherit (finalAttrs)
+              pname
+              version
+              src
+              pnpmWorkspaces
+              ;
+            pnpm = pnpmPinned;
+            fetcherVersion = 3;
+            hash = "sha256-RPW842JniDhnnpPiU+n+LP3LovZHnsamVN/RmDmxyyQ=";
+          };
+
+          nativeBuildInputs = [
+            pkgs.bun
+            pkgs.nodejs_24
+            pnpmPinned
+            pkgs.pnpmConfigHook
+          ]
+          # `bun build --compile` copies the (Nix-patched) bun runtime as the
+          # base executable, but the result and the embedded N-API module still
+          # need their ELF interpreter/rpath rewritten to Nix store paths, or
+          # they fail to start on NixOS (no FHS /lib64/ld-linux). Mirror what
+          # packages.binary does for the downloaded binary.
+          ++ pkgs.lib.optionals isLinux [ pkgs.autoPatchelfHook ];
+
+          buildInputs = pkgs.lib.optionals isLinux [
+            pkgs.stdenv.cc.cc.lib
+          ];
+
+          preBuild = ''
+            # Drop the prebuilt N-API module where the literal require() in
+            # packages/core/src/runtime/node/native.ts looks for it, so that
+            # `bun build --compile` statically embeds it into the binary.
+            cp ${vibe-native}/${platformInfo.napiNode} packages/native/${platformInfo.napiNode}
+
+            # Deterministic version.ts instead of the git/timestamp generator.
+            cp ${versionFile} packages/core/src/version.ts
+          '';
+
+          buildPhase = ''
+            runHook preBuild
+            export HOME=$TMPDIR
+            export SHARP_IGNORE_GLOBAL_LIBVIPS=1
+            bun build --compile --minify --outfile vibe main.ts
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 vibe $out/bin/vibe
+            runHook postInstall
+          '';
+
+          # The output is a self-contained Bun executable; stripping corrupts it.
+          dontStrip = true;
+
+          meta = with pkgs.lib; {
+            description = "Git worktree helper CLI";
+            homepage = "https://github.com/kexi/vibe";
+            license = licenses.asl20;
+            platforms = builtins.attrNames platforms;
+            mainProgram = "vibe";
+          };
+        });
       in
       {
-        packages.default = pkgs.stdenv.mkDerivation {
+        # Default to the source build: it is reproducible and avoids the
+        # per-release SHA-256 churn the prebuilt binary needs. `fromSource` is
+        # kept as an explicit alias for clarity and CI.
+        packages.default = vibe-source;
+        packages.fromSource = vibe-source;
+        packages.vibe-native = vibe-native;
+
+        # Prebuilt release binary (fast path; skips compiling). Requires the
+        # per-platform hashes above to be bumped on every release, so it is no
+        # longer the default.
+        packages.binary = pkgs.stdenv.mkDerivation {
           pname = "vibe";
           inherit version;
 
@@ -61,7 +249,7 @@
           '';
 
           meta = with pkgs.lib; {
-            description = "Git worktree helper CLI";
+            description = "Git worktree helper CLI (prebuilt release binary)";
             homepage = "https://github.com/kexi/vibe";
             license = licenses.asl20;
             platforms = builtins.attrNames platforms;

--- a/packages/docs/src/content/docs/installation.mdx
+++ b/packages/docs/src/content/docs/installation.mdx
@@ -85,7 +85,13 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     ```
 
     :::note
-    The Nix package installs pre-built binaries from GitHub Releases, verified with SHA-256 hashes.
+    The default package (`packages.default` / `.#fromSource`) is built from
+    source for reproducibility. If you prefer the prebuilt release binary
+    (skips compiling, verified with SHA-256 hashes), use `packages.binary`:
+
+    ```bash frame="terminal"
+    nix run github:kexi/vibe#binary -- start feat/my-feature
+    ```
     :::
 
   </TabItem>

--- a/packages/docs/src/content/docs/ja/installation.mdx
+++ b/packages/docs/src/content/docs/ja/installation.mdx
@@ -85,7 +85,13 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     ```
 
     :::note
-    NixパッケージはGitHub Releasesのビルド済みバイナリをSHA-256ハッシュで検証してインストールします。
+    デフォルトパッケージ（`packages.default` / `.#fromSource`）は再現性のため
+    ソースからビルドされます。ビルド済みのリリースバイナリ（コンパイル不要、
+    SHA-256ハッシュで検証）を使いたい場合は `packages.binary` を指定します：
+
+    ```bash frame="terminal"
+    nix run github:kexi/vibe#binary -- start feat/my-feature
+    ```
     :::
 
   </TabItem>


### PR DESCRIPTION
## Summary

- Build the Nix package from source instead of fetching a prebuilt release binary, so `packages.default` is reproducible and no longer needs four per-platform SHA-256 hashes bumped each release. The prebuilt binary stays available as `packages.binary`.
- The source build compiles the napi-rs Rust crate (`vibe-native`), provides `node_modules` offline via `fetchPnpmDeps`, and `bun build --compile`s the self-contained executable; `version.ts` is generated deterministically (flake revision, no wall-clock time).
- On Linux the binary and its embedded N-API module are run through `autoPatchelfHook` so they start on NixOS (no FHS `/lib64/ld-linux`); CI asserts the ELF interpreter resolves under `/nix/store` so a non-Nix interpreter can't pass silently.
- pnpm is pinned to the repo's `10.26.2`: nixpkgs' `pnpm_10` (10.33.4) writes the v11 store (binary `index.db`) that `fetchPnpmDeps` only handles at fetcherVersion ≥ 4, which this nixpkgs lacks; 10.26.2 writes the v10 store fetcherVersion 3 supports. The fetch is scoped to the root + `@kexi/vibe-core` workspaces (all the CLI needs).
- CI (`nix.yml`) builds `.#vibe-native` and `.#fromSource`, smoke-tests the binary, and runs on `pull_request` as well as push. Docs (`installation.mdx`, en/ja) explain the source-build default and the `#binary` fast path.

> In-repo only. Submitting to the official nixpkgs tree (`pkgs/by-name/vi/vibe/package.nix`) is separate and out of scope here.

## Test plan

- [x] `nix-build` CI job green on Linux: flake check, `vibe-native`, `fromSource`, smoke test, and the `/nix/store` interpreter assertion all pass
- [x] `nix build .#binary` still works (prebuilt fast path)
- [x] `nix flake check` evaluates for all four systems (linux/darwin × x64/arm64)
- [x] `pnpm run check:docs` passes (lint / prettier / astro check)