### PR TITLE
chore: add gitleaks secret scanning (pre-commit + CI)

### DIFF
--- a/.claude/rules/ci-cd-workflows.md
+++ b/.claude/rules/ci-cd-workflows.md
@@ -64,6 +64,9 @@ steps:
   Bun); it is only needed for JSR distribution testing
 - `actions/setup-node` with `registry-url` - used in publish jobs for npm
   registry auth / OIDC, layered on top of `setup-toolchain`
+- `gitleaks/gitleaks-action` - secret scanning; the official action bundles its
+  own gitleaks binary and maintained scan / PR-comment logic. The Nix dev shell
+  still provides gitleaks for the local pre-commit hook (lefthook)
 - Platform-specific SDK setup (e.g., Xcode, Android SDK)
 
 ### Benefits

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Security-sensitive configuration requires owner review. Scoped to the files
+# that actually gate security — the secret-scanning ruleset and the CI
+# workflows/actions that enforce it — rather than all of .github/, so routine
+# changes (issue/PR templates) do not trigger review fatigue that would dull
+# scrutiny of the entries that matter. This file lives under .github/ and is
+# itself owner-protected by the /.github/CODEOWNERS entry below.
+/.gitleaks.toml @kexi
+/.github/workflows/ @kexi
+/.github/actions/ @kexi
+/.github/CODEOWNERS @kexi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main, develop]
 
+# Least privilege: CI only reads the repository. Jobs that need more must
+# request it explicitly at the job level.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -279,6 +284,45 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-toolchain
       - run: pinact run --check
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    # The action comments on the PR via GITHUB_TOKEN, which needs write access to
+    # pull requests. Granted only here, not at the top level, so every other job
+    # keeps the read-only default. contents:read is restated because declaring
+    # job-level permissions drops the inherited top-level set otherwise.
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      # fetch-depth: 0 so the action can resolve the PR's base ref and scan
+      # every commit in the range (not just the tip), catching a secret added in
+      # an intermediate commit even if a later commit removes it. On push it
+      # scans the full history of the pushed ref.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      # Why the official action instead of the dev-shell gitleaks via a plain
+      # `run:` step: it bundles a maintained scanner and posts findings as PR
+      # comments. setup-toolchain is dropped since the action ships its own
+      # gitleaks binary.
+      #
+      # Note on config tampering: the action's config precedence is the same as
+      # the CLI's (GITLEAKS_CONFIG env / repo-root .gitleaks.toml), so it does
+      # NOT prevent a fork PR from editing .gitleaks.toml in the same PR. That
+      # evasion is blocked operationally: CODEOWNERS guards .gitleaks.toml and
+      # branch protection requires this check to pass before merge.
+      #
+      # GITLEAKS_LICENSE is required for organization repos only; kexi/vibe is a
+      # personal repo, so it is intentionally omitted.
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
 
   build:
     needs: [build-binaries, build-deb, build-native]

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Thumbs.db
 
 # Claude
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Environment
 .env

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,34 @@
+# Secret scanning config consumed by gitleaks. The pre-commit hook
+# (lefthook.yml, using the Nix dev-shell gitleaks) scans staged changes; the CI
+# `gitleaks` job (gitleaks/gitleaks-action) scans full git history and points at
+# this file via GITLEAKS_CONFIG.
+#
+# This in-repo config does not by itself stop a PR from weakening the ruleset
+# (gitleaks reads whatever .gitleaks.toml is in the tree). That is guarded
+# operationally: CODEOWNERS protects this file and branch protection requires
+# the CI gitleaks check before merge.
+
+# Inherit gitleaks' built-in ruleset (AWS keys, GitHub tokens, private keys,
+# generic high-entropy secrets, etc.). The default ruleset also ships a global
+# path allowlist that already excludes lock files (pnpm-lock.yaml,
+# package-lock.json, yarn.lock, …) — verified with `--log-level trace`:
+# "skipping file: global allowlist allowed-path=true path=pnpm-lock.yaml".
+[extend]
+useDefault = true
+
+# Allowlist policy (Why no project-level allowlist):
+# - The pnpm-lock.yaml `integrity: sha512-…` digests that motivated a project
+#   suppression are content hashes, not secrets. They are already covered by the
+#   default ruleset's lock-file path allowlist above, so a project entry is
+#   redundant.
+# - Why not a project-level `regexes = ['''sha512-…''']` (the MEDIUM finding): a
+#   bare global `regexes` allowlist applies to EVERY scanned file, so a real
+#   sha512-shaped secret pasted into any other file would be silently exempted.
+# - Why not scope it with `paths` (AND): gitleaks 8.30.1 ignores
+#   `matchCondition = "AND"` on a global allowlist and evaluates commit/path with
+#   OR regardless (verified: trace logs `condition=OR`, and an AWS key dropped
+#   into pnpm-lock.yaml is skipped by path alone). `paths` would therefore blind
+#   the scanner to the whole lock file rather than narrowing the regex.
+# - So there is intentionally no project allowlist. Add one only for a concrete
+#   false positive, scoped to the specific value/regex — never by excluding a
+#   containing path.

