### PR TITLE
test: include e2e in full checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,9 @@ Code should follow SOLID principles:
 - Format check (TS scripts): `pnpm run fmt:check`
 - Rust checks (fmt + clippy + tests): `pnpm run check:rust`
 - npm shim / release-script tests: `pnpm run test:npm`
+- E2E tests: `pnpm run test:e2e`
 - Run all checks: `pnpm run check:all`
-  (fmt:check, lint, check:rust, test:npm, check:docs, check:video)
+  (fmt:check, lint, check:rust, test:npm, test:e2e, check:docs, check:video)
 - All checks must pass before committing
 
 ## Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,7 @@ alongside each — both work.
 
 ```bash
 # Run ALL checks (REQUIRED before creating PR):
-# fmt:check + lint (oxfmt/oxlint on scripts) + check:rust + test:npm + check:docs + check:video
-# NOTE: check:all does NOT run test:e2e (it needs a built binary); CI's e2e-test
-# job gates that. Run `just test-e2e` manually when touching command behavior.
+# fmt:check + lint (oxfmt/oxlint on scripts) + check:rust + test:npm + test:e2e + check:docs + check:video
 just check                   # = pnpm run check:all
 
 # Rust (the shipped binary) — fmt + clippy + workspace tests
@@ -27,7 +25,7 @@ just run -- <command>        # = cargo run --manifest-path rust/Cargo.toml -p vi
 # npm launcher-shim tests (shim resolution + the surviving release scripts)
 just test-npm                # = pnpm run test:npm
 
-# E2E tests (drive the built binary through node-pty)
+# E2E tests (build and drive the Rust debug binary through node-pty)
 just test-e2e                # = pnpm run test:e2e
 
 # Checks for docs / video packages only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ pnpm run fmt:check     # Check TS-script formatting (oxfmt)
 pnpm run lint          # Run linter (oxlint) on the TS scripts
 pnpm run check:rust    # Rust: cargo fmt --check + clippy -D warnings + workspace tests
 pnpm run test:npm      # npm launcher-shim + release-script tests
+pnpm run test:e2e      # Build and run E2E tests against the Rust debug binary
 pnpm run check:docs    # Docs package checks
 pnpm run check:video   # Video package typecheck
 
@@ -70,8 +71,9 @@ This runs:
 2. Linter (`pnpm run lint`)
 3. Rust checks (`pnpm run check:rust`)
 4. npm shim / release-script tests (`pnpm run test:npm`)
-5. Docs checks (`pnpm run check:docs`)
-6. Video typecheck (`pnpm run check:video`)
+5. E2E tests (`pnpm run test:e2e`)
+6. Docs checks (`pnpm run check:docs`)
+7. Video typecheck (`pnpm run check:video`)
 
 ## Release Process
 

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ default:
 
 # --- Aggregate check ---
 
-# All checks required before opening a PR (fmt:check + lint + check:rust + test:npm + check:docs + check:video).
+# All checks required before opening a PR (fmt:check + lint + check:rust + test:npm + test:e2e + check:docs + check:video).
 check:
     pnpm run check:all
 
@@ -66,7 +66,7 @@ lint-fix:
 test-npm:
     pnpm run test:npm
 
-# E2E tests — drive the built binary; needs a prior `just build` (not part of `just check`).
+# E2E tests — build and drive the Rust debug binary.
 test-e2e:
     pnpm run test:e2e
 

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "get-version": "node -e \"console.log(JSON.parse(require('fs').readFileSync('package.json')).version)\"",
     "install:all": "pnpm install",
     "test:npm": "pnpm -C packages/npm test",
-    "test:e2e": "pnpm -C packages/e2e test",
+    "test:e2e": "cargo build --manifest-path rust/Cargo.toml -p vibe && pnpm -C packages/e2e test",
     "clean": "pnpm -r exec rm -rf node_modules dist",
     "check:docs": "pnpm -C packages/docs lint && pnpm -C packages/docs format && pnpm -C packages/docs check",
     "check:video": "pnpm -C packages/video typecheck",
-    "check:all": "pnpm run fmt:check && pnpm run lint && pnpm run check:rust && pnpm run test:npm && pnpm run check:docs && pnpm run check:video"
+    "check:all": "pnpm run fmt:check && pnpm run lint && pnpm run check:rust && pnpm run test:npm && pnpm run test:e2e && pnpm run check:docs && pnpm run check:video"
   },
   "dependencies": {
     "smol-toml": "^1.6.0"

--- a/packages/e2e/helpers/pty.ts
+++ b/packages/e2e/helpers/pty.ts
@@ -1,4 +1,5 @@
 import * as pty from "node-pty";
+import { existsSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
@@ -134,7 +135,7 @@ export class VibeCommandRunner {
 
 /**
  * Get the path to the vibe binary for testing
- * Defaults to the VIBE_BINARY_PATH environment variable or '<repo-root>/vibe-e2e'
+ * Defaults to the VIBE_BINARY_PATH environment variable or the Cargo debug binary.
  */
 export function getVibePath(): string {
   if (process.env.VIBE_BINARY_PATH) {
@@ -144,5 +145,14 @@ export function getVibePath(): string {
   // Get repo root by going up from packages/e2e/helpers directory
   const currentDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(currentDir, "..", "..", "..");
-  return join(repoRoot, "vibe-e2e");
+  const binaryName = process.platform === "win32" ? "vibe.exe" : "vibe";
+  const binaryPath = join(repoRoot, "rust", "target", "debug", binaryName);
+
+  if (!existsSync(binaryPath)) {
+    throw new Error(
+      `E2E binary not found at ${binaryPath}. Run pnpm run test:e2e from the repository root, or set VIBE_BINARY_PATH.`,
+    );
+  }
+
+  return binaryPath;
 }


### PR DESCRIPTION
## Summary
- include E2E tests in the aggregate check:all workflow
- build the Rust debug binary before running E2E tests
- update contributor and agent docs to match the new required checks

## Tests
- pnpm run check:all