### PR TITLE
fix: honor start --force

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -120,6 +120,7 @@ vibe start feat/new-feature --base origin/develop --track
 | `--no-hooks`      | pre-startおよびpost-startフックをスキップ   |
 | `--no-copy`       | ファイルとディレクトリのコピーをスキップ    |
 | `-n`, `--dry-run` | 変更を加えずに実行内容を表示                |
+| `-f`, `--force`   | 確認をスキップ（既存Worktreeへ移動、または競合Worktreeを上書き） |
 
 #### Cleanオプション
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ This approach allows `vibe clean` to complete instantly regardless of worktree s
 | `--no-hooks`      | Skip pre-start and post-start hooks                |
 | `--no-copy`       | Skip copying files and directories                 |
 | `-n`, `--dry-run` | Show what would be executed without making changes |
+| `-f`, `--force`   | Skip prompts: navigate to existing branch worktree or overwrite conflicting worktree |
 
 #### Clean Options
 

--- a/packages/docs/src/content/docs/commands/start.mdx
+++ b/packages/docs/src/content/docs/commands/start.mdx
@@ -25,6 +25,7 @@ vibe start <branch> [options]
 | `--no-hooks`                  | Skip pre-start and post-start hooks       | <Badge text="v0.5.0+" />  |
 | `--no-copy`                   | Skip file and directory copying           | <Badge text="v0.5.0+" />  |
 | `-n`, `--dry-run`             | Preview operations without executing      | <Badge text="v0.8.0+" />  |
+| `-f`, `--force`               | Skip confirmation prompts                 |                           |
 | `-V`, `--verbose`             | Show detailed output                      | <Badge text="v0.8.0+" />  |
 | `-q`, `--quiet`               | Suppress non-essential output             | <Badge text="v0.8.0+" />  |
 | `--claude-code-worktree-hook` | Claude Code WorktreeCreate hook mode      | <Badge text="v0.23.0+" /> |
@@ -89,6 +90,8 @@ You can choose from:
 - **Overwrite**: Delete and recreate the worktree
 - **Reuse**: Use the existing directory as-is
 - **Cancel**: Abort the operation
+
+With `--force`, vibe skips these prompts. If the branch is already used by another worktree, vibe navigates to that worktree. If the target directory is a worktree for a different branch, vibe overwrites it and creates the requested worktree.
 
 ### Worktree Location
 

--- a/packages/docs/src/content/docs/ja/commands/start.mdx
+++ b/packages/docs/src/content/docs/ja/commands/start.mdx
@@ -25,6 +25,7 @@ vibe start <branch> [options]
 | `--no-hooks`                  | pre-startとpost-startフックをスキップ     | <Badge text="v0.5.0+" />  |
 | `--no-copy`                   | ファイル・ディレクトリのコピーをスキップ  | <Badge text="v0.5.0+" />  |
 | `-n`, `--dry-run`             | 実行せずに操作内容をプレビュー            | <Badge text="v0.8.0+" />  |
+| `-f`, `--force`               | 確認プロンプトをスキップ                  |                           |
 | `-V`, `--verbose`             | 詳細な出力を表示                          | <Badge text="v0.8.0+" />  |
 | `-q`, `--quiet`               | 不要な出力を抑制                          | <Badge text="v0.8.0+" />  |
 | `--claude-code-worktree-hook` | Claude Code WorktreeCreateフックモード    | <Badge text="v0.23.0+" /> |
@@ -89,6 +90,8 @@ $ vibe start feat/new-feature
 - **上書き**: 削除して再作成
 - **再利用**: 既存ディレクトリをそのまま使用
 - **キャンセル**: 操作を中止
+
+`--force`を指定すると、これらの確認プロンプトをスキップします。ブランチが他のWorktreeで既に使用されている場合は、そのWorktreeへ移動します。対象ディレクトリが異なるブランチのWorktreeの場合は、上書きして指定されたWorktreeを作成します。
 
 ### Worktreeの配置場所
 

--- a/packages/e2e/start.test.ts
+++ b/packages/e2e/start.test.ts
@@ -201,6 +201,41 @@ describe("start command", () => {
     }
   });
 