--- a/docs/SECURITY_CHECKLIST.ja.md
+++ b/docs/SECURITY_CHECKLIST.ja.md
@@ -59,7 +59,16 @@ vibe CLIツールの包括的なセキュリティチェックリストです。
   - **ワークフロー完全性**: サードパーティ Actions は完全コミット SHA に固定 (`pinact-verify` job が未固定参照をブロック)。ツールチェーンは `flake.lock` (Rust は `rust-toolchain.toml`) で再現的に固定
   - **ランナー egress 可視化**: 全 job に `step-security/harden-runner` (audit モード) を配置し、外向き通信と `/proc` アクセスを記録。Shai-Hulud 系マルウェアが用いる `*.getsession.org` などの C2 を検知可能に
   - **公開時の出所証明**: 全リリースで `npm publish --provenance` を有効化し OIDC 署名された attestation を付与
-- **適用**: CI の `pinact-verify` job + 全 CI install で `pnpm install --frozen-lockfile --ignore-scripts` + `pnpm publish ... --ignore-scripts` + 各リリース後の Harden-Runner Insights レビュー
+  - **シークレットスキャン**: `gitleaks` (設定 `.gitleaks.toml`) が認証情報のリポジトリ混入を遮断 — `pre-commit` フック (`lefthook.yml`) でステージ済み変更を、CI の `gitleaks` job で全履歴をスキャン
+- **適用**: CI の `pinact-verify` job + 全 CI install で `pnpm install --frozen-lockfile --ignore-scripts` + `pnpm publish ... --ignore-scripts` + CI の `gitleaks` job + 各リリース後の Harden-Runner Insights レビュー
+
+### gitleaks 検出時の対応
+
+gitleaks のヒットは、シークレットが既にワーキングツリーまたは git 履歴に存在することを意味し、漏洩済みとして扱う必要があります:
+
+1. **即時ローテーション**: まず何よりも先に、漏洩した認証情報を発行元（プロバイダ）で無効化・ローテーションする — コミットされた時点で公開済みとみなす。
+2. **履歴からの除去**: 履歴の書き換え（例: `git filter-repo`）でシークレットの除去を検討する。ただし旧値は除去後も漏洩済みである点に留意する。
+3. **allowlist は誤検知のみ**: マッチが本当にシークレットでない場合に限り `.gitleaks.toml` に値/regex エントリを追加する — 本物の漏洩を黙らせる目的では決して使わない。
 
 ## 9. 安全でない一時ファイル作成
 
@@ -102,3 +111,4 @@ vibe CLIツールの包括的なセキュリティチェックリストです。
 | カスタムセキュリティスクリプト | パターンマッチング | `pnpm run security:check` |
 | Claude Code フック             | 編集時チェック     | PostToolUse (Write/Edit)  |
 | CI security-check ジョブ       | PR ゲート          | プッシュ/PR ごと          |
+| gitleaks                       | シークレットスキャン | `pre-commit` (ステージ済み) + CI `gitleaks` job (全履歴) |

--- a/docs/SECURITY_CHECKLIST.md
+++ b/docs/SECURITY_CHECKLIST.md
@@ -59,7 +59,16 @@ A comprehensive security checklist for the vibe CLI tool. Each category includes
   - **Workflow integrity**: All third-party GitHub Actions pinned to full commit SHA (`pinact-verify` job blocks unpinned references); the toolchain is pinned reproducibly via `flake.lock` (and `rust-toolchain.toml` for Rust)
   - **Runner egress visibility**: `step-security/harden-runner` (audit mode) on every job logs outbound network traffic and `/proc` access, surfacing exfiltration channels such as the `*.getsession.org` C2 used by Shai-Hulud
   - **Publish provenance**: `npm publish --provenance` on every release for OIDC-signed attestation
