### PR TITLE
ci: add NPM_TOKEN fallback so first-time package publishes work

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -271,6 +271,13 @@ jobs:
       - name: Publish @kexi/${{ matrix.package }}
         if: steps.guard.outputs.skip != 'true'
         working-directory: packages/vibe-${{ matrix.platform }}-${{ matrix.arch }}
+        # NODE_AUTH_TOKEN authenticates the publish. OIDC trusted publishing
+        # cannot CREATE a brand-new package (it 404s on the initial PUT), so the
+        # per-platform packages need a token for their first publish; once they
+        # exist with a configured trusted publisher, OIDC takes over and this
+        # token is unused. Provenance still attaches via id-token: write.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public
 
   # Publish @kexi/vibe (the launcher shim). It needs ALL five platform packages
@@ -330,4 +337,8 @@ jobs:
       - name: Publish @kexi/vibe
         if: steps.guard.outputs.skip != 'true'
         working-directory: packages/npm
+        # See the platform publish step: NODE_AUTH_TOKEN covers the first publish
+        # of a not-yet-existing package, which OIDC alone cannot create.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

v2.0.0's npm publish failed all 5 platform jobs with `E404 Not Found - PUT @kexi/vibe-* ... or you do not have permission`. Root cause: `publish-npm.yml` authenticates purely via **OIDC trusted publishing**, but **OIDC cannot create a brand-new package** — and the five per-platform packages (`@kexi/vibe-{linux,darwin}-{x64,arm64}`, `@kexi/vibe-win32-x64`) have never been published. So npm never advanced past 1.8.1.

Add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to both publish steps so the **first** publish of a not-yet-existing package is authenticated by a token. Provenance still attaches via `id-token: write`. Once each package exists with a configured trusted publisher, OIDC takes over and the token goes unused. The idempotency guard makes re-runs safe.

**Action required:** add an `NPM_TOKEN` repository secret (an npm automation/granular token with permission to create packages in the `@kexi` scope) before re-running the publish.

Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)