### PR TITLE
feat: add submodule auto init config

### DIFF
--- a/packages/docs/src/content/docs/configuration/hooks.mdx
+++ b/packages/docs/src/content/docs/configuration/hooks.mdx
@@ -9,12 +9,12 @@ Hooks allow you to run commands automatically during the worktree lifecycle.
 
 ## Available Hooks
 
-| Hook         | When                     | Working Directory |
-| ------------ | ------------------------ | ----------------- |
-| `pre_start`  | Before worktree creation | Origin repository |
-| `post_start` | After worktree creation  | New worktree      |
-| `pre_clean`  | Before worktree removal  | Current worktree  |
-| `post_clean` | After worktree removal   | Main repository   |
+| Hook         | When                    | Working Directory |
+| ------------ | ----------------------- | ----------------- |
+| `pre_start`  | After worktree creation | Origin repository |
+| `post_start` | After worktree creation | New worktree      |
+| `pre_clean`  | Before worktree removal | Current worktree  |
+| `post_clean` | After worktree removal  | Main repository   |
 
 ## Configuration
 
@@ -78,10 +78,11 @@ Progress display auto-disables in non-TTY environments (e.g., CI/CD), and hook o
 
 For `vibe start`:
 
-1. `pre_start` hooks run in origin repository
-2. Worktree is created
-3. Files/directories are copied
-4. `post_start` hooks run in new worktree
+1. Worktree is created
+2. Submodules are initialized when `[submodules] auto_init = true`
+3. `pre_start` hooks run in origin repository
+4. Files/directories are copied
+5. `post_start` hooks run in new worktree
 
 For `vibe clean`:
 
@@ -138,15 +139,17 @@ pre_clean = ["docker-compose down"]
 
 ### Git Submodules
 
+Prefer first-class submodule initialization when recursive defaults are enough:
+
 ```toml
-[hooks]
-post_start = [
-  "git submodule update --init --recursive || true"
-]
+[submodules]
+auto_init = true
 ```
 
-:::tip
-`|| true` prevents the hook from failing when submodule initialization encounters network issues. Remove it if you want strict error handling.
+This runs `git submodule update --init --recursive` in the new worktree before `pre_start` hooks. Failures abort `vibe start` so authentication and network errors are visible.
+
+:::note
+Use a hook instead when you need custom submodule behavior, such as non-recursive updates, filtered updates, or intentionally ignoring failures.
 :::
 
 ## Skipping Hooks