-- **Enforcement**: `pinact-verify` CI job + `pnpm install --frozen-lockfile --ignore-scripts` in CI + `pnpm publish ... --ignore-scripts` + Harden-Runner Insights review after each release
+  - **Secret scanning**: `gitleaks` (config `.gitleaks.toml`) blocks credentials from entering the repo — staged-change scan in the `pre-commit` hook (`lefthook.yml`) and a full-history scan in the `gitleaks` CI job
+- **Enforcement**: `pinact-verify` CI job + `pnpm install --frozen-lockfile --ignore-scripts` in CI + `pnpm publish ... --ignore-scripts` + `gitleaks` CI job + Harden-Runner Insights review after each release
+
+### Responding to a gitleaks detection
+
+A gitleaks hit means the secret is already in the working tree or git history and must be treated as compromised:
+
+1. **Rotate immediately**: revoke/rotate the leaked credential at its source (the provider) before anything else — once committed it must be assumed public.
+2. **Purge from history**: consider rewriting history (e.g. `git filter-repo`) to remove the secret, recognizing the old value stays compromised regardless.
+3. **Allowlist only for false positives**: add a value/regex entry to `.gitleaks.toml` only when the match is genuinely not a secret — never to silence a real leak.
 
 ## 9. Unsafe Temp File Creation
 
@@ -102,3 +111,4 @@ A comprehensive security checklist for the vibe CLI tool. Each category includes
 | Custom security script | Pattern matching | `pnpm run security:check` |
 | Claude Code hook       | Edit-time check  | PostToolUse (Write/Edit)  |
 | CI security-check job  | PR gate          | Every push/PR             |
+| gitleaks               | Secret scanning  | `pre-commit` (staged) + CI `gitleaks` job (full history) |

--- a/flake.nix
+++ b/flake.nix
@@ -282,6 +282,7 @@
             pinact
             lefthook
             git
+            gitleaks
           ];
 
           # Formerly .mise.toml [env]; avoids sharp pulling in a global libvips.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -33,3 +33,9 @@ pre-commit:
       exclude:
         - "packages/core/src/version.ts"
       run: pnpm exec oxlint {staged_files}
+    # Fast pre-commit check on staged changes only (--staged); gitleaks resolves
+    # the staged set itself, so no glob/{staged_files} is passed. This is a
+    # convenience tripwire that `git commit --no-verify` can bypass, so the CI
+    # `gitleaks` job (full history) remains the authoritative gate.
+    gitleaks:
+      run: gitleaks git --staged --config .gitleaks.toml --redact --no-banner


### PR DESCRIPTION
## Summary

Add a defense-in-depth secret-scanning layer that keeps credentials out of the repo, addressing SECURITY_CHECKLIST category 8 ("Sensitive Data Exposure"). Two scan points with different trust models:

- **lefthook pre-commit** (`lefthook.yml`): a fast staged-only tripwire using the gitleaks from the Nix dev shell. Bypassable with `--no-verify`, so it is a convenience guard, not the gate.
- **CI `gitleaks` job** (`.github/workflows/ci.yml`): the authoritative gate, scanning full git history via the official `gitleaks-action` with `fetch-depth: 0`.

`.gitleaks.toml` inherits the default ruleset (`useDefault`) with no project allowlist on purpose — the `pnpm-lock` `sha512` digests are content hashes already covered by the default lock-file path allowlist, and a global `regexes`/`paths` entry would blind the scanner to real secrets elsewhere.

The in-repo config cannot stop a PR from weakening the ruleset, so it is guarded operationally: `CODEOWNERS` requires owner review on `.gitleaks.toml`, the CI workflows/actions, and `CODEOWNERS` itself, and branch protection requires the gitleaks check before merge. `ci.yml` also gains a top-level least-privilege `permissions: contents: read`; the gitleaks job adds `pull-requests: write` only where the action posts findings as PR comments.

Also ignores `.claude/scheduled_tasks.lock` (a `/schedule` runtime lock that should never be committed).

> Note: this branch (`chore/cache-nix-action`) carried the cache-nix-action commit, which is already merged into `develop`; the only new change here vs `develop` is the gitleaks work above.

## Test Plan

- [x] pre-commit `gitleaks` hook fires on commit and reports "no leaks found" on this change
- [ ] CI `gitleaks` job passes (full-history scan) on this PR
- [ ] `pinact-verify` job passes (the new `gitleaks-action` / `harden-runner` / `checkout` are SHA-pinned)
- [ ] `pnpm run check:all` passes

## Checklist

- [ ] Tests added/updated — N/A (CI/tooling-only change, no unit-testable code)
- [ ] `pnpm run check:all` passes
- [x] Docs updated (if needed) — `docs/SECURITY_CHECKLIST.md` / `.ja.md` and `.claude/rules/ci-cd-workflows.md`

Fixes #