### PR TITLE
ci: bring the release-workflow --admin fix to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,4 +478,6 @@ jobs:
             --title "chore: update Nix flake to ${VERSION}" \
             --body "Automated update of \`flake.nix\` and \`flake.lock\` for v${VERSION}."
 
-          gh pr merge "$BRANCH" --merge --delete-branch
+          # --admin bypasses develop's branch-protection policy, which otherwise
+          # rejects this bot merge ("base branch policy prohibits the merge").
+          gh pr merge "$BRANCH" --merge --admin --delete-branch

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780336545,
-        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,19 +25,19 @@
       platforms = {
         x86_64-linux = {
           artifact = "vibe-linux-x64";
-          hash = "sha256-UBS9+p13knX1kzMYRphrkj3rTV/uLdP/Wgn5WifQFZw=";
+          hash = "sha256-Kz/iOskssAnMVBisv4ePPcwc9LD5kZoJJ5smGgYQz7I=";
         };
         aarch64-linux = {
           artifact = "vibe-linux-arm64";
-          hash = "sha256-nDABUwRqEQZ/g0JAdL6WWXuR/M+Q01uKt7UIGFZJI0M=";
+          hash = "sha256-KBz8yxq7PfFgeUlvCZCCLbQVDei1D0QDHp1Fxr+Rf4E=";
         };
         x86_64-darwin = {
           artifact = "vibe-darwin-x64";
-          hash = "sha256-fGAdMJIQBR3L+Z7ClRgMlDoHEyN+omRfaAdnpyHgTIU=";
+          hash = "sha256-MX14Nwv5pxPZMxVQ+yGlJpHgTlQ1AbhumWNo/RGRw44=";
         };
         aarch64-darwin = {
           artifact = "vibe-darwin-arm64";
-          hash = "sha256-mqlfWzIXnYZ0k+zdOKV9bMpK2rjxu4Y5LiIS4DwQUfk=";
+          hash = "sha256-uPTSfTQB2kS/Mrch5OHvlbGITkNDQiMm311Ir6AUvMs=";
         };
       };
     in


### PR DESCRIPTION
## Summary

Fast-forward main with #516, which adds `--admin` to the `update-nix` PR merge in the Release workflow. This is required on `main` so the v2.0.0 Release run (which runs from the release tag on main) can conclude `success` and trigger the gated npm publish.

After merge: recreate the v2.0.0 release so a fresh Release run uses the corrected workflow → npm publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)