### PR TITLE
chore: release v1.7.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/kexi/vibe",
   "exports": "./main.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-monorepo",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "type": "module",
   "description": "Monorepo for vibe CLI - Git worktree management tool",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-core",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Core components for Vibe - Runtime abstraction, types, errors, and context",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/docs/src/content/docs/changelog.mdx
+++ b/packages/docs/src/content/docs/changelog.mdx
@@ -5,6 +5,20 @@ description: Version history and release notes for vibe
 
 All notable changes to vibe are documented here.
 
+## v1.7.0
+
+**Released:** 2026-05-31
+
+### Added
+
+- Recipes documentation for integrating vibe with external tools — [tmux](/recipes/tmux/), [cmux](/recipes/cmux/), and [direnv](/recipes/direnv/). See the [Recipes](/recipes/) overview.
+
+### Changed
+
+- The Nix flake's default package (`nix run github:kexi/vibe`, `nix profile install github:kexi/vibe`) now builds vibe from source for a reproducible install instead of fetching a prebuilt release binary. If you prefer the prebuilt fast path, use the `#binary` output (e.g. `nix run github:kexi/vibe#binary`). See [Installation → Nix](/installation/).
+
+---
+
 ## v1.6.0
 
 **Released:** 2026-05-16

--- a/packages/docs/src/content/docs/ja/changelog.mdx
+++ b/packages/docs/src/content/docs/ja/changelog.mdx
@@ -5,6 +5,20 @@ description: vibeのバージョン履歴とリリースノート
 
 vibeの主要な変更はここに記録されています。
 
+## v1.7.0
+
+**リリース日:** 2026年5月31日
+
+### 追加
+
+- 外部ツールと vibe を連携させるためのレシピ集ドキュメントを追加しました — [tmux](/ja/recipes/tmux/)、[cmux](/ja/recipes/cmux/)、[direnv](/ja/recipes/direnv/)。概要は [レシピ集](/ja/recipes/) を参照。
+
+### 変更
+
+- Nix flake のデフォルトパッケージ（`nix run github:kexi/vibe`、`nix profile install github:kexi/vibe`）が、ビルド済みリリースバイナリを取得する代わりに、再現可能なインストールのためにソースから vibe をビルドするようになりました。ビルド済みの高速パスを使いたい場合は `#binary` 出力を利用してください（例: `nix run github:kexi/vibe#binary`）。詳細は [インストール → Nix](/ja/installation/) を参照。
+
+---
+
 ## v1.6.0
 
 **リリース日:** 2026年5月16日

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-native",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Native clone operations for vibe CLI (clonefile on macOS, FICLONE on Linux)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Git worktree helper CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Release version 1.7.0

User-facing changes since v1.6.0:

- **Added**: Recipes documentation for integrating vibe with external tools (tmux, cmux, direnv) (#464)
- **Changed**: The Nix flake default package now builds vibe from source for a reproducible install; the prebuilt binary is available via the `#binary` output (#469)

## Checklist

- [x] Version updated in package.json
- [x] Version synced to all package.json files
- [x] Changelog updated (packages/docs/src/content/docs/changelog.mdx + ja)
- [ ] CI checks passing

---

After merging this PR:
1. Create a PR from `develop` to `main`
2. Merge the `develop` → `main` PR
3. Create a GitHub Release with tag `v1.7.0`
4. CI will automatically publish to npm and JSR