### PR TITLE
fix: build release binaries with official bun to drop /nix/store deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,35 @@ jobs:
 
       - uses: ./.github/actions/setup-toolchain
 
+      # bug #490: `bun build --compile` bakes the running bun into the binary.
+      # The Nix-store bun links libicucore.A.dylib by /nix/store path, so the
+      # released binary fails dyld resolution on non-Nix (Homebrew) hosts. Build
+      # the binary with an official bun instead. Pin it to the Nix bun version
+      # (derived from the flake.lock-locked nixpkgs bun) so the two never drift.
+      - name: Pin official bun to the Nix bun version
+        if: runner.os != 'Windows'
+        id: bunver
+        shell: bash
+        run: echo "version=$(bun --version)" >> "$GITHUB_OUTPUT"
+      - name: Setup official bun
+        if: runner.os != 'Windows'
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: ${{ steps.bunver.outputs.version }}
+      - name: Resolve official bun path
+        if: runner.os != 'Windows'
+        id: officialbun
+        shell: bash
+        run: |
+          # Fail loudly if setup-bun did not land where expected, rather than
+          # silently falling back to the Nix bun and re-introducing #490.
+          bun_path="$HOME/.bun/bin/bun"
+          if [ ! -x "$bun_path" ]; then
+            echo "::error::official bun not found at $bun_path"
+            exit 1
+          fi
+          echo "path=$bun_path" >> "$GITHUB_OUTPUT"
+
       - uses: ./.github/actions/setup-takumi-guard
         with:
           api-key: ${{ secrets.TAKUMI_GUARD_API_KEY }}
@@ -81,6 +110,11 @@ jobs:
           fi
 
       - name: Build release binary
+        env:
+          # Non-Windows: bake the official bun (resolved above) as the baseclient
+          # so no /nix/store dependency is embedded (bug #490). Windows leaves this
+          # empty and uses the PATH bun (the official setup-bun from setup-toolchain).
+          VIBE_COMPILE_BUN: ${{ runner.os != 'Windows' && steps.officialbun.outputs.path || '' }}
         run: bun run scripts/build.ts --target ${{ matrix.target }} --output ${{ matrix.artifact }} --distribution binary
 
       - name: Verify native module embedding
@@ -91,6 +125,32 @@ jobs:
             exit 1
           fi
           echo "Native module embedding verified"