+  test("--force overwrites conflicting worktree without prompting", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+
+    const vibePath = getVibePath();
+    const parentDir = dirname(repoPath);
+    const repoName = basename(repoPath);
+    const worktreePath = `${parentDir}/${repoName}-feat-force`;
+
+    execFileSync("git", ["worktree", "add", "-b", "other", worktreePath], {
+      cwd: repoPath,
+      stdio: "pipe",
+    });
+
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
+    try {
+      await runner.spawn(["start", "feat/force", "--force"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+      assertOutputContains(output, "cd");
+      expect(output).not.toContain("Overwrite");
+
+      await assertDirectoryExists(worktreePath);
+      const branch = execFileSync("git", ["branch", "--show-current"], {
+        cwd: worktreePath,
+        encoding: "utf-8",
+      }).trim();
+      expect(branch).toBe("feat/force");
+    } finally {
+      runner.dispose();
+    }
+  });
+
   test("Error when branch name is missing", async () => {
     const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
     cleanup = repoCleanup;

--- a/rust/crates/vibe-core/src/commands/start.rs
+++ b/rust/crates/vibe-core/src/commands/start.rs
@@ -50,6 +50,9 @@ pub struct StartFlags {
     /// is a leading-dash base value allowed.
     pub base_from_equals: bool,
     pub track: bool,
+    /// Skip confirmation prompts: navigate to an already-used branch, and
+    /// overwrite a different-branch worktree at the target path.
+    pub force: bool,
     /// Claude-Code WorktreeCreate hook mode (stdin name → stdout path).
     pub worktree_hook: bool,
 }
@@ -134,8 +137,7 @@ where
                 "Branch is in use but worktree path is unknown".to_string(),
             ));
         };
-        if let Some(outcome) =
-            handle_existing_branch_worktree(deps, branch_name, &existing, flags.dry_run)?
+        if let Some(outcome) = handle_existing_branch_worktree(deps, branch_name, &existing, flags)?
         {
             return Ok(outcome);
         }
@@ -296,7 +298,7 @@ fn handle_existing_branch_worktree<I, G, R, S, P, Sr>(
     deps: &StartDeps<I, G, R, S, P, Sr>,
     branch_name: &str,
     existing: &str,
-    dry_run: bool,
+    flags: &StartFlags,
 ) -> Result<Option<Outcome>>
 where
     I: Io,
