### PR TITLE
chore: switch Nix store cache from magic-nix-cache to cache-nix-action

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -11,9 +11,19 @@ runs:
     - name: Install Nix
       if: runner.os != 'Windows'
       uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+    # Cache the Nix store via the standard GitHub Actions cache (actions/cache
+    # under the hood). Unlike magic-nix-cache, this does not reverse-engineer
+    # GitHub's cache API, so it is not subject to the 418/429 throttling that
+    # made CI flaky. Keyed on the flake inputs so the cache invalidates only
+    # when the toolchain changes; restore-prefixes lets unrelated changes still
+    # reuse the previous store. purge is left off so no `actions: write`
+    # permission is required.
     - name: Nix store cache
       if: runner.os != 'Windows'
-      uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+      uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
     - name: Load dev shell into environment
       if: runner.os != 'Windows'
       shell: bash


### PR DESCRIPTION
## Why

The flaky CI in #484 (and the v14 bump in #485) traced back to **magic-nix-cache reverse-engineering GitHub's internal Actions Cache API** — an unsupported path. When Determinate Systems' cache had an incident, requests returned `418` / `(429) Too Many Requests` ("GitHub Actions Cache throttled Magic Nix Cache") and cascaded into cancelled jobs and fixed-output hash mismatches. Bumping the action version only mitigated the symptom.

This switches to the GitHub Actions **standard cache** path.

## What

Replace `magic-nix-cache-action` with `nix-community/cache-nix-action` in `.github/actions/setup-toolchain/action.yml`:

- `cache-nix-action` is a thin wrapper over the official `actions/cache`, so it uses the GitHub Actions Cache through the **supported** API and is not subject to the throttling that broke CI. It also handles Nix-store specifics (size, key strategy) that raw `actions/cache` leaves to the caller.
- Keyed on `flake.nix` + `flake.lock`, so the cache invalidates only when the toolchain changes; `restore-prefixes-first-match` lets unrelated changes reuse the previous store.
- `purge` is intentionally left off, so no `actions: write` permission is required on the calling jobs.

Supersedes the v14 bump from #485 (magic-nix-cache is removed entirely).

## Verification

- `pinact run --check` passes (SHA pinned to `7df957e` / v7.0.2).
- The real test is this PR's own CI: the Nix jobs (`lint`, `typecheck`, `test`, `docs`, `nix-build`, `build-binaries`) should populate and reuse the new cache without 418/429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)