### PR TITLE
fix(nix): update pnpmDeps hash to match current lockfile

### DIFF
--- a/.claude/rules/tool-versions.md
+++ b/.claude/rules/tool-versions.md
@@ -19,3 +19,28 @@ globs:
   major-only versions is prohibited due to supply chain attack risks.
 - When updating versions, verify functionality (`nix develop` + `pnpm run check:all`)
   before committing.
+
+## Fixed-output hashes that track the lockfile
+
+`flake.nix` carries fixed-output hashes that are NOT covered by `flake.lock`
+and must be updated by hand whenever the thing they hash changes:
+
+- `pnpmDeps.hash` — the `fetchPnpmDeps` output. **Changes whenever
+  `pnpm-lock.yaml` changes** (a dependency add/remove/bump, or a `pnpm install`
+  that rewrites integrity digests). Stale here means the `nix-build` job fails
+  with `hash mismatch in fixed-output derivation … vibe-pnpm-deps`.
+- `pnpmPinned.hash` — only when the pinned pnpm version itself is bumped.
+- The four `platforms.*.hash` prebuilt-binary hashes — only on a release that
+  republishes those binaries.
+
+To refresh `pnpmDeps.hash` after a lockfile change, build it and copy the
+`got:` value Nix reports (OS-independent — same on Linux and macOS):
+
+```sh
+nix build '.#fromSource.pnpmDeps' --rebuild   # prints specified: / got:
+```
+
+Then paste the `got:` `sha256-…` into `flake.nix` and confirm `nix flake check`
+passes. Because the `nix-build` job runs only on its `paths` filter
+(`pnpm-lock.yaml`, `flake.nix`, …) and is easy to miss on merge, **always run
+this check locally in any PR that touches `pnpm-lock.yaml`.**

--- a/flake.nix
+++ b/flake.nix
@@ -165,7 +165,7 @@
               ;
             pnpm = pnpmPinned;
             fetcherVersion = 3;
-            hash = "sha256-RPW842JniDhnnpPiU+n+LP3LovZHnsamVN/RmDmxyyQ=";
+            hash = "sha256-qU/e6Q3HGPrVXIfgHq9gbUsPUiW/+IEtE3fcYJvruTE=";
           };
 
           nativeBuildInputs = [


### PR DESCRIPTION
## Summary

The `nix-build` job (`.github/workflows/nix.yml`) has been failing on `develop` since #484 with a fixed-output hash mismatch:

```
error: hash mismatch in fixed-output derivation '…-vibe-pnpm-deps.drv':
         specified: sha256-RPW842JniDhnnpPiU+n+LP3LovZHnsamVN/RmDmxyyQ=
            got:    sha256-qU/e6Q3HGPrVXIfgHq9gbUsPUiW/+IEtE3fcYJvruTE=
```

**Root cause:** #484 (the oxlint/oxfmt migration) rewrote `pnpm-lock.yaml` but did not refresh `flake.nix`'s `pnpmDeps.hash`; #487 carried the stale hash forward. The hash is a fixed-output digest of the pnpm dependency fetch, so it must be updated whenever the lockfile changes.

**Why it stayed hidden:** `nix.yml` runs only on its `paths` filter (`pnpm-lock.yaml`, `flake.nix`, …), and a failure on the *post-merge push* no longer blocks anything (already merged). It only resurfaced on **PR #466** — a Dependabot harden-runner bump that edits `nix.yml` itself, re-triggering the job on a PR. So #466's `nix-build` failure is **not** caused by harden-runner; it just exposed this pre-existing `develop` regression.

**The fix** updates `flake.nix:168` to the correct hash. The value is OS-independent: Linux CI and a local macOS `nix build .#fromSource.pnpmDeps --rebuild` both report the same `got`. (The earlier local "pass" was a stale Nix-store cache hit that skipped verification.)

This also documents, in `.claude/rules/tool-versions.md`, that `pnpmDeps.hash` must be refreshed on every `pnpm-lock.yaml` change, with the exact recompute command — so lockfile churn does not re-break this silently.

> **Once this merges, rebase/re-run #466** — its `nix-build` will then pass without any harden-runner change.

## Test Plan

- [x] `nix build .#fromSource.pnpmDeps` succeeds locally with the new hash (macOS/aarch64-darwin)
- [x] `nix flake check` passes locally (`all checks passed!`)
- [x] Confirmed Linux CI and local macOS produce the identical `got` hash (OS-independent)
- [ ] `nix-build` (Nix workflow) passes on this PR in CI

## Checklist

- [ ] Tests added/updated — N/A (build-config fix, covered by the existing `nix-build` job)
- [ ] `pnpm run check:all` passes — N/A (no source/TS change; `flake.nix` + a docs rule only)
- [x] Docs updated (if needed) — `.claude/rules/tool-versions.md`

Fixes #