### PR TITLE
fix: scope Nix flake version bump to the release line only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,8 +345,11 @@ jobs:
           fi
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Replace version (works for both placeholder and real values)
-          sed -i "s/version = \".*\"/version = \"$VERSION\"/" flake.nix
+          # Bump only the top-level release version. Anchored to its marker
+          # comment so the `version = "..."` pins below it (pnpm, vibe-native)
+          # are never clobbered — a blanket s/version = ".*"/ rewrote all three
+          # and broke the source build (pnpm fetched at the release version).
+          sed -i -E "s|^( *version = )\"[^\"]*\"(; # release version.*)$|\1\"$VERSION\"\2|" flake.nix
 
           # Replace hashes using artifact name as anchor (works for both placeholder and real SRI hashes)
           sed -i '/vibe-linux-x64/,/};/s|hash = ".*"|hash = "${{ steps.hashes.outputs.linux_x64 }}"|' flake.nix

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     let
-      version = "1.6.0";
+      version = "1.7.0"; # release version; bumped by .github/workflows/release.yml (update-nix)
 
       # Platform-specific metadata.
       # - artifact/hash: prebuilt release binary (packages.default)
@@ -17,22 +17,22 @@
       platforms = {
         x86_64-linux = {
           artifact = "vibe-linux-x64";
-          hash = "sha256-uyepiJGCOhNOaySw4v2VrWdLcO/bpjB0Ghx2/wE6ywQ=";
+          hash = "sha256-MoBfXYFdAuSwZEoVeomfnT04w8eyWiQ1snmrF9BOEfQ=";
           napiNode = "vibe-native.linux-x64-gnu.node";
         };
         aarch64-linux = {
           artifact = "vibe-linux-arm64";
-          hash = "sha256-tqrwaeZIHcv7uRUd9CZzt7TbS1mY53RhzIpW5J0iKAU=";
+          hash = "sha256-iZub4Sum4Uh/oQFksN0xeGDPDNECiPCRW3XJZ5lMMhQ=";
           napiNode = "vibe-native.linux-arm64-gnu.node";
         };
         x86_64-darwin = {
           artifact = "vibe-darwin-x64";
-          hash = "sha256-dvMNWQlv/jFPnNXaJVfJ0qQcCBF+x2MrpF5aEei2Fz4=";
+          hash = "sha256-X3QQjSGZa4zbt2UA3FLkIAZwnCljdRUqXso7J/g6HEc=";
           napiNode = "vibe-native.darwin-x64.node";
         };
         aarch64-darwin = {
           artifact = "vibe-darwin-arm64";
-          hash = "sha256-OBWXsztaefIP21y2pDYJYXY7KqXNs9D8bGPJB2qJ6pA=";
+          hash = "sha256-CQltgfWBj+DnsIZcF7VII4Omo8GxbuWLSWcawPiFeuE=";
           napiNode = "vibe-native.darwin-arm64.node";
         };
       };


### PR DESCRIPTION
## Summary

The v1.7.0 release's `update-nix` job failed and the Nix flake never advanced past 1.6.0. Two fixes:

1. **Workflow** — `update-nix` bumped the version with a blanket `sed s/version = ".*"/.../`. After #469 added the source build, `flake.nix` has **three** `version = "..."` lines (vibe `1.x`, pnpm pin `10.26.2`, vibe-native `0.12.0`). The blanket sed rewrote all three, so the build fetched `pnpm@1.7.0` against pnpm 10.26.2's hash → fixed-output hash mismatch. Now anchored to a marker comment on the release-version line.
2. **flake.nix** — manually brought to 1.7.0 (version + 4 prebuilt-binary SRI hashes), since the failed job never opened its PR.

## Notes

- The `pnpmDeps` hash is **unchanged** — a version bump does not change which dependencies pnpm fetches.
- Verified locally:
  - `nix build .#fromSource` → builds, `vibe --version` → `1.7.0`
  - `nix build .#binary` → downloads v1.7.0 asset, `vibe --version` → `1.7.0`
- Root cause traces to #469 (source build added the extra `version =` pins that the pre-existing sed predated).

## Test plan

- [x] `pnpm run check:all`
- [x] `nix build .#fromSource` + run
- [x] `nix build .#binary` + run
- [ ] CI `nix-build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)