+
+      - name: Assert no /nix/store references in release binary
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          BIN: ${{ matrix.artifact }}
+        run: |
+          # bug #490 regression guard: a /nix/store path in the released binary
+          # (linked dylib or embedded string) breaks launch on non-Nix hosts.
+          fail=0
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            otool -L "$BIN" || true
+            if otool -L "$BIN" | grep -q '/nix/store'; then fail=1; fi
+          else
+            if ldd "$BIN" 2>/dev/null | grep -q '/nix/store'; then fail=1; fi
+          fi
+          if strings "$BIN" | grep -q '/nix/store'; then
+            echo "::error::release binary embeds /nix/store path(s)"
+            strings "$BIN" | grep '/nix/store' | head
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::$BIN depends on /nix/store; breaks on non-Nix hosts (#490 regression)"
+            exit 1
+          fi
+          echo "OK: no /nix/store references"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -118,6 +178,29 @@ jobs:
 
       - uses: ./.github/actions/setup-toolchain
 
+      # bug #490: same official-bun baseclient as the build job, so the deb's
+      # rebuilt binary carries no /nix/store dependency.
+      - name: Pin official bun to the Nix bun version
+        id: bunver
+        shell: bash
+        run: echo "version=$(bun --version)" >> "$GITHUB_OUTPUT"
+      - name: Setup official bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: ${{ steps.bunver.outputs.version }}
+      - name: Resolve official bun path
+        id: officialbun
+        shell: bash
+        run: |
+          # Fail loudly if setup-bun did not land where expected, rather than
+          # silently falling back to the Nix bun and re-introducing #490.
+          bun_path="$HOME/.bun/bin/bun"
+          if [ ! -x "$bun_path" ]; then
+            echo "::error::official bun not found at $bun_path"
+            exit 1
+          fi
+          echo "path=$bun_path" >> "$GITHUB_OUTPUT"
+
       - uses: ./.github/actions/setup-takumi-guard
         with:
           api-key: ${{ secrets.TAKUMI_GUARD_API_KEY }}
@@ -132,9 +215,32 @@ jobs:
         run: pnpm install --ignore-scripts
 
       - name: Rebuild with deb distribution metadata
+        env:
+          # bug #490: bake the official bun, not the Nix-store bun, into the deb binary.
+          VIBE_COMPILE_BUN: ${{ steps.officialbun.outputs.path }}
         run: |
           TARGET="${{ matrix.arch == 'amd64' && 'x86_64-unknown-linux-gnu' || 'aarch64-unknown-linux-gnu' }}"
           bun run scripts/build.ts --target "$TARGET" --output vibe-deb --distribution deb
+
+      - name: Assert no /nix/store references in deb binary
+        shell: bash
+        run: |
+          # bug #490 regression guard for the Linux/deb binary. This job runs on
+          # an amd64 runner for both arches, so `ldd` cannot resolve the arm64
+          # binary (architecture mismatch) — `strings` grep is the primary check;
+          # ldd is a best-effort extra signal only on the amd64 build.
+          fail=0
+          if ldd vibe-deb 2>/dev/null | grep -q '/nix/store'; then fail=1; fi
+          if strings vibe-deb | grep -q '/nix/store'; then
+            echo "::error::deb binary embeds /nix/store path(s)"
+            strings vibe-deb | grep '/nix/store' | head
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::vibe-deb depends on /nix/store; breaks on non-Nix hosts (#490 regression)"
+            exit 1
+          fi
+          echo "OK: no /nix/store references"
 
       - name: Build .deb package
         run: |

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -185,7 +185,19 @@ async function compile(options: CompileOptions): Promise<void> {
   args.push("--outfile", options.output);
   args.push("main.ts");
 
-  await runCommand("bun", args, { inherit: true });
+  // `bun build --compile` bakes the *running* bun runtime into the binary as the
+  // baseclient, so the binary inherits that bun's dynamic-library dependencies.
+  // VIBE_COMPILE_BUN lets CI point this at an official (oven-sh) bun instead of
+  // the PATH bun. Why not just rely on PATH: in CI the PATH bun is the Nix-store
+  // bun, which links libicucore.A.dylib (and friends) by absolute /nix/store
+  // path — those paths do not exist on a Homebrew/non-Nix host, so the embedded
+  // baseclient fails dyld resolution at launch (bug #490). Unset locally, the
+  // default "bun" keeps dev and Nix source builds unchanged.
+  // Why `||` not `??`: CI passes an empty string on Windows (the ternary's else
+  // branch), and an empty bun path must fall back to "bun", not spawn("").
+  const bunBin = process.env.VIBE_COMPILE_BUN || "bun";
+
+  await runCommand(bunBin, args, { inherit: true });
 }
 
 const parseArgsOptions: ParseArgsConfig["options"] = {


### PR DESCRIPTION
## Summary

Homebrew-distributed `vibe` 1.8.0 aborted at launch on non-Nix hosts with a dyld error (`/nix/store/...-ICU-.../lib/libicucore.A.dylib` not loaded). `bun build --compile` bakes the *running* bun runtime into the binary as the baseclient, and the release job ran it under the Nix-store bun — whose absolute `/nix/store` dylib paths do not exist on a Homebrew/non-Nix machine. The same defect affected the Linux and `.deb` binaries.

This compiles the release binaries with an official (oven-sh) bun instead, pinned to the Nix bun version (derived from the flake.lock-locked nixpkgs bun) so the two never drift. Native-module (rust/napi) and `pnpm install` steps stay on Nix; only the `bun build --compile` baseclient is swapped, via a new `VIBE_COMPILE_BUN` env honored by `scripts/build.ts` (default behavior unchanged when unset). A CI guard fails the release if any distributed binary still references `/nix/store`.

Related to #490.

## Test Plan

- [x] `pnpm run check:all` passes (501 passed / 3 skipped; lint, format, typecheck green)
- [x] `scripts/build.ts` behaves identically when `VIBE_COMPILE_BUN` is unset (`|| "bun"` fallback)
- [ ] On the next release, confirm `otool -L vibe-darwin-arm64 | grep -c /nix/store == 0` and `strings vibe-linux-* | grep -c /nix/store == 0`
- [ ] Verify the rebuilt `vibe-darwin-arm64` launches on a non-Nix macOS host (`vibe --version`, `vibe start <branch>`)

## Checklist

- [ ] Tests added/updated <!-- N/A: scripts/ has no test harness; the CI binary guard provides the regression check -->
- [x] `pnpm run check:all` passes
- [ ] Docs updated (if needed) <!-- N/A: CI-internal change, no user-facing docs affected -->

Fixes #490