### PR TITLE
chore: bump magic-nix-cache-action to v14

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
     - name: Nix store cache
       if: runner.os != 'Windows'
-      uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+      uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
     - name: Load dev shell into environment
       if: runner.os != 'Windows'
       shell: bash


### PR DESCRIPTION
## Why

PR #484's CI hit flaky failures in `build-binaries` and `nix-build`, traced to a Determinate Systems caching incident — the logs showed `HTTP 418` / `(429) Too Many Requests`, `GitHub Actions Cache throttled Magic Nix Cache`, and a link to `status.determinate.systems`. The throttle cascaded into cancelled jobs and a fixed-output hash mismatch rather than degrading gracefully.

The pinned `v13` predates throttle-handling improvements. Bumping to `v14` (released 2026-05-29, the current latest) should make the cache step fall back more cleanly when the GitHub Actions Cache API rate-limits.

## What

- `magic-nix-cache-action`: `v13` → `v14` (SHA `908b263…`) in `.github/actions/setup-toolchain/action.yml`.
- `nix-installer-action` stays at `v22` (already latest).

## Considered but deferred

A full migration to **FlakeHub Cache** (the Determinate-official cache that doesn't reverse-engineer GitHub's cache API) was evaluated. It requires FlakeHub organization enrollment / OSS free-account approval (`support@flakehub.com`) plus `id-token: write` OIDC permissions on every Nix job — an external setup step outside this repo. Tracked separately.

## Verification

- `pinact run --check` passes (SHA pinning intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)