@@ -199,11 +202,12 @@ When Claude Code creates a worktree (via natural language, `isolation: "worktree
 **WorktreeCreate:**
 
 1. Reads worktree name from stdin (Claude Code hook protocol)
-2. Runs `pre_start` hooks in the origin repository
-3. Creates the git worktree
-4. Copies files/directories using CoW
-5. Runs `post_start` hooks in the new worktree (e.g., `pnpm install`)
-6. Outputs the worktree path to stdout for Claude Code
+2. Creates the git worktree
+3. Initializes submodules when `[submodules] auto_init = true`
+4. Runs `pre_start` hooks in the origin repository
+5. Copies files/directories using CoW
+6. Runs `post_start` hooks in the new worktree (e.g., `pnpm install`)
+7. Outputs the worktree path to stdout for Claude Code
 
 **WorktreeRemove:**
 

--- a/packages/docs/src/content/docs/configuration/vibe-toml.mdx
+++ b/packages/docs/src/content/docs/configuration/vibe-toml.mdx
@@ -116,6 +116,21 @@ vibe automatically selects the best copy strategy based on your system:
 
 See [Hooks](/configuration/hooks/) for details on configuring pre/post hooks.
 
+## Submodules Configuration
+
+Initialize git submodules automatically after the worktree is created and before `pre_start` hooks run:
+
+```toml
+[submodules]
+auto_init = true
+```
+
+- **Default**: `false`
+- Runs `git submodule update --init --recursive` in the new worktree
+- `--no-hooks` does not skip submodule initialization
+- Repositories without `.gitmodules` are treated as a successful no-op by git
+- Submodule update failures abort `vibe start` and leave the created worktree available for inspection
+
 ## Worktree Configuration <Badge text="v0.6.0+" />
 
 Customize the worktree directory path using an external script.
@@ -175,6 +190,9 @@ post_start = [
 ]
 pre_clean = ["git stash"]
 post_clean = ["echo 'Cleanup complete'"]
+
+[submodules]
+auto_init = true
 
 [worktree]
 path_script = "~/.config/vibe/worktree-path.sh"

--- a/packages/docs/src/content/docs/ja/configuration/hooks.mdx
+++ b/packages/docs/src/content/docs/ja/configuration/hooks.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 | フック       | 実行タイミング | 作業ディレクトリ |
 | ------------ | -------------- | ---------------- |
-| `pre_start`  | Worktree作成前 | 元リポジトリ     |
+| `pre_start`  | Worktree作成後 | 元リポジトリ     |
 | `post_start` | Worktree作成後 | 新しいWorktree   |
 | `pre_clean`  | Worktree削除前 | 現在のWorktree   |
 | `post_clean` | Worktree削除後 | メインリポジトリ |
@@ -78,10 +78,11 @@ vibeはフック実行中にリアルタイム進捗ツリーを表示します�
 
 `vibe start`の場合：
 
-1. `pre_start`フックが元リポジトリで実行
-2. Worktreeが作成される
-3. ファイル/ディレクトリがコピーされる
-4. `post_start`フックが新しいWorktreeで実行
+1. Worktreeが作成される
+2. `[submodules] auto_init = true`の場合、サブモジュールが初期化される
+3. `pre_start`フックが元リポジトリで実行
+4. ファイル/ディレクトリがコピーされる
+5. `post_start`フックが新しいWorktreeで実行
 
 `vibe clean`の場合：
 
@@ -138,15 +139,17 @@ pre_clean = ["docker-compose down"]
 
 ### Gitサブモジュール
 
+再帰的な既定動作で十分な場合は、ファーストクラスのサブモジュール初期化を優先してください：
+
 ```toml
-[hooks]
-post_start = [
-  "git submodule update --init --recursive || true"
-]
+[submodules]
+auto_init = true
 ```
 
-:::tip
-`|| true`を付けることで、ネットワークエラー等でサブモジュールの初期化に失敗してもフック全体が失敗しません。厳密なエラーハンドリングが必要な場合は除去してください。
+これは新しいWorktree内で、`pre_start`フックより前に`git submodule update --init --recursive`を実行します。失敗時は`vibe start`を中断するため、認証やネットワークの問題が見える状態になります。
+
+:::note
+非再帰更新、フィルタ付き更新、失敗を意図的に無視する場合など、カスタムのサブモジュール動作が必要な場合はフックを使用してください。
 :::
 
 ## フックのスキップ
@@ -199,11 +202,12 @@ Claude CodeがWorktreeを作成する場合（自然言語、`isolation: "worktr
 **WorktreeCreate:**
 
 1. stdinからWorktree名を読み取り（Claude Codeフックプロトコル）
-2. 元リポジトリで`pre_start`フックを実行
-3. git Worktreeを作成
-4. CoWを使用してファイル/ディレクトリをコピー
-5. 新しいWorktreeで`post_start`フックを実行（例：`pnpm install`）
-6. Claude Code向けにWorktreeパスをstdoutに出力
+2. git Worktreeを作成
+3. `[submodules] auto_init = true`の場合、サブモジュールを初期化
+4. 元リポジトリで`pre_start`フックを実行
+5. CoWを使用してファイル/ディレクトリをコピー
+6. 新しいWorktreeで`post_start`フックを実行（例：`pnpm install`）
+7. Claude Code向けにWorktreeパスをstdoutに出力
 
 **WorktreeRemove:**
 

--- a/packages/docs/src/content/docs/ja/configuration/vibe-toml.mdx
+++ b/packages/docs/src/content/docs/ja/configuration/vibe-toml.mdx
@@ -116,6 +116,21 @@ vibeはシステムに応じて最適なコピー戦略を自動選択します�
 
 フック設定の詳細は[フック](/ja/configuration/hooks/)を参照してください。
 
+## サブモジュール設定
+
+Worktree作成後、`pre_start`フックの実行前にgitサブモジュールを自動初期化します：
+
+```toml
+[submodules]
+auto_init = true
+```
+
+- **デフォルト**: `false`
+- 新しいWorktree内で`git submodule update --init --recursive`を実行します
+- `--no-hooks`ではサブモジュール初期化はスキップされません
+- `.gitmodules`がないリポジトリでは、gitにより成功したno-opとして扱われます
+- サブモジュール更新に失敗すると`vibe start`は中断され、作成済みWorktreeは調査用に残ります
+
 ## Worktree設定 <Badge text="v0.6.0+" />
 
 外部スクリプトを使用してWorktreeディレクトリパスをカスタマイズできます。
@@ -175,6 +190,9 @@ post_start = [
 ]
 pre_clean = ["git stash"]
 post_clean = ["echo 'クリーンアップ完了'"]
+
+[submodules]
+auto_init = true
 
 [worktree]
 path_script = "~/.config/vibe/worktree-path.sh"

--- a/rust/crates/vibe-core/src/commands/start.rs
+++ b/rust/crates/vibe-core/src/commands/start.rs
@@ -3,7 +3,8 @@
 //! Ported from `packages/core/src/commands/start.ts`. The validation cascade,
 //! existing-branch navigate, same-branch idempotent re-entry, different-branch
 //! Overwrite/Reuse/Cancel select, worktree creation, and the
-//! pre_start → copy → post_start config-and-hooks sequence mirror the TS. The
+//! submodule init → pre_start → copy → post_start config-and-hooks sequence
+//! mirror the TS. The
 //! Claude-Code `--claude-code-worktree-hook` mode reads a name from stdin and
 //! outputs the worktree PATH to stdout (not a `cd`), with non-fatal post-setup.
 //!
@@ -501,8 +502,8 @@ where
     )))
 }
 
