### PR TITLE
docs: document mounting a btrfs volume in WSL2 to enable CoW copies

### DIFF
--- a/packages/docs/src/content/docs/ja/recipes/index.mdx
+++ b/packages/docs/src/content/docs/ja/recipes/index.mdx
@@ -14,6 +14,7 @@ sidebar:
 - [cmux](/ja/recipes/cmux/) — 新しいWorktreeでcmuxワークスペースを開く
 - [tmux](/ja/recipes/tmux/) — tmuxペインを新しいWorktreeに分割する
 - [direnv](/ja/recipes/direnv/) — 新しいWorktreeで自動的に`direnv allow`する
+- [WSL2 + btrfs](/ja/recipes/wsl2-btrfs/) — btrfsボリュームをマウントしてWSL2で実CoWコピーを有効化する
 
 :::tip
 レシピで使うのは公式の環境変数（`VIBE_WORKTREE_PATH`、`VIBE_ORIGIN_PATH`）と`sh`互換構文のみなので、macOSとLinuxでそのまま動作します。

--- a/packages/docs/src/content/docs/ja/recipes/wsl2-btrfs.mdx
+++ b/packages/docs/src/content/docs/ja/recipes/wsl2-btrfs.mdx
@@ -1,0 +1,65 @@
+---
+title: WSL2 + btrfs
+description: btrfs ボリュームをマウントして WSL2 で実 Copy-on-Write (reflink) コピーを有効化する
+sidebar:
+  order: 5
+---
+
+WSL2 内では vibe は Linux として動作し、`clone`（`cp --reflink`）または `rsync` の[コピー戦略](/ja/configuration/vibe-toml/#コピーパフォーマンスの最適化)を自動的に選択します（設定不要）。しかし WSL2 のルートファイルシステムは常に **ext4** であり reflink に対応していないため、`cp --reflink=auto` は黙ってフルコピーにフォールバックします。
+
+WSL2 で実 Copy-on-Write を得るには、別途 **btrfs** ボリュームをマウントし、プロジェクト（例: `node_modules`）をその上に置きます。プロジェクトが btrfs 上に乗れば、vibe の既存の `clone` 戦略が自動的に瞬時の CoW コピーを生成します。
+
+## WSL ルートで CoW ができない理由
+
+- WSL2 のルートは **ext4** でハードコードされており、`.wslconfig` や `wsl.conf` で変更できません（参照: [microsoft/WSL#9339](https://github.com/microsoft/WSL/issues/9339)）。
+- 「btrfs ディストリ」（openSUSE / Fedora）を使っても**解決しません**。WSL はディストリに関係なく rootfs を自身の ext4 VHDX に展開するためです。
+- ルートに対する `btrfs-convert` は**実用的ではありません**。変換後のルートは WSL で起動しません。
+- reflink は**同一ファイルシステム内でのみ**動作するため、コピー元とコピー先の両方が btrfs ボリューム上に存在する必要があります。
+
+## 推奨セットアップ — 二次 btrfs VHD をマウントする
+
+:::caution
+`wsl --mount` には Windows 11（または Store 版の WSL）と、**管理者権限**の PowerShell（管理者として実行）が必要です。
+:::
+
+Windows 側で、管理者権限の PowerShell を開き、VHD を作成して WSL にアタッチします:
+
+```powershell
+New-VHD -Path C:\wsl\dev-btrfs.vhdx -Dynamic -SizeBytes 128GB -BlockSizeBytes 1MB
+wsl --mount --vhd C:\wsl\dev-btrfs.vhdx --bare
+```
+
+次に WSL 内で、ボリュームを一度だけフォーマットしてマウントします:
+
+```bash
+lsblk                                  # 新しいデバイスを確認（例: /dev/sdd）
+sudo mkfs.btrfs /dev/sdd
+sudo mkdir -p /mnt/btrfs
+sudo blkid /dev/sdd                    # UUID をコピー
+echo 'UUID=<uuid> /mnt/btrfs btrfs defaults,nofail 0 0' | sudo tee -a /etc/fstab
+sudo mount -a
+sudo chown $USER:$USER /mnt/btrfs
+
+# プロジェクトを btrfs ボリュームに置く。reflink はその中で動作する
+mv ~/myproject /mnt/btrfs/myproject
+cd /mnt/btrfs && cp --reflink=always -r myproject myproject-copy
+```
+
+## 再起動後の再アタッチ
+
+`wsl --mount --vhd ... --bare` はホスト側の操作であり、Windows の再起動後に再実行する必要があります（例: ログイン時に「最上位の特権で実行する」よう設定したタスクスケジューラのエントリ）。ディスクがアタッチされれば、`/etc/fstab` が自動的にマウントします（`automount.mountFsTab` の既定値は `true`）。
+
+## 注意点
+
+:::caution
+
+- ファイルシステムをまたぐ reflink は不可能です。ext4 ルートから btrfs ボリュームへのコピーはフルコピーになります。
+- 同一 btrfs 上でのマウントポイントをまたぐ reflink にはカーネル ≥ 5.18 が必要です。WSL2 の 6.6 カーネルはこの条件を満たします。
+  :::
+
+## 参考リンク
+
+- [MS Learn – WSL2 で Linux ディスクをマウントする](https://learn.microsoft.com/ja-jp/windows/wsl/wsl2-mount-disk)
+- [microsoft/WSL#9339 – ext4 以外のルートファイルシステム](https://github.com/microsoft/WSL/issues/9339)
+- [btrfs docs – Reflink](https://btrfs.readthedocs.io/en/latest/Reflink.html)
+- vibe – [コピーパフォーマンスの最適化](/ja/configuration/vibe-toml/#コピーパフォーマンスの最適化)

--- a/packages/docs/src/content/docs/recipes/index.mdx
+++ b/packages/docs/src/content/docs/recipes/index.mdx
@@ -14,6 +14,7 @@ Each recipe is intentionally small — one or two lines of TOML you can paste in
 - [cmux](/recipes/cmux/) — open a cmux workspace in the new worktree
 - [tmux](/recipes/tmux/) — split a tmux pane into the new worktree
 - [direnv](/recipes/direnv/) — auto-`direnv allow` the new worktree
+- [WSL2 + btrfs](/recipes/wsl2-btrfs/) — enable real CoW copies in WSL2 via a mounted btrfs volume
 
 :::tip
 Recipes only use documented environment variables (`VIBE_WORKTREE_PATH`, `VIBE_ORIGIN_PATH`) and `sh`-compatible syntax, so they work on macOS and Linux out of the box.

--- a/packages/docs/src/content/docs/recipes/wsl2-btrfs.mdx
+++ b/packages/docs/src/content/docs/recipes/wsl2-btrfs.mdx
@@ -1,0 +1,65 @@
+---
+title: WSL2 + btrfs
+description: Enable real Copy-on-Write (reflink) copies in WSL2 by mounting a btrfs volume
+sidebar:
+  order: 5
+---
+
+Inside WSL2, vibe runs as Linux and automatically picks the `clone` (`cp --reflink`) or `rsync` [copy strategy](/configuration/vibe-toml/#copy-performance-optimization) — no configuration needed. But the WSL2 root filesystem is always **ext4**, which does not support reflink, so `cp --reflink=auto` silently falls back to a full copy.
+
+To get real Copy-on-Write in WSL2, mount a separate **btrfs** volume and keep your project (e.g. `node_modules`) on it. Once the project lives on btrfs, vibe's existing `clone` strategy produces instant CoW copies automatically.
+
+## Why the WSL root can't do CoW
+
+- The WSL2 root is **ext4** and hardcoded — it is not configurable via `.wslconfig` or `wsl.conf` (ref [microsoft/WSL#9339](https://github.com/microsoft/WSL/issues/9339)).
+- A "btrfs distro" (openSUSE / Fedora) does **not** help: WSL unpacks the rootfs into its own ext4 VHDX regardless.
+- Running `btrfs-convert` on the root is **not viable** — the converted root won't boot in WSL.
+- reflink only works **within the same filesystem**, so the source and the copy must both live on the btrfs volume.
+
+## Recommended setup — mount a secondary btrfs VHD
+
+:::caution
+`wsl --mount` requires Windows 11 (or the Store version of WSL) and an **elevated** PowerShell (Run as Administrator).
+:::
+
+On the Windows side, in an Administrator PowerShell, create a VHD and attach it to WSL:
+
+```powershell
+New-VHD -Path C:\wsl\dev-btrfs.vhdx -Dynamic -SizeBytes 128GB -BlockSizeBytes 1MB
+wsl --mount --vhd C:\wsl\dev-btrfs.vhdx --bare
+```
+
+Then, inside WSL, format and mount the volume once:
+
+```bash
+lsblk                                  # find the new device, e.g. /dev/sdd
+sudo mkfs.btrfs /dev/sdd
+sudo mkdir -p /mnt/btrfs
+sudo blkid /dev/sdd                    # copy the UUID
+echo 'UUID=<uuid> /mnt/btrfs btrfs defaults,nofail 0 0' | sudo tee -a /etc/fstab
+sudo mount -a
+sudo chown $USER:$USER /mnt/btrfs
+
+# Put the project on the btrfs volume; reflink works within it
+mv ~/myproject /mnt/btrfs/myproject
+cd /mnt/btrfs && cp --reflink=always -r myproject myproject-copy
+```
+
+## Re-attach on reboot
+
+`wsl --mount --vhd ... --bare` is a host-side operation and must be re-run after a Windows restart (for example, a Task Scheduler entry set to "Run with highest privileges" at login). Once the disk is attached, `/etc/fstab` mounts it automatically (`automount.mountFsTab` defaults to `true`).
+
+## Caveats
+
+:::caution
+
+- reflink across filesystems is impossible — copying from the ext4 root to the btrfs volume is a full copy.
+- Cross-mountpoint reflink on the same btrfs needs kernel ≥ 5.18; WSL2's 6.6 kernel clears this.
+  :::
+
+## References
+
+- [MS Learn – Mount a Linux disk in WSL2](https://learn.microsoft.com/en-us/windows/wsl/wsl2-mount-disk)
+- [microsoft/WSL#9339 – non-ext4 root filesystem](https://github.com/microsoft/WSL/issues/9339)
+- [btrfs docs – Reflink](https://btrfs.readthedocs.io/en/latest/Reflink.html)
+- vibe – [Copy Performance Optimization](/configuration/vibe-toml/#copy-performance-optimization)


### PR DESCRIPTION
## Summary

Inside WSL2, vibe runs as Linux and automatically selects its existing `clone` (`cp --reflink`) / `rsync` strategy. But the WSL2 root filesystem is always **ext4**, which has no reflink support, so `cp --reflink=auto` silently falls back to a full copy. This adds a docs-site recipe documenting the only robust way to get real CoW in WSL2: mount a separate btrfs volume and keep the project on it. This unlocks vibe's existing CoW path with no code change.

This is a documentation-only task — no changes to vibe's code.

- New: `recipes/wsl2-btrfs.mdx` (EN) / `ja/recipes/wsl2-btrfs.mdx` (JA) — created with identical structure per `.claude/rules/docs-i18n.md`
- Edited: added links to the lineup in `recipes/index.mdx` / `ja/recipes/index.mdx`

Fixes #479

## Test Plan

- [x] `pnpm run check:docs` (lint / prettier / astro check) passes with 0 errors
- [x] `astro build` succeeds; both EN/JA pages (`/recipes/wsl2-btrfs/`, `/ja/recipes/wsl2-btrfs/`) are generated with no broken links
- [x] Verified the anchor links `#copy-performance-optimization` (EN) / `#コピーパフォーマンスの最適化` (JA) match the heading IDs in the built HTML

## Checklist

- [ ] Tests added/updated (N/A — docs only)
- [x] `pnpm run check:all` passes (docs-only change; verified with `pnpm run check:docs`)
- [x] Docs updated (if needed)