### PR TITLE
refactor: derive Nix flake version from package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,7 +333,7 @@ jobs:
             echo "${key}=${sri}" >> "$GITHUB_OUTPUT"
           done
 
-      - name: Update flake.nix
+      - name: Update flake.nix binary hashes
         id: version
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -345,23 +345,17 @@ jobs:
           fi
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Bump only the top-level release version. Anchored to its marker
-          # comment so the `version = "..."` pins below it (pnpm, vibe-native)
-          # are never clobbered — a blanket s/version = ".*"/ rewrote all three
-          # and broke the source build (pnpm fetched at the release version).
-          sed -i -E "s|^( *version = )\"[^\"]*\"(; # release version.*)$|\1\"$VERSION\"\2|" flake.nix
-
-          # Replace hashes using artifact name as anchor (works for both placeholder and real SRI hashes)
+          # flake.nix derives `version` from package.json, so there is no version
+          # line to bump here. Only the prebuilt-binary SRI hashes need updating,
+          # and they are unknowable until the release assets exist (post-tag) —
+          # that is why this job runs after release rather than in the release PR.
+          # Anchor each replace on its artifact name so the pnpm/native version
+          # pins are never touched (a blanket s/version = ".*"/ once clobbered all
+          # three and broke the source build).
           sed -i '/vibe-linux-x64/,/};/s|hash = ".*"|hash = "${{ steps.hashes.outputs.linux_x64 }}"|' flake.nix
           sed -i '/vibe-linux-arm64/,/};/s|hash = ".*"|hash = "${{ steps.hashes.outputs.linux_arm64 }}"|' flake.nix
           sed -i '/vibe-darwin-x64/,/};/s|hash = ".*"|hash = "${{ steps.hashes.outputs.darwin_x64 }}"|' flake.nix
           sed -i '/vibe-darwin-arm64/,/};/s|hash = ".*"|hash = "${{ steps.hashes.outputs.darwin_arm64 }}"|' flake.nix
-
-          # Verify version was updated
-          if ! grep -q "version = \"$VERSION\"" flake.nix; then
-            echo "Error: Version was not updated correctly"
-            exit 1
-          fi
 
       - name: Update flake.lock
         run: nix flake lock --update-input nixpkgs --update-input flake-utils

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,14 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     let
-      version = "1.7.0"; # release version; bumped by .github/workflows/release.yml (update-nix)
+      # Single source of truth: read the release version from package.json at
+      # eval time instead of hardcoding it here. A literal duplicate drifts out
+      # of sync — the release tag pointed at a commit whose flake.nix still said
+      # the previous version, so a source build / `#binary` from that tag built
+      # the wrong version. Deriving it means flake.nix is correct at every
+      # commit and tag with no release-time bump. (pnpm/native pins below are
+      # tool versions, deliberately independent of the release version.)
+      version = (builtins.fromJSON (builtins.readFile ./package.json)).version;
 
       # Platform-specific metadata.
       # - artifact/hash: prebuilt release binary (packages.default)


### PR DESCRIPTION
## Summary

Eliminates the dual maintenance of the release version (flake.nix literal vs `package.json`) that caused the v1.7.0 release tag to carry a stale `flake.nix` (version 1.6.0). Follow-up to #472, adopting the more idiomatic "single source of truth" pattern.

### Problem

`flake.nix` hardcoded `version = "x.y.z"`. The `update-nix` job bumped it **after** release and **only on develop**, so the release tag (on `main`) always pointed at a commit whose `flake.nix` named the *previous* version → a source build / `#binary` from that tag built the wrong version. #469 worsened the risk by adding two more `version = "..."` pins (pnpm `10.26.2`, vibe-native `0.12.0`) that a blanket bump could clobber (the actual v1.7.0 failure).

### Fix

- **flake.nix** — derive the version at eval time:
  ```nix
  version = (builtins.fromJSON (builtins.readFile ./package.json)).version;
  ```
  Now `flake.nix` is correct at **every commit and tag** with no release-time bump, and the pnpm/native tool-version pins can never be clobbered.
- **release.yml `update-nix`** — drop the version `sed` (and its verify-grep); it now only refreshes the prebuilt-binary SRI hashes, which are genuinely unknowable until the post-tag release assets exist.

### Why this over syncing flake.nix in the release PR

Deriving removes the second source entirely — no `sed`, no marker, no `--check`, no chance of drift. Matches how most non-nixpkgs flakes handle version (read from `Cargo.toml` / `package.json`).

### Residual (acceptable, undocumented path)

`#binary` pinned to a *tag* still carries that tag's binary hashes (refreshed on develop post-release), so it would fail loudly with a hash mismatch until the next release syncs main. All documented install paths use `github:kexi/vibe` (default branch = develop) and are always correct.

## Test plan

- [x] `pnpm run check:all`
- [x] `nix eval` → derived version `1.7.0`
- [x] `nix build .#fromSource` → `vibe --version` = `1.7.0`
- [x] `nix build .#binary` → `vibe --version` = `1.7.0`
- [ ] CI `nix-build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)