-/// Run config-driven hooks + copy: pre_start (in repo_root) → copy files + dirs →
-/// post_start (in worktree_path).
+/// Run config-driven operations: submodule init → pre_start (in repo_root) →
+/// copy files + dirs → post_start (in worktree_path).
 fn run_config_and_hooks<I, G, R, S, P, Sr>(
     deps: &StartDeps<I, G, R, S, P, Sr>,
     config: Option<&VibeConfig>,
@@ -529,6 +530,8 @@ where
     if has_ops {
         deps.tracker.start();
     }
+
+    init_submodules(deps, config, worktree_path, options.dry_run)?;
 
     // pre_start hooks (in repo_root).
     if !options.skip_hooks {
@@ -610,6 +613,7 @@ where
 
 /// Whether config has any hook/copy operation (drives starting the tracker).
 fn config_has_operations(config: &VibeConfig, options: &ConfigAndHooks) -> bool {
+    let has_submodule_init = submodules_auto_init_enabled(config);
     let hooks_count = if options.skip_hooks {
         0
     } else {
@@ -634,7 +638,65 @@ fn config_has_operations(config: &VibeConfig, options: &ConfigAndHooks) -> bool 
             })
             .unwrap_or(0)
     };
-    hooks_count + copy_count > 0
+    has_submodule_init || hooks_count + copy_count > 0
+}
+
+fn submodules_auto_init_enabled(config: &VibeConfig) -> bool {
+    config
+        .submodules
+        .as_ref()
+        .and_then(|s| s.auto_init)
+        .unwrap_or(false)
+}
+
+fn init_submodules<I, G, R, S, P, Sr>(
+    deps: &StartDeps<I, G, R, S, P, Sr>,
+    config: &VibeConfig,
+    worktree_path: &str,
+    dry_run: bool,
+) -> Result<()>
+where
+    I: Io,
+    G: GitRunner,
+    R: RepoResolver,
+    S: ScriptRunner,
+    P: Prompt,
+    Sr: StdinReader,
+{
+    if !submodules_auto_init_enabled(config) {
+        return Ok(());
+    }
+
+    let command = format!("git -C {worktree_path} submodule update --init --recursive");
+    if dry_run {
+        log_dry_run(deps.io, &format!("Would run: {command}"));
+        return Ok(());
+    }
+
+    let phase = deps.tracker.add_phase("Initializing submodules");
+    let task = deps
+        .tracker
+        .add_task(phase, "git submodule update --init --recursive");
+    deps.tracker.start_task(task);
+    let result = deps.git.run(&[
+        "-C",
+        worktree_path,
+        "submodule",
+        "update",
+        "--init",
+        "--recursive",
+    ]);
+
+    match result {
+        Ok(_) => {
+            deps.tracker.complete_task(task);
+            Ok(())
+        }
+        Err(err) => {
+            deps.tracker.fail_task(task, &err.to_string());
+            Err(err)
+        }
+    }
 }
 
 /// Run a lifecycle hook list with a phase/tasks on the tracker.

--- a/rust/crates/vibe-core/src/commands/start_tests.rs
+++ b/rust/crates/vibe-core/src/commands/start_tests.rs
@@ -7,7 +7,7 @@ use crate::error::VibeError;
 use crate::git::RepoInfo;
 use crate::hooks::FakeHookRunner;
 use crate::io::FakeIo;
-use crate::progress::RecordingTracker;
+use crate::progress::{RecordingTracker, TrackerEvent};
 use crate::stdin::FakeStdin;
 use crate::worktree_path::ScriptOutput;
 use std::cell::RefCell;
@@ -23,6 +23,7 @@ struct MockGit {
     local_branches: Vec<String>,
     remote_branches: Vec<String>,
     existing_revisions: Vec<String>,
+    fail_prefix: Option<Vec<String>>,
     pub calls: RefCell<Vec<Vec<String>>>,
 }
 
@@ -34,11 +35,16 @@ impl MockGit {
             local_branches: vec![],
             remote_branches: vec![],
             existing_revisions: vec![],
+            fail_prefix: None,
             calls: RefCell::new(vec![]),
         }
     }
     fn with_revision(mut self, r: &str) -> Self {
         self.existing_revisions.push(r.to_string());
+        self
+    }
+    fn failing_on(mut self, prefix: &[&str]) -> Self {
+        self.fail_prefix = Some(prefix.iter().map(|s| s.to_string()).collect());
         self
     }
     fn calls_contain(&self, prefix: &[&str]) -> bool {
@@ -47,6 +53,18 @@ impl MockGit {
             .iter()
             .any(|c| c.len() >= prefix.len() && c[..prefix.len()] == *prefix)
     }
+    fn submodule_update_calls(&self) -> usize {
+        self.calls
+            .borrow()
+            .iter()
+            .filter(|c| {
+                c.iter().any(|arg| arg == "submodule")
+                    && c.iter().any(|arg| arg == "update")
+                    && c.iter().any(|arg| arg == "--init")
+                    && c.iter().any(|arg| arg == "--recursive")
+            })
+            .count()
+    }
 }
 
 impl GitRunner for MockGit {
@@ -54,6 +72,21 @@ impl GitRunner for MockGit {
         self.calls
             .borrow_mut()
             .push(args.iter().map(|s| s.to_string()).collect());
+
+        if let Some(prefix) = &self.fail_prefix {
+            let is_matching_prefix = args.len() >= prefix.len()
+                && args
+                    .iter()
+                    .take(prefix.len())
+                    .zip(prefix.iter())
+                    .all(|(actual, expected)| actual == expected);
+            if is_matching_prefix {
+                return Err(VibeError::GitOperation {
+                    command: args.join(" "),
+                    message: "failed: submodule update".into(),
+                });
+            }
+        }
 
         if args.contains(&"--show-toplevel") {
             return Ok(self.repo_root.clone());
@@ -700,6 +733,12 @@ fn different_branch_cancel_emits_no_cd() {
 /// Build a trusted-config fixture + resolver, returning (fixture, io, resolver,
 /// repo_root). The config has a pre_start, a copy file, and a post_start hook.
 fn trusted_config_repo() -> (Fixture, FakeIo, TrustResolver, String) {
+    trusted_config_repo_with_content(
+        "[hooks]\npre_start = [\"echo pre\"]\npost_start = [\"echo post\"]\n[copy]\nfiles = [\".env\"]\n",
+    )
+}
+
+fn trusted_config_repo_with_content(content: &str) -> (Fixture, FakeIo, TrustResolver, String) {
     use crate::hash::hash_content;
     use crate::settings::{AllowEntry, RepoId, VibeSettings};
     use crate::settings_io::save_user_settings;
@@ -707,7 +746,6 @@ fn trusted_config_repo() -> (Fixture, FakeIo, TrustResolver, String) {
 
     let fx = Fixture::new();
     let repo = fx.mkdir("repo");
-    let content = "[hooks]\npre_start = [\"echo pre\"]\npost_start = [\"echo post\"]\n[copy]\nfiles = [\".env\"]\n";
     fx.write("repo/.vibe.toml", content);
     fx.write("repo/.env", "SECRET=1");
 
@@ -740,6 +778,49 @@ fn trusted_config_repo() -> (Fixture, FakeIo, TrustResolver, String) {
         TrustResolver { repos },
         repo.to_string_lossy().into_owned(),
     )
+}
+
+fn start_with_config(
+    content: &str,
+    fail_prefix: Option<&[&str]>,
+    flags: &StartFlags,
+) -> (
+    Fixture,
+    FakeIo,
+    TrustResolver,
+    String,
+    MockGit,
+    Fakes,
+    Result<Outcome>,
+) {
+    let (fx, io, resolver, repo_root) = trusted_config_repo_with_content(content);
+    let mut git = MockGit::new(
+        &repo_root,
+        &format!("worktree {repo_root}\nbranch refs/heads/main\n\n"),
+    );
+    if let Some(prefix) = fail_prefix {
+        git = git.failing_on(prefix);
+    }
+    let s = NoScript;
+    let p = ScriptPrompt::confirming(true);
+    let sin = FakeStdin::none();
+    let fk = Fakes::new();
+    let result = {
+        let d = StartDeps {
+            io: &io,
+            git: &git,
+            resolver: &resolver,
+            script_runner: &s,
+            prompt: &p,
+            stdin: &sin,
+            hook_runner: &fk.hooks,
+            executor: &fk.exec,
+            tracker: &fk.tracker,
+            version: V,
+        };
+        start_command(&d, "feat", flags, OutputOptions::default())
+    };
+    (fx, io, resolver, repo_root, git, fk, result)
 }
 
 struct TrustResolver {
@@ -826,6 +907,90 @@ fn no_hooks_and_no_copy_skip_operations() {
         ..Default::default()
     };
     start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
+    assert!(fk.hooks.calls.borrow().is_empty());
+    assert!(fk.exec.file_copies.lock().unwrap().is_empty());
+}
+
+#[test]
+fn submodules_auto_init_runs_before_pre_start() {
+    let content = "[submodules]\nauto_init = true\n[hooks]\npre_start = [\"echo pre\"]\n";
+    let (_fx, _io, _resolver, repo_root, git, fk, result) =
+        start_with_config(content, None, &StartFlags::default());
+    result.unwrap();
+
+    assert!(git.calls_contain(&[
+        "-C",
+        &format!("{}-feat", repo_root),
+        "submodule",
+        "update",
+        "--init",
+        "--recursive"
+    ]));
+    let events = fk.tracker.events();
+    let submodule_phase = events.iter().position(
+        |event| matches!(event, TrackerEvent::Phase(label) if label == "Initializing submodules"),
+    );
+    let pre_start_phase = events.iter().position(
+        |event| matches!(event, TrackerEvent::Phase(label) if label == "Pre-start hooks"),
+    );
+    assert!(submodule_phase.is_some());
+    assert!(pre_start_phase.is_some());
+    assert!(submodule_phase < pre_start_phase);
+}
+
+#[test]
+fn submodules_auto_init_false_and_omitted_do_not_run() {
+    for content in [
+        "[submodules]\nauto_init = false\n",
+        "[hooks]\npre_start = [\"echo pre\"]\n",
+    ] {
+        let (_fx, _io, _resolver, _repo_root, git, _fk, result) =
+            start_with_config(content, None, &StartFlags::default());
+        result.unwrap();
+        assert_eq!(git.submodule_update_calls(), 0);
+    }
+}
+
+#[test]
+fn submodules_auto_init_runs_with_no_hooks() {
+    let content = "[submodules]\nauto_init = true\n[hooks]\npre_start = [\"echo pre\"]\npost_start = [\"echo post\"]\n";
+    let flags = StartFlags {
+        no_hooks: true,
+        ..Default::default()
+    };
+    let (_fx, _io, _resolver, _repo_root, git, fk, result) =
+        start_with_config(content, None, &flags);
+    result.unwrap();
+
+    assert_eq!(git.submodule_update_calls(), 1);
+    assert!(fk.hooks.calls.borrow().is_empty());
+}
+
+#[test]
+fn submodules_auto_init_dry_run_logs_without_running_git() {
+    let content = "[submodules]\nauto_init = true\n";
+    let flags = StartFlags {
+        dry_run: true,
+        ..Default::default()
+    };
+    let (_fx, io, _resolver, _repo_root, git, _fk, result) =
+        start_with_config(content, None, &flags);
+    result.unwrap();
+
+    assert_eq!(git.submodule_update_calls(), 0);
+    assert!(io.stderr_text().contains("Would run: git -C"));
+    assert!(io
+        .stderr_text()
+        .contains("submodule update --init --recursive"));
+}
+
+#[test]
+fn submodules_auto_init_failure_aborts_remaining_operations() {
+    let content = "[submodules]\nauto_init = true\n[hooks]\npre_start = [\"echo pre\"]\npost_start = [\"echo post\"]\n[copy]\nfiles = [\".env\"]\n";
+    let (_fx, _io, _resolver, _repo_root, _git, fk, result) =
+        start_with_config(content, Some(&["-C"]), &StartFlags::default());
+
+    assert!(result.is_err());
     assert!(fk.hooks.calls.borrow().is_empty());
     assert!(fk.exec.file_copies.lock().unwrap().is_empty());
 }

--- a/rust/crates/vibe-core/src/config.rs
+++ b/rust/crates/vibe-core/src/config.rs
@@ -22,6 +22,8 @@ pub struct VibeConfig {
     pub worktree: Option<WorktreeConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clean: Option<CleanConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub submodules: Option<SubmodulesConfig>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -85,6 +87,13 @@ pub struct WorktreeConfig {
 pub struct CleanConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delete_branch: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubmodulesConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_init: Option<bool>,
 }
 
 /// Parse a `VibeConfig` from TOML text, validating it like the Zod schema.
@@ -220,6 +229,16 @@ pub fn merge_configs(base: &VibeConfig, local: &VibeConfig) -> VibeConfig {
             .and_then(|c| c.delete_branch)
             .or_else(|| base.clean.as_ref().and_then(|c| c.delete_branch));
         merged.clean = Some(CleanConfig { delete_branch });
+    }
+
+    // submodules: present if either side has it; auto_init local > base.
+    if base.submodules.is_some() || local.submodules.is_some() {
+        let auto_init = local
+            .submodules
+            .as_ref()
+            .and_then(|s| s.auto_init)
+            .or_else(|| base.submodules.as_ref().and_then(|s| s.auto_init));
+        merged.submodules = Some(SubmodulesConfig { auto_init });
     }
 
     merged
@@ -448,6 +467,47 @@ mod tests {
         );
     }
 
+    #[test]
+    fn submodules_local_auto_init_wins() {
+        let base = VibeConfig {
+            submodules: Some(SubmodulesConfig {
+                auto_init: Some(false),
+            }),
+            ..Default::default()
+        };
+        let local = VibeConfig {
+            submodules: Some(SubmodulesConfig {
+                auto_init: Some(true),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            merge_configs(&base, &local).submodules.unwrap().auto_init,
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn submodules_base_auto_init_survives_with_unrelated_local() {
+        let base = VibeConfig {
+            submodules: Some(SubmodulesConfig {
+                auto_init: Some(true),
+            }),
+            ..Default::default()
+        };
+        let local = VibeConfig {
+            copy: Some(CopyConfig {
+                files: Some(vec!["x".into()]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            merge_configs(&base, &local).submodules.unwrap().auto_init,
+            Some(true)
+        );
+    }
+
     // --- parse_vibe_config ---
 
     #[test]
@@ -474,14 +534,24 @@ path_script = "p.sh"
 
 [clean]
 delete_branch = true
+
+[submodules]
+auto_init = true
 "#;
         let cfg = parse_vibe_config(toml, "/p/.vibe.toml").unwrap();
         assert_eq!(cfg.copy.as_ref().unwrap().concurrency, Some(8));
         assert_eq!(cfg.clean.as_ref().unwrap().delete_branch, Some(true));
+        assert_eq!(cfg.submodules.as_ref().unwrap().auto_init, Some(true));
         assert_eq!(
             cfg.worktree.as_ref().unwrap().path_script.as_deref(),
             Some("p.sh")
         );
+    }
+
+    #[test]
+    fn parses_submodules_auto_init_true() {
+        let cfg = parse_vibe_config("[submodules]\nauto_init = true\n", "/p/.vibe.toml").unwrap();
+        assert_eq!(cfg.submodules.unwrap().auto_init, Some(true));
     }
 
     #[test]
@@ -494,6 +564,13 @@ delete_branch = true
     #[test]
     fn rejects_unknown_nested_property() {
         let toml = "[copy]\nbogus = 1\n";
+        let err = parse_vibe_config(toml, "/path/.vibe.toml").unwrap_err();
+        assert!(err.to_string().contains("/path/.vibe.toml"));
+    }
+
+    #[test]
+    fn rejects_unknown_submodules_field() {
+        let toml = "[submodules]\nbogus = 1\n";
         let err = parse_vibe_config(toml, "/path/.vibe.toml").unwrap_err();
         assert!(err.to_string().contains("/path/.vibe.toml"));
     }


### PR DESCRIPTION
## Summary
- add [submodules] auto_init support to .vibe.toml parsing and merge semantics
- initialize git submodules after worktree creation and before pre_start hooks
- document the new config in English and Japanese docs

Closes #523

## Checks
- pnpm run check:all