### PR TITLE
chore: make beta release manual-trigger only

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,13 +1,12 @@
 name: Beta Release
 
 on:
-  push:
-    branches: [develop]
+  workflow_dispatch:
 
-# Prevent duplicate beta releases by limiting concurrent runs
+# Serialize concurrent manual runs without killing an in-flight build
 concurrency:
   group: beta-release
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

The Beta Release workflow ran on every push to `develop`, the main development branch, so each push kicked off a full 5-platform binary build, prerelease creation, and Homebrew tap update. That is excessive for a beta channel where building on demand is enough.

This switches the trigger from `push: [develop]` to `workflow_dispatch`, so betas are built only when explicitly requested via the GitHub UI or `gh workflow run "Beta Release"`. `cancel-in-progress` is set to `false` so back-to-back manual runs each complete instead of killing an in-flight build (the previous `true` only made sense for push-storm dedup).

The version logic keeps using `github.run_number` (still assigned for `workflow_dispatch`), and the existing `gh release view` duplicate check guards against collisions. The build / release / Homebrew jobs are unchanged.

Related to #477.

## Test Plan

- [ ] After merge, run `gh workflow run "Beta Release"` and confirm a `v<version>-beta.<n>` prerelease is created and `vibe-beta.rb` in the Homebrew tap is updated
- [ ] Push to `develop` and confirm the Beta Release workflow does **not** start
- [x] `ruby -ryaml` parse of `beta-release.yml` succeeds

## Checklist

- [ ] Tests added/updated — N/A (CI workflow change, no test target)
- [ ] \`pnpm run check:all\` passes — N/A (workflow-only change; no source/docs touched)
- [ ] Docs updated (if needed) — N/A (no documented behavior change; beta build remains, just manual)