@@ -306,13 +308,17 @@ where
     P: Prompt,
     Sr: StdinReader,
 {
-    if dry_run {
+    if flags.dry_run {
         log_dry_run(
             deps.io,
             &format!("Branch '{branch_name}' is already used in worktree '{existing}'"),
         );
         log_dry_run(deps.io, &format!("Would navigate to: {existing}"));
         return Ok(Some(Outcome::none()));
+    }
+
+    if flags.force {
+        return Ok(Some(Outcome::cd(existing.to_string())));
     }
 
     let navigate = deps.prompt.confirm(&format!(
@@ -421,6 +427,11 @@ where
         );
         log_dry_run(deps.io, "Would prompt to Overwrite/Reuse/Cancel");
         return Ok(ConflictDecision::Done(Outcome::none()));
+    }
+
+    if flags.force {
+        remove_worktree(deps.git, worktree_path, true)?;
+        return Ok(ConflictDecision::Continue);
     }
 
     let choice = deps.prompt.select(

--- a/rust/crates/vibe-core/src/commands/start_tests.rs
+++ b/rust/crates/vibe-core/src/commands/start_tests.rs
@@ -145,6 +145,16 @@ impl Prompt for ScriptPrompt {
     }
 }
 
+struct PanicPrompt;
+impl Prompt for PanicPrompt {
+    fn confirm(&self, message: &str) -> bool {
+        panic!("confirm prompt should not run: {message}");
+    }
+    fn select(&self, message: &str, _choices: &[String]) -> Result<usize> {
+        panic!("select prompt should not run: {message}");
+    }
+}
+
 struct Fakes {
     hooks: FakeHookRunner,
     exec: FakeCopyExecutor,
@@ -251,6 +261,38 @@ fn existing_branch_worktree_cancels_on_decline() {
         start_command(&d, "feat", &StartFlags::default(), OutputOptions::default()).unwrap();
     assert_eq!(outcome, Outcome::none());
     assert!(io.stderr_text().contains("Cancelled"));
+}
+
+#[test]
+fn existing_branch_force_navigates_without_prompt() {
+    let (_fx, io) = io_with_home();
+    let git = MockGit::new("/repo", &two_worktrees("/repo", "/wt/feat", "feat"));
+    let (r, s, p, sin, fk) = (
+        NoResolver,
+        NoScript,
+        PanicPrompt,
+        FakeStdin::none(),
+        Fakes::new(),
+    );
+    let d = StartDeps {
+        io: &io,
+        git: &git,
+        resolver: &r,
+        script_runner: &s,
+        prompt: &p,
+        stdin: &sin,
+        hook_runner: &fk.hooks,
+        executor: &fk.exec,
+        tracker: &fk.tracker,
+        version: V,
+    };
+    let flags = StartFlags {
+        force: true,
+        ..Default::default()
+    };
+    let outcome = start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
+    assert_eq!(outcome, Outcome::cd("/wt/feat"));
+    assert!(!git.calls_contain(&["worktree", "add"]));
 }
 
 #[test]
@@ -494,6 +536,39 @@ fn different_branch_overwrite_removes_and_creates() {
         start_command(&d, "feat", &StartFlags::default(), OutputOptions::default()).unwrap();
     assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
     // Removed the old worktree (force, with `--`) then created the new one.
+    assert!(git.calls_contain(&["worktree", "remove", "--force", "--", "/home/u/repo-feat"]));
+    assert!(git.calls_contain(&["worktree", "add", "-b", "feat", "--", "/home/u/repo-feat"]));
+}
+
+#[test]
+fn different_branch_force_overwrites_without_prompt() {
+    let (_fx, io) = io_with_home();
+    let git = conflicting_git();
+    let (r, s, p, sin, fk) = (
+        NoResolver,
+        NoScript,
+        PanicPrompt,
+        FakeStdin::none(),
+        Fakes::new(),
+    );
+    let d = StartDeps {
+        io: &io,
+        git: &git,
+        resolver: &r,
+        script_runner: &s,
+        prompt: &p,
+        stdin: &sin,
+        hook_runner: &fk.hooks,
+        executor: &fk.exec,
+        tracker: &fk.tracker,
+        version: V,
+    };
+    let flags = StartFlags {
+        force: true,
+        ..Default::default()
+    };
+    let outcome = start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
+    assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
     assert!(git.calls_contain(&["worktree", "remove", "--force", "--", "/home/u/repo-feat"]));
     assert!(git.calls_contain(&["worktree", "add", "-b", "feat", "--", "/home/u/repo-feat"]));
 }

--- a/rust/crates/vibe/src/cli.rs
+++ b/rust/crates/vibe/src/cli.rs
@@ -79,13 +79,6 @@ pub struct StartArgs {
     #[arg(short = 'n', long = "dry-run")]
     pub dry_run: bool,
     /// Skip confirmation prompts.
-    //
-    // The TS `vibe start` accepts `--force/-f`: `parseArgsOptions` is a single
-    // flat `node:util parseArgs` table shared by every subcommand, so
-    // `vibe start --force` parses without error there, and `completion-spec.ts`
-    // declares `--force/-f` for `start`. We mirror that surface here (it is
-    // wired into start's behavior in Phase 4); for now it just needs to exist so
-    // clap and the completion spec agree with the TS reality.
     #[arg(short = 'f', long)]
     pub force: bool,
     /// Base branch/commit for the new branch.

--- a/rust/crates/vibe/src/commands/mod.rs
+++ b/rust/crates/vibe/src/commands/mod.rs
@@ -191,6 +191,7 @@ fn with_start_deps<T>(
 #[allow(clippy::too_many_arguments)]
 pub fn start(
     branch_name: &str,
+    force: bool,
     no_hooks: bool,
     no_copy: bool,
     dry_run: bool,
@@ -210,6 +211,7 @@ pub fn start(
         base,
         base_from_equals,
         track,
+        force,
         worktree_hook,
     };
     with_start_deps(opts, |deps| start_command(deps, branch_name, &flags, opts))
@@ -232,6 +234,7 @@ pub fn scratch(
         base,
         base_from_equals,
         track,
+        force: false,
         worktree_hook: false,
     };
     let clock = RealClock;

--- a/rust/crates/vibe/src/main.rs
+++ b/rust/crates/vibe/src/main.rs
@@ -13,12 +13,25 @@ mod version;
 
 use clap::Parser;
 use cli::{Cli, Command};
+use std::io::Write;
 use vibe_core::commands::Outcome;
 use vibe_core::output::OutputOptions;
 use vibe_core::{format_error_message, Io, RealIo, VibeError};
 
 fn main() {
-    let cli = Cli::parse();
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(error) => {
+            let exit_code = error.exit_code();
+            // The shell wrapper evals stdout, so clap help must use stderr just
+            // like the TypeScript CLI did.
+            let _ = write!(std::io::stderr(), "{error}");
+            if error.kind() == clap::error::ErrorKind::DisplayHelp {
+                eprintln!("{}#readme", version::REPOSITORY);
+            }
+            std::process::exit(exit_code);
+        }
+    };
 
     // Custom version output, matching the TS BUILD_INFO block (stderr, exit 0).
     if cli.version {
@@ -92,6 +105,7 @@ fn dispatch(command: Command, opts: OutputOptions) -> Result<Outcome, VibeError>
         }
         Command::Start(args) => commands::start(
             &args.branch_name.unwrap_or_default(),
+            args.force,
             args.no_hooks,
             args.no_copy,
             args.dry_run,
@@ -131,7 +145,7 @@ fn dispatch(command: Command, opts: OutputOptions) -> Result<Outcome, VibeError>
 fn print_help() {
     use clap::CommandFactory;
     let mut cmd = Cli::command();
-    let _ = cmd.print_help();
+    let _ = cmd.write_help(&mut std::io::stderr());
     eprintln!();
     eprintln!("{}#readme", version::REPOSITORY);
 }

--- a/rust/crates/vibe/tests/eval_contract.rs
+++ b/rust/crates/vibe/tests/eval_contract.rs
@@ -99,6 +99,43 @@ fn run_vibe_stdin(
     child.wait_with_output().expect("wait vibe")
 }
 
+#[test]
+fn help_writes_to_stderr_not_stdout() {
+    let home = tempfile::tempdir().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+
+    let out = run_vibe(tmp.path(), home.path(), &["--help"]);
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+
+    assert!(out.status.success(), "help should exit 0: {stderr:?}");
+    assert!(
+        stdout.is_empty(),
+        "help must not be eval'd from stdout: {stdout:?}"
+    );
+    assert!(stderr.contains("Usage: vibe"), "help missing from stderr");
+}
+
+#[test]
+fn bare_invocation_help_writes_to_stderr_not_stdout() {
+    let home = tempfile::tempdir().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+
+    let out = run_vibe(tmp.path(), home.path(), &[]);
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+
+    assert!(
+        out.status.success(),
+        "bare invocation should exit 0: {stderr:?}"
+    );
+    assert!(
+        stdout.is_empty(),
+        "bare help must not be eval'd from stdout: {stdout:?}"
+    );
+    assert!(stderr.contains("Usage: vibe"), "help missing from stderr");
+}
+
 /// A single main worktree at `<root>/main` (no secondary). Returns the
 /// canonicalized main path. Used by create-path cases (start / scratch / jump).
 fn setup_main_repo(root: &Path) -> PathBuf {


### PR DESCRIPTION
## Summary

- Wire `vibe start --force` from clap dispatch into the Rust start command
- Skip start confirmation prompts with explicit defaults: navigate to an already-used branch worktree, or overwrite a conflicting worktree path
- Document the start `--force` behavior in EN/JA docs and README
- Keep the eval contract safe by ensuring help output stays off stdout

Closes #507

## Verification

- `pnpm run check:all`
- `VIBE_BINARY_PATH=/Users/kei/ghq/github.com/kexi/vibe/rust/target/debug/vibe pnpm -C packages/e2e test`
