### PR TITLE
chore: add justfile as a unified task entrypoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,31 +4,35 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Development Commands
 
+`just` is the unified entrypoint (a thin facade over the pnpm scripts; run
+`just` with no args to list recipes). The equivalent `pnpm run` command is shown
+alongside each — both work.
+
 ```bash
 # Run ALL checks (REQUIRED before creating PR):
 # fmt:check + lint (oxfmt/oxlint on scripts) + check:rust + test:npm + check:docs + check:video
 # NOTE: check:all does NOT run test:e2e (it needs a built binary); CI's e2e-test
-# job gates that. Run `pnpm run test:e2e` manually when touching command behavior.
-pnpm run check:all
+# job gates that. Run `just test-e2e` manually when touching command behavior.
+just check                   # = pnpm run check:all
 
 # Rust (the shipped binary) — fmt + clippy + workspace tests
-pnpm run check:rust
+just check-rust              # = pnpm run check:rust
 
 # Build the shipped Rust binary (release)
-pnpm run build:rust          # cargo build --manifest-path rust/Cargo.toml -p vibe --release
+just build                   # = pnpm run build:rust (cargo build --manifest-path rust/Cargo.toml -p vibe --release)
 
 # Run the Rust binary directly during development
-cargo run --manifest-path rust/Cargo.toml -p vibe -- <command>
+just run -- <command>        # = cargo run --manifest-path rust/Cargo.toml -p vibe -- <command>
 
 # npm launcher-shim tests (shim resolution + the surviving release scripts)
-pnpm run test:npm
+just test-npm                # = pnpm run test:npm
 
 # E2E tests (drive the built binary through node-pty)
-pnpm run test:e2e
+just test-e2e                # = pnpm run test:e2e
 
 # Checks for docs / video packages only
-pnpm run check:docs
-pnpm run check:video
+just check-docs              # = pnpm run check:docs
+just check-video             # = pnpm run check:video
 ```
 
 ## Architecture

--- a/flake.nix
+++ b/flake.nix
@@ -154,6 +154,7 @@
             lefthook
             git
             gitleaks
+            just
           ];
 
           # Formerly .mise.toml [env]; avoids sharp pulling in a global libvips.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,90 @@
+# vibe — unified task entrypoint.
+#
+# Thin facade over the existing runners (pnpm / cargo). Each recipe delegates to
+# the matching `package.json` script so command strings live in exactly one place
+# (package.json stays the source of truth); this file only provides a single,
+# memorable front door instead of three scattered ones (pnpm / cargo / bun).
+#
+# Why not name recipes `check:rust` to match the pnpm scripts? `:` is just's
+# module-path separator, so recipe names use `-` (e.g. `check-rust`). The pnpm
+# script names themselves are unchanged.
+# Why not inline `--manifest-path rust/Cargo.toml` here? It already lives in the
+# pnpm scripts; the only cargo call we make directly is `run`, which has no pnpm
+# script to defer to.
+
+# Default: list available recipes.
+default:
+    @just --list
+
+# --- Aggregate check ---
+
+# All checks required before opening a PR (fmt:check + lint + check:rust + test:npm + check:docs + check:video).
+check:
+    pnpm run check:all
+
+# --- Build / run ---
+
+# Build the shipped Rust binary (release).
+build:
+    pnpm run build:rust
+
+# Run the Rust binary directly during development, e.g. `just run -- start`.
+run *args:
+    cargo run --manifest-path rust/Cargo.toml -p vibe -- {{args}}
+
+# --- Individual checks ---
+
+# Rust (shipped binary) — fmt + clippy + workspace tests.
+check-rust:
+    pnpm run check:rust
+
+# Docs package checks only (lint + format + check).
+check-docs:
+    pnpm run check:docs
+
+# Video package typecheck only.
+check-video:
+    pnpm run check:video
+
+# --- Format / lint (TS/JS via oxfmt/oxlint) ---
+
+fmt:
+    pnpm run fmt
+
+fmt-check:
+    pnpm run fmt:check
+
+lint:
+    pnpm run lint
+
+lint-fix:
+    pnpm run lint:fix
+
+# --- Tests ---
+
+# npm launcher-shim tests.
+test-npm:
+    pnpm run test:npm
+
+# E2E tests — drive the built binary; needs a prior `just build` (not part of `just check`).
+test-e2e:
+    pnpm run test:e2e
+
+# --- Setup / chores ---
+
+install:
+    pnpm install
+
+clean:
+    pnpm run clean
+
+# --- Docs / video dev servers (per-package) ---
+
+docs-dev:
+    pnpm -C packages/docs dev
+
+video:
+    pnpm -C packages/video start
+
+video-render:
+    pnpm -C packages/video render


### PR DESCRIPTION
## Summary

Development commands were split across three runners (`pnpm run X`, `cargo ... --manifest-path rust/Cargo.toml`, `bun run scripts/X`), so the same goal had different front doors and was hard to remember.

This PR introduces `just` as a single, memorable entrypoint that delegates to the existing pnpm scripts:

- **`justfile`** (new) — a thin facade. Each recipe defers to the matching `package.json` script, so command strings live in exactly one place (package.json stays the source of truth). The only direct `cargo` call is `just run -- <command>`, since no pnpm script covers it. Recipe names use `-` instead of `:` (e.g. `check-rust`), because `:` is just's module-path separator; the pnpm script names are unchanged.
- **`flake.nix`** — `just` added to the dev shell so it is available in `nix develop`.
- **`CLAUDE.md`** — Development Commands rewritten as `just <recipe>  # = pnpm run <script>`, keeping both forms working during the transition.

Out of scope (intentionally unchanged): CI workflows keep their direct `pnpm`/`cargo`/`bun` calls, and `package.json` script names/contents are untouched.

## Test Plan

- [x] `nix develop --command just --version` resolves (just 1.51.0)
- [x] `just` (no args) lists all recipes cleanly
- [x] `just fmt-check` correctly delegates to `pnpm run fmt:check` (oxfmt clean)
- [x] `nix flake check` passes with `just` added to the dev shell
- [ ] `just check` (= `pnpm run check:all`) full run

## Checklist

- [ ] Tests added/updated (N/A — task-runner facade, no behavior change)
- [ ] `pnpm run check:all` passes (not yet run end-to-end; representative recipes verified)
- [x] Docs updated (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)