### PR TITLE
fix: honor start force flag

### DIFF
--- a/packages/docs/src/content/docs/commands/start.mdx
+++ b/packages/docs/src/content/docs/commands/start.mdx
@@ -25,7 +25,7 @@ vibe start <branch> [options]
 | `--no-hooks`                  | Skip pre-start and post-start hooks       | <Badge text="v0.5.0+" />  |
 | `--no-copy`                   | Skip file and directory copying           | <Badge text="v0.5.0+" />  |
 | `-n`, `--dry-run`             | Preview operations without executing      | <Badge text="v0.8.0+" />  |
-| `-f`, `--force`               | Skip confirmation prompts                 |                           |
+| `-f`, `--force`               | Skip confirmation prompts                 | <Badge text="v2.0.0+" />  |
 | `-V`, `--verbose`             | Show detailed output                      | <Badge text="v0.8.0+" />  |
 | `-q`, `--quiet`               | Suppress non-essential output             | <Badge text="v0.8.0+" />  |
 | `--claude-code-worktree-hook` | Claude Code WorktreeCreate hook mode      | <Badge text="v0.23.0+" /> |

--- a/packages/docs/src/content/docs/ja/commands/start.mdx
+++ b/packages/docs/src/content/docs/ja/commands/start.mdx
@@ -25,7 +25,7 @@ vibe start <branch> [options]
 | `--no-hooks`                  | pre-startとpost-startフックをスキップ     | <Badge text="v0.5.0+" />  |
 | `--no-copy`                   | ファイル・ディレクトリのコピーをスキップ  | <Badge text="v0.5.0+" />  |
 | `-n`, `--dry-run`             | 実行せずに操作内容をプレビュー            | <Badge text="v0.8.0+" />  |
-| `-f`, `--force`               | 確認プロンプトをスキップ                  |                           |
+| `-f`, `--force`               | 確認プロンプトをスキップ                  | <Badge text="v2.0.0+" />  |
 | `-V`, `--verbose`             | 詳細な出力を表示                          | <Badge text="v0.8.0+" />  |
 | `-q`, `--quiet`               | 不要な出力を抑制                          | <Badge text="v0.8.0+" />  |
 | `--claude-code-worktree-hook` | Claude Code WorktreeCreateフックモード    | <Badge text="v0.23.0+" /> |


### PR DESCRIPTION
## Summary

`vibe start --force/-f` was accepted by the CLI parser (mirroring the TS arg table and completion spec) but never wired into the command's behavior. This PR makes it effective:

- When the branch is already used by another worktree, `--force` skips the confirmation and navigates (`cd`) to that worktree.
- When the target directory is a worktree for a different branch, `--force` skips the Overwrite/Reuse/Cancel prompt, removes the conflicting worktree, and creates the requested one.
- `--dry-run` still takes precedence, so `--dry-run --force` performs no destructive action.

It also fixes `--help` (and bare invocation / clap parse errors) to write to stderr instead of stdout, since the shell wrapper evals stdout — matching the TS CLI's behavior.

README (en/ja) and the docs site (en/ja) document the flag with a `v2.0.0+` badge.

## Test Plan

- Added unit tests in `rust/crates/vibe-core/src/commands/start_tests.rs` (`existing_branch_force_navigates_without_prompt`, `different_branch_force_overwrites_without_prompt`) using a `PanicPrompt` to prove no prompt runs
- Added `eval_contract` tests asserting help output goes to stderr with empty stdout for `--help` and bare invocation
- Added an e2e test (`--force overwrites conflicting worktree without prompting`) in `packages/e2e/start.test.ts`; CI's e2e-test job runs it against the built binary
- Ran `pnpm run check:all` and all checks pass

## Checklist

- [x] Tests added/updated
- [x] `pnpm run check:all` passes
- [x] Docs updated (if needed)

Fixes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)