### PR TITLE
ci: bring NPM_TOKEN publish fallback to main

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -271,6 +271,13 @@ jobs:
       - name: Publish @kexi/${{ matrix.package }}
         if: steps.guard.outputs.skip != 'true'
         working-directory: packages/vibe-${{ matrix.platform }}-${{ matrix.arch }}
+        # NODE_AUTH_TOKEN authenticates the publish. OIDC trusted publishing
+        # cannot CREATE a brand-new package (it 404s on the initial PUT), so the
+        # per-platform packages need a token for their first publish; once they
+        # exist with a configured trusted publisher, OIDC takes over and this
+        # token is unused. Provenance still attaches via id-token: write.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public
 
   # Publish @kexi/vibe (the launcher shim). It needs ALL five platform packages
@@ -330,4 +337,8 @@ jobs:
       - name: Publish @kexi/vibe
         if: steps.guard.outputs.skip != 'true'
         working-directory: packages/npm
+        # See the platform publish step: NODE_AUTH_TOKEN covers the first publish
+        # of a not-yet-existing package, which OIDC alone cannot create.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public

--- a/flake.nix
+++ b/flake.nix
@@ -25,19 +25,19 @@
       platforms = {
         x86_64-linux = {
           artifact = "vibe-linux-x64";
-          hash = "sha256-Kz/iOskssAnMVBisv4ePPcwc9LD5kZoJJ5smGgYQz7I=";
+          hash = "sha256-KNYAfX4F3tIsTgsZ14pNqHsLlOKbcn+0X/bU9YUqlME=";
         };
         aarch64-linux = {
           artifact = "vibe-linux-arm64";
-          hash = "sha256-KBz8yxq7PfFgeUlvCZCCLbQVDei1D0QDHp1Fxr+Rf4E=";
+          hash = "sha256-1ENhKncBo+GvRFY7G+jXfWj9EH0tl05rhybzQ2fXEX8=";
         };
         x86_64-darwin = {
           artifact = "vibe-darwin-x64";
-          hash = "sha256-MX14Nwv5pxPZMxVQ+yGlJpHgTlQ1AbhumWNo/RGRw44=";
+          hash = "sha256-UuMHOtyBufuI1twY3zNml/428VAx2d7cgblwVF15rYE=";
         };
         aarch64-darwin = {
           artifact = "vibe-darwin-arm64";
-          hash = "sha256-uPTSfTQB2kS/Mrch5OHvlbGITkNDQiMm311Ir6AUvMs=";
+          hash = "sha256-m4jgnuA6LhH1wOkMyqf5asLiDIHzYGHuHZ2UMmLDUE0=";
         };
       };
     in


### PR DESCRIPTION
Fast-forward main with #519 so the v2.0.0 npm publish path can create the new per-platform packages. Requires the NPM_TOKEN secret to be set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)