### PR TITLE
feat: add robocopy copy strategy for Windows

### DIFF
--- a/packages/core/src/utils/copy/copy.test.ts
+++ b/packages/core/src/utils/copy/copy.test.ts
@@ -11,6 +11,7 @@ import {
 import { StandardStrategy } from "./strategies/standard.ts";
 import { CloneStrategy } from "./strategies/clone.ts";
 import { RsyncStrategy } from "./strategies/rsync.ts";
+import { RobocopyStrategy } from "./strategies/robocopy.ts";
 import { validatePath } from "./validation.ts";
 import { setupRealTestContext } from "../../context/testing.ts";
 
@@ -102,6 +103,76 @@ describe("RsyncStrategy", () => {
   });
 });
 
+describe("RobocopyStrategy", () => {
+  it("name is robocopy", () => {
+    const strategy = new RobocopyStrategy();
+    expect(strategy.name).toBe("robocopy");
+  });
+
+  it("is unavailable on non-Windows platforms", async () => {
+    resetState();
+    const isWindows = process.platform === "win32";
+    if (isWindows) return;
+
+    const strategy = new RobocopyStrategy();
+    expect(await strategy.isAvailable()).toBe(false);
+  });
+});
+
+// Robocopy only runs on Windows; gate the real-copy assertions accordingly.
+describe.skipIf(process.platform !== "win32")("RobocopyStrategy (Windows)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    resetState();
+    tempDir = await mkdtemp(join(tmpdir(), "vibe-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("is available", async () => {
+    const strategy = new RobocopyStrategy();
+    expect(await strategy.isAvailable()).toBe(true);
+  });
+
+  it("copies directory contents into dest", async () => {
+    const srcDir = join(tempDir, "source");
+    const destDir = join(tempDir, "dest");
+
+    await mkdir(srcDir);
+    await writeFile(join(srcDir, "file1.txt"), "content1");
+    await mkdir(join(srcDir, "nested"));
+    await writeFile(join(srcDir, "nested", "file2.txt"), "content2");
+
+    const strategy = new RobocopyStrategy();
+    await strategy.copyDirectory(srcDir, destDir);
+
+    const content1 = await readFile(join(destDir, "file1.txt"), "utf-8");
+    const content2 = await readFile(join(destDir, "nested", "file2.txt"), "utf-8");
+    expect(content1).toBe("content1");
+    expect(content2).toBe("content2");
+  });
+
+  it("treats a no-change re-copy (exit code 1) as success", async () => {
+    const srcDir = join(tempDir, "source");
+    const destDir = join(tempDir, "dest");
+
+    await mkdir(srcDir);
+    await writeFile(join(srcDir, "file1.txt"), "content1");
+
+    const strategy = new RobocopyStrategy();
+    // First copy returns code 1 (files copied); second returns code 0/1
+    // depending on robocopy's diff detection. Both must not throw.
+    await strategy.copyDirectory(srcDir, destDir);
+    await strategy.copyDirectory(srcDir, destDir);
+
+    const content1 = await readFile(join(destDir, "file1.txt"), "utf-8");
+    expect(content1).toBe("content1");
+  });
+});
+
 describe("detectCapabilities", () => {
   it("caches result", async () => {
     resetState();
@@ -111,6 +182,18 @@ describe("detectCapabilities", () => {
 
     // Same reference means it's cached
     expect(result1).toBe(result2);
+  });
+
+  it("reports robocopyAvailable matching the platform", async () => {
+    resetState();
+
+    const result = await detectCapabilities();
+    const isWindows = process.platform === "win32";
+    // robocopy is only detected on Windows; elsewhere it is always false.
+    if (!isWindows) {
+      expect(result.robocopyAvailable).toBe(false);
+    }
+    expect(typeof result.robocopyAvailable).toBe("boolean");
   });
 });
 
@@ -136,6 +219,7 @@ describe("CopyService", () => {
         strategy.name === "clonefile" ||
         strategy.name === "clone" ||
         strategy.name === "rsync" ||
+        strategy.name === "robocopy" ||
         strategy.name === "standard";
       expect(isValidStrategy).toBe(true);
     } finally {

--- a/packages/core/src/utils/copy/copy.test.ts
+++ b/packages/core/src/utils/copy/copy.test.ts
@@ -155,7 +155,7 @@ describe.skipIf(process.platform !== "win32")("RobocopyStrategy (Windows)", () =
     expect(content2).toBe("content2");
   });
 
-  it("treats a no-change re-copy (exit code 1) as success", async () => {
+  it("re-copying an unchanged directory does not throw", async () => {
     const srcDir = join(tempDir, "source");
     const destDir = join(tempDir, "dest");
 
@@ -163,10 +163,11 @@ describe.skipIf(process.platform !== "win32")("RobocopyStrategy (Windows)", () =
     await writeFile(join(srcDir, "file1.txt"), "content1");
 
     const strategy = new RobocopyStrategy();
-    // First copy returns code 1 (files copied); second returns code 0/1
-    // depending on robocopy's diff detection. Both must not throw.
-    await strategy.copyDirectory(srcDir, destDir);
-    await strategy.copyDirectory(srcDir, destDir);
+    // The first copy returns code 1 (files copied) and the second typically
+    // code 0/1 depending on robocopy's diff detection. Both are < 8, so neither
+    // call must reject — that is what the success-by-exit-code-< 8 check buys us.
+    await expect(strategy.copyDirectory(srcDir, destDir)).resolves.toBeUndefined();
+    await expect(strategy.copyDirectory(srcDir, destDir)).resolves.toBeUndefined();
 
     const content1 = await readFile(join(destDir, "file1.txt"), "utf-8");
     expect(content1).toBe("content1");

--- a/packages/core/src/utils/copy/detector.ts
+++ b/packages/core/src/utils/copy/detector.ts
@@ -17,12 +17,13 @@ export async function detectCapabilities(
     return cachedCapabilities;
   }
 
-  const [cloneSupported, rsyncAvailable] = await Promise.all([
+  const [cloneSupported, rsyncAvailable, robocopyAvailable] = await Promise.all([
     detectCloneSupport(ctx),
     detectRsyncAvailable(ctx),
+    detectRobocopyAvailable(ctx),
   ]);
 
-  cachedCapabilities = { cloneSupported, rsyncAvailable };
+  cachedCapabilities = { cloneSupported, rsyncAvailable, robocopyAvailable };
   return cachedCapabilities;
 }
 
@@ -120,6 +121,33 @@ async function detectRsyncAvailable(ctx: AppContext): Promise<boolean> {
     const result = await ctx.runtime.process.run({
       cmd: "rsync",
       args: ["--version"],
+      stderr: "null",
+      stdout: "null",
+    });
+
+    return result.success;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect if robocopy command is available (Windows only).
+ *
+ * Uses `where robocopy` rather than `robocopy --version`: robocopy has no
+ * version flag, and invoking it without source/dest returns exit code 16,
+ * so success-by-exit-code-0 cannot distinguish "present" from "bad args".
+ */
+async function detectRobocopyAvailable(ctx: AppContext): Promise<boolean> {
+  const isWindows = ctx.runtime.build.os === "windows";
+  if (!isWindows) {
+    return false;
+  }
+
+  try {
+    const result = await ctx.runtime.process.run({
+      cmd: "where",
+      args: ["robocopy"],
       stderr: "null",
       stdout: "null",
     });

--- a/packages/core/src/utils/copy/index.ts
+++ b/packages/core/src/utils/copy/index.ts
@@ -2,6 +2,7 @@ import type { CopyStrategy, CopyStrategyType } from "./types.ts";
 import {
   CloneStrategy,
   NativeCloneStrategy,
+  RobocopyStrategy,
   RsyncStrategy,
   StandardStrategy,
 } from "./strategies/index.ts";
@@ -9,7 +10,7 @@ import type { AppContext } from "../../context/index.ts";
 
 export type { CopyCapabilities, CopyStrategy, CopyStrategyType } from "./types.ts";
 export { detectCapabilities, resetCapabilitiesCache } from "./detector.ts";
-export { CloneStrategy, NativeCloneStrategy, RsyncStrategy, StandardStrategy };
+export { CloneStrategy, NativeCloneStrategy, RobocopyStrategy, RsyncStrategy, StandardStrategy };
 
 /**
  * CopyService manages copy operations with automatic strategy selection
@@ -20,6 +21,7 @@ export { CloneStrategy, NativeCloneStrategy, RsyncStrategy, StandardStrategy };
  * - Directory copy:
  *   - macOS: NativeClone (clonefile FFI) > Clone (cp -c) > Rsync > Standard
  *   - Linux: Clone (cp --reflink=auto) > Rsync > Standard
+ *   - Windows: Robocopy (/MT) > Standard
  *
  * The overhead of spawning external processes (cp, rsync) makes them slower
  * for individual file copies, but they excel at bulk directory operations.
@@ -36,11 +38,13 @@ export class CopyService {
     // Priority order for directory copy:
     // macOS: native clone (clonefile) -> clone (cp -c) -> rsync -> standard
     // Linux: clone (cp --reflink) -> rsync -> standard
+    // Windows: robocopy (/MT) -> standard (the others are unavailable there)
     // NativeCloneStrategy is only used when it supports directory cloning (macOS)
     this.directoryStrategies = [
       this.nativeCloneStrategy,
       new CloneStrategy(),
       new RsyncStrategy(),
+      new RobocopyStrategy(),
       this.standardStrategy,
     ];
   }
@@ -100,7 +104,7 @@ export class CopyService {
 
   /**
    * Copy a directory recursively from src to dest.
-   * Uses the best available strategy (Clone > Rsync > Standard).
+   * Uses the best available strategy (Clone > Rsync > Robocopy > Standard).
    * Falls back to standard strategy on error.
    */
   async copyDirectory(src: string, dest: string): Promise<void> {

--- a/packages/core/src/utils/copy/strategies/index.ts
+++ b/packages/core/src/utils/copy/strategies/index.ts
@@ -1,4 +1,5 @@
 export { CloneStrategy } from "./clone.ts";
 export { NativeCloneStrategy } from "./native-clone.ts";
+export { RobocopyStrategy } from "./robocopy.ts";
 export { RsyncStrategy } from "./rsync.ts";
 export { StandardStrategy } from "./standard.ts";

--- a/packages/core/src/utils/copy/strategies/robocopy.ts
+++ b/packages/core/src/utils/copy/strategies/robocopy.ts
@@ -1,0 +1,80 @@
+import { dirname } from "node:path";
+import { detectCapabilities } from "../detector.ts";
+import type { CopyStrategy } from "../types.ts";
+import { validatePath } from "../validation.ts";
+import { runtime } from "../../../runtime/index.ts";
+
+/**
+ * Robocopy-based copy strategy (Windows only).
+ *
+ * Uses the multithreaded `robocopy /MT` to accelerate copying directories with
+ * many small files (e.g. node_modules) into a worktree. Robocopy is bundled
+ * with Windows, needs no elevation, and works on any NTFS volume.
+ */
+export class RobocopyStrategy implements CopyStrategy {
+  readonly name = "robocopy" as const;
+
+  async isAvailable(): Promise<boolean> {
+    const capabilities = await detectCapabilities();
+    return capabilities.robocopyAvailable;
+  }
+
+  async copyFile(src: string, dest: string): Promise<void> {
+    // Robocopy is a directory-level tool, so single files are copied with the
+    // plain runtime copy (matching StandardStrategy.copyFile semantics).
+    validatePath(src);
+    validatePath(dest);
+
+    const destDir = dirname(dest);
+    await runtime.fs.mkdir(destDir, { recursive: true }).catch(() => {});
+
+    await runtime.fs.copyFile(src, dest);
+  }
+
+  async copyDirectory(src: string, dest: string): Promise<void> {
+    // Validate paths to prevent command injection
+    validatePath(src);
+    validatePath(dest);
+
+    // Ensure parent directory exists
+    const destDir = dirname(dest);
+    await runtime.fs.mkdir(destDir, { recursive: true }).catch(() => {});
+
+    const result = await runtime.process.run({
+      cmd: "robocopy",
+      args: [
+        src,
+        dest,
+        // /E copies subdirectories including empty ones: robocopy maps
+        // src's *contents* into dest, matching copyDirectory(src, dest).
+        "/E",
+        // /MT runs the copy multithreaded (default 8 threads).
+        "/MT",
+        // Suppress per-file/dir logging, job header/summary, and the progress
+        // percentage so output stays small and needs no parsing.
+        "/NFL",
+        "/NDL",
+        "/NJH",
+        "/NJS",
+        "/NP",
+        // Cap retries: robocopy defaults to 1 million retries with a 30s wait,
+        // which would hang on a transient failure instead of falling back.
+        "/R:1",
+        "/W:1",
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    // Robocopy uses bitmask exit codes: 0-7 indicate success (files copied,
+    // extra files, mismatches), 8+ indicate failure. result.success
+    // (code === 0) would wrongly reject a normal successful copy (code 1).
+    const isRobocopySuccess = result.code < 8;
+    if (!isRobocopySuccess) {
+      const stderr = new TextDecoder().decode(result.stderr);
+      throw new Error(
+        `Robocopy directory copy failed (code ${result.code}): ${src} -> ${dest}: ${stderr}`,
+      );
+    }
+  }
+}

--- a/packages/core/src/utils/copy/strategies/robocopy.ts
+++ b/packages/core/src/utils/copy/strategies/robocopy.ts
@@ -71,9 +71,14 @@ export class RobocopyStrategy implements CopyStrategy {
     // (code === 0) would wrongly reject a normal successful copy (code 1).
     const isRobocopySuccess = result.code < 8;
     if (!isRobocopySuccess) {
-      const stderr = new TextDecoder().decode(result.stderr);
+      // Robocopy writes its diagnostics (e.g. "ERROR 5 ... Access is denied")
+      // to stdout, not stderr, so the failure detail lives in stdout; stderr is
+      // appended only as a fallback for the rare message that lands there.
+      const stdout = new TextDecoder().decode(result.stdout).trim();
+      const stderr = new TextDecoder().decode(result.stderr).trim();
+      const detail = [stdout, stderr].filter(Boolean).join(" ");
       throw new Error(
-        `Robocopy directory copy failed (code ${result.code}): ${src} -> ${dest}: ${stderr}`,
+        `Robocopy directory copy failed (code ${result.code}): ${src} -> ${dest}: ${detail}`,
       );
     }
   }

--- a/packages/core/src/utils/copy/types.ts
+++ b/packages/core/src/utils/copy/types.ts
@@ -1,7 +1,7 @@
 /**
  * Copy strategy type identifier
  */
-export type CopyStrategyType = "clonefile" | "clone" | "rsync" | "standard";
+export type CopyStrategyType = "clonefile" | "clone" | "rsync" | "robocopy" | "standard";
 
 /**
  * Interface for copy strategies
@@ -34,4 +34,6 @@ export interface CopyCapabilities {
   cloneSupported: boolean;
   /** Whether rsync command is available */
   rsyncAvailable: boolean;
+  /** Whether robocopy command is available (Windows only) */
+  robocopyAvailable: boolean;
 }

--- a/packages/docs/src/content/docs/configuration/vibe-toml.mdx
+++ b/packages/docs/src/content/docs/configuration/vibe-toml.mdx
@@ -93,12 +93,13 @@ The environment variable takes precedence over the config file setting.
 
 vibe automatically selects the best copy strategy based on your system:
 
-| Strategy        | When Used                             | Platform    |
-| --------------- | ------------------------------------- | ----------- |
-| Clone (CoW)     | Directory copy on APFS                | macOS       |
-| Clone (reflink) | Directory copy on Btrfs/XFS           | Linux       |
-| rsync           | Directory copy when clone unavailable | macOS/Linux |
-| Standard        | File copy, or fallback                | All         |
+| Strategy         | When Used                             | Platform    |
+| ---------------- | ------------------------------------- | ----------- |
+| Clone (CoW)      | Directory copy on APFS                | macOS       |
+| Clone (reflink)  | Directory copy on Btrfs/XFS           | Linux       |
+| rsync            | Directory copy when clone unavailable | macOS/Linux |
+| robocopy (`/MT`) | Directory copy                        | Windows     |
+| Standard         | File copy, or fallback                | All         |
 
 **How it works:**
 

--- a/packages/docs/src/content/docs/ja/configuration/vibe-toml.mdx
+++ b/packages/docs/src/content/docs/ja/configuration/vibe-toml.mdx
@@ -93,12 +93,13 @@ VIBE_COPY_CONCURRENCY=16 vibe start feat/my-feature
 
 vibeはシステムに応じて最適なコピー戦略を自動選択します：
 
-| 戦略            | 使用条件                                    | プラットフォーム |
-| --------------- | ------------------------------------------- | ---------------- |
-| Clone (CoW)     | APFSでのディレクトリコピー                  | macOS            |
-| Clone (reflink) | Btrfs/XFSでのディレクトリコピー             | Linux            |
-| rsync           | cloneが利用できない場合のディレクトリコピー | macOS/Linux      |
-| Standard        | ファイルコピー、またはフォールバック        | 全て             |
+| 戦略             | 使用条件                                    | プラットフォーム |
+| ---------------- | ------------------------------------------- | ---------------- |
+| Clone (CoW)      | APFSでのディレクトリコピー                  | macOS            |
+| Clone (reflink)  | Btrfs/XFSでのディレクトリコピー             | Linux            |
+| rsync            | cloneが利用できない場合のディレクトリコピー | macOS/Linux      |
+| robocopy (`/MT`) | ディレクトリコピー                          | Windows          |
+| Standard         | ファイルコピー、またはフォールバック        | 全て             |
 
 **仕組み：**
 


### PR DESCRIPTION
## Summary
- Add a Windows-only `robocopy /MT` directory-copy strategy so worktree creation gets the same bulk-copy acceleration on Windows that macOS/Linux already get from clone/rsync. It slots into `CopyService` as `Robocopy (/MT) > Standard`.
- Detect availability via `where robocopy` (robocopy has no `--version` and bad-arg invocation returns 16, so exit-code-0 cannot distinguish "present" from "bad args"), gated to Windows.
- Treat robocopy's bitmask exit codes correctly: 0–7 are success (a normal copy returns 1), 8+ are failure. On failure, surface the diagnostic from stdout (robocopy logs errors there, not stderr) so copy failures are debuggable.
- Update the copy-strategy table in the `vibe.toml` docs (EN/JA).

## Test plan
- [ ] On Windows: `copyDirectory` copies a tree (incl. nested dirs) into dest, and a no-change re-copy (exit code 1) does not throw.
- [ ] On macOS/Linux: `RobocopyStrategy.isAvailable()` and `detectCapabilities().robocopyAvailable` are `false`; strategy selection is unaffected.
- [ ] `pnpm run check:all` passes; CI green on all platforms.