### PR TITLE
chore: update Nix flake to 1.8.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,22 +24,22 @@
       platforms = {
         x86_64-linux = {
           artifact = "vibe-linux-x64";
-          hash = "sha256-dwzcfFsiBEyWzZAsjIwZutkbfnTx2xLOYxRQBzfatj8=";
+          hash = "sha256-IK3Mus3OPVnxqojBI2dLFOyKwganV6tfGs5duGCoqWg=";
           napiNode = "vibe-native.linux-x64-gnu.node";
         };
         aarch64-linux = {
           artifact = "vibe-linux-arm64";
-          hash = "sha256-9AkDZOVlLM+O4mFBkREzQDAs6LBLhBish/xlU2wE32M=";
+          hash = "sha256-6i98Hh5jnThHIXFPUoc2/XXEqzwBc6ZuEWP1JAAu3hg=";
           napiNode = "vibe-native.linux-arm64-gnu.node";
         };
         x86_64-darwin = {
           artifact = "vibe-darwin-x64";
-          hash = "sha256-+Y4RNhPv+JoqsPvS31v26ShDrpcrNSJdu1NUyyBl9fs=";
+          hash = "sha256-ly10wj0u/jh7J5Tyo2RlAEAMHV7n3FUGfaSyaa8U1kw=";
           napiNode = "vibe-native.darwin-x64.node";
         };
         aarch64-darwin = {
           artifact = "vibe-darwin-arm64";
-          hash = "sha256-Ui+3M5+FDOvbrYOC3mjqICXY7Yacz0otC0IRPAUxMhw=";
+          hash = "sha256-A95UEErpNXknVXSl8+ZBvXDNHL7WuW+ogsirMLGN2BY=";
           napiNode = "vibe-native.darwin-arm64.node";
         };
       };


### PR DESCRIPTION
Automated update of `flake.nix` and `flake.lock` for v1.8.0.