### PR TITLE
feat: read trusted submodule configs

### DIFF
--- a/packages/docs/src/content/docs/configuration/hooks.mdx
+++ b/packages/docs/src/content/docs/configuration/hooks.mdx
@@ -9,12 +9,12 @@ Hooks allow you to run commands automatically during the worktree lifecycle.
 
 ## Available Hooks
 
-| Hook         | When                     | Working Directory |
-| ------------ | ------------------------ | ----------------- |
-| `pre_start`  | Before worktree creation | Origin repository |
-| `post_start` | After worktree creation  | New worktree      |
-| `pre_clean`  | Before worktree removal  | Current worktree  |
-| `post_clean` | After worktree removal   | Main repository   |
+| Hook         | When                    | Working Directory |
+| ------------ | ----------------------- | ----------------- |
+| `pre_start`  | After worktree creation | Origin repository |
+| `post_start` | After worktree creation | New worktree      |
+| `pre_clean`  | Before worktree removal | Current worktree  |
+| `post_clean` | After worktree removal  | Main repository   |
 
 ## Configuration
 
@@ -78,10 +78,12 @@ Progress display auto-disables in non-TTY environments (e.g., CI/CD), and hook o
 
 For `vibe start`:
 
-1. `pre_start` hooks run in origin repository
-2. Worktree is created
-3. Files/directories are copied
-4. `post_start` hooks run in new worktree
+1. Worktree is created
+2. Listed submodules are initialized when `[submodules] configs = [...]`
+3. Each listed submodule's trusted `pre_start`, copy rules, and `post_start` run from that submodule root
+4. Parent `pre_start` hooks run in origin repository
+5. Parent files/directories are copied
+6. Parent `post_start` hooks run in new worktree
 
 For `vibe clean`:
 
@@ -138,15 +140,17 @@ pre_clean = ["docker-compose down"]
 
 ### Git Submodules
 
+Use first-class submodule configs when a direct submodule has its own setup files or hooks:
+
 ```toml
-[hooks]
-post_start = [
-  "git submodule update --init --recursive || true"
-]
+[submodules]
+configs = ["libs/foo"]
 ```
 
-:::tip
-`|| true` prevents the hook from failing when submodule initialization encounters network issues. Remove it if you want strict error handling.
+This runs `git submodule update --init -- libs/foo` in the new worktree, then loads `libs/foo/.vibe.toml` through the normal trust store. The submodule's copy rules and hooks resolve paths from `libs/foo`, and they run before the parent repository's `pre_start` hooks.
+
+:::note
+Use a hook instead when you need custom submodule behavior, such as recursive updates, filtered updates, or intentionally ignoring failures.
 :::
 
 ## Skipping Hooks
@@ -199,11 +203,12 @@ When Claude Code creates a worktree (via natural language, `isolation: "worktree
 **WorktreeCreate:**
 
 1. Reads worktree name from stdin (Claude Code hook protocol)
-2. Runs `pre_start` hooks in the origin repository
-3. Creates the git worktree
-4. Copies files/directories using CoW
-5. Runs `post_start` hooks in the new worktree (e.g., `pnpm install`)
-6. Outputs the worktree path to stdout for Claude Code
+2. Creates the git worktree
+3. Initializes listed submodules and runs their trusted setup when `[submodules] configs = [...]`
+4. Runs parent `pre_start` hooks in the origin repository
+5. Copies parent files/directories using CoW
+6. Runs parent `post_start` hooks in the new worktree (e.g., `pnpm install`)
+7. Outputs the worktree path to stdout for Claude Code
 
 **WorktreeRemove:**
 

--- a/packages/docs/src/content/docs/configuration/vibe-toml.mdx
+++ b/packages/docs/src/content/docs/configuration/vibe-toml.mdx
@@ -116,6 +116,24 @@ vibe automatically selects the best copy strategy based on your system:
 
 See [Hooks](/configuration/hooks/) for details on configuring pre/post hooks.
 
+## Submodules Configuration
+
+Load trusted `.vibe.toml` files from selected direct submodules after the worktree is created and before the parent repository's `pre_start` hooks run:
+
+```toml
+[submodules]
+configs = ["libs/foo", "vendor/bar"]
+```
+
+- **Default**: `[]`
+- Each entry must exactly match a direct submodule path in `.gitmodules`
+- Runs `git submodule update --init -- <paths>` in the new worktree
+- Loads each submodule's `.vibe.toml` / `.vibe.local.toml` with that submodule's own trust entry
+- Runs the submodule config's hooks and copy rules with paths resolved from the submodule root
+- `--no-hooks` skips submodule hooks, but does not skip submodule initialization
+- `--no-copy` skips submodule copy rules
+- Submodule update, trust, path validation, or setup failures abort `vibe start` and leave the created worktree available for inspection
+
 ## Worktree Configuration <Badge text="v0.6.0+" />
 
 Customize the worktree directory path using an external script.
@@ -175,6 +193,9 @@ post_start = [
 ]
 pre_clean = ["git stash"]
 post_clean = ["echo 'Cleanup complete'"]
+
+[submodules]
+configs = ["libs/foo"]
 
 [worktree]
 path_script = "~/.config/vibe/worktree-path.sh"

--- a/packages/docs/src/content/docs/ja/configuration/hooks.mdx
+++ b/packages/docs/src/content/docs/ja/configuration/hooks.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 | フック       | 実行タイミング | 作業ディレクトリ |
 | ------------ | -------------- | ---------------- |
-| `pre_start`  | Worktree作成前 | 元リポジトリ     |
+| `pre_start`  | Worktree作成後 | 元リポジトリ     |
 | `post_start` | Worktree作成後 | 新しいWorktree   |
 | `pre_clean`  | Worktree削除前 | 現在のWorktree   |
 | `post_clean` | Worktree削除後 | メインリポジトリ |
@@ -78,10 +78,12 @@ vibeはフック実行中にリアルタイム進捗ツリーを表示します�
 
 `vibe start`の場合：
 
-1. `pre_start`フックが元リポジトリで実行
-2. Worktreeが作成される
-3. ファイル/ディレクトリがコピーされる
-4. `post_start`フックが新しいWorktreeで実行
+1. Worktreeが作成される
+2. `[submodules] configs = [...]`の場合、指定されたサブモジュールが初期化される
+3. 各サブモジュールの信頼済み`pre_start`、copyルール、`post_start`がサブモジュールルート基準で実行される
+4. 親の`pre_start`フックが元リポジトリで実行
+5. 親のファイル/ディレクトリがコピーされる
+6. 親の`post_start`フックが新しいWorktreeで実行
 
 `vibe clean`の場合：
 
@@ -138,15 +140,17 @@ pre_clean = ["docker-compose down"]
 
 ### Gitサブモジュール
 
+直接サブモジュールに独自のsetupファイルやフックがある場合は、ファーストクラスのサブモジュール設定を使用してください：
+
 ```toml
-[hooks]
-post_start = [
-  "git submodule update --init --recursive || true"
-]
+[submodules]
+configs = ["libs/foo"]
 ```
 
-:::tip
-`|| true`を付けることで、ネットワークエラー等でサブモジュールの初期化に失敗してもフック全体が失敗しません。厳密なエラーハンドリングが必要な場合は除去してください。
+これは新しいWorktree内で`git submodule update --init -- libs/foo`を実行し、その後`libs/foo/.vibe.toml`を通常のtrust store経由で読み込みます。サブモジュールのcopyルールとフックは`libs/foo`基準で解決され、親リポジトリの`pre_start`フックより前に実行されます。
+
+:::note
+再帰更新、フィルタ付き更新、失敗を意図的に無視する場合など、カスタムのサブモジュール動作が必要な場合はフックを使用してください。
 :::
 
 ## フックのスキップ
@@ -199,11 +203,12 @@ Claude CodeがWorktreeを作成する場合（自然言語、`isolation: "worktr
 **WorktreeCreate:**
 
 1. stdinからWorktree名を読み取り（Claude Codeフックプロトコル）
-2. 元リポジトリで`pre_start`フックを実行
-3. git Worktreeを作成
-4. CoWを使用してファイル/ディレクトリをコピー
-5. 新しいWorktreeで`post_start`フックを実行（例：`pnpm install`）
-6. Claude Code向けにWorktreeパスをstdoutに出力
+2. git Worktreeを作成
+3. `[submodules] configs = [...]`の場合、指定されたサブモジュールを初期化し、信頼済みsetupを実行
+4. 元リポジトリで親の`pre_start`フックを実行
+5. CoWを使用して親のファイル/ディレクトリをコピー
+6. 新しいWorktreeで親の`post_start`フックを実行（例：`pnpm install`）
+7. Claude Code向けにWorktreeパスをstdoutに出力
 
 **WorktreeRemove:**
 

--- a/packages/docs/src/content/docs/ja/configuration/vibe-toml.mdx
+++ b/packages/docs/src/content/docs/ja/configuration/vibe-toml.mdx
@@ -116,6 +116,24 @@ vibeはシステムに応じて最適なコピー戦略を自動選択します�
 
 フック設定の詳細は[フック](/ja/configuration/hooks/)を参照してください。
 
+## サブモジュール設定
+
+Worktree作成後、親リポジトリの`pre_start`フックの実行前に、指定した直接サブモジュールの信頼済み`.vibe.toml`を読み込みます：
+
+```toml
+[submodules]
+configs = ["libs/foo", "vendor/bar"]
+```
+
+- **デフォルト**: `[]`
+- 各エントリは`.gitmodules`内の直接サブモジュールpathと完全一致する必要があります
+- 新しいWorktree内で`git submodule update --init -- <paths>`を実行します
+- 各サブモジュールの`.vibe.toml` / `.vibe.local.toml`は、そのサブモジュール自身のtrust entryで読み込まれます
+- サブモジュール設定内のフックとcopyルールは、サブモジュールルート基準で実行されます
+- `--no-hooks`はサブモジュールのフックをスキップしますが、サブモジュール初期化はスキップしません
+- `--no-copy`はサブモジュールのcopyルールをスキップします
+- サブモジュール更新、trust、path検証、setupのいずれかに失敗すると`vibe start`は中断され、作成済みWorktreeは調査用に残ります
+
 ## Worktree設定 <Badge text="v0.6.0+" />
 
 外部スクリプトを使用してWorktreeディレクトリパスをカスタマイズできます。
@@ -175,6 +193,9 @@ post_start = [
 ]
 pre_clean = ["git stash"]
 post_clean = ["echo 'クリーンアップ完了'"]
+
+[submodules]
+configs = ["libs/foo"]
 
 [worktree]
 path_script = "~/.config/vibe/worktree-path.sh"

--- a/packages/e2e/start.test.ts
+++ b/packages/e2e/start.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { existsSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { basename, dirname, join } from "path";
 import { afterEach, describe, expect, test } from "vitest";
 import { getVibePath, VibeCommandRunner } from "./helpers/pty.js";
@@ -10,6 +10,66 @@ import {
   assertOutputContains,
   waitForCondition,
 } from "./helpers/assertions.js";
+
+function git(args: string[], cwd: string, homePath: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      HOME: homePath,
+    },
+    stdio: "pipe",
+  });
+}
+
+async function trustConfig(vibePath: string, cwd: string, homePath: string): Promise<void> {
+  const trustRunner = new VibeCommandRunner(vibePath, cwd, homePath);
+  try {
+    await trustRunner.spawn(["trust"]);
+    await trustRunner.waitForExit();
+    const trustOutput = trustRunner.getOutput();
+    assertExitCode(trustRunner.getExitCode(), 0, trustOutput);
+  } finally {
+    trustRunner.dispose();
+  }
+}
+
+function createSubmoduleSource(
+  homePath: string,
+  name: string,
+  markerFile: string,
+): string {
+  const sourcePath = join(homePath, `${name}-source`);
+  mkdirSync(sourcePath, { recursive: true });
+  git(["init"], sourcePath, homePath);
+  git(["config", "user.email", "test@example.com"], sourcePath, homePath);
+  git(["config", "user.name", "Test User"], sourcePath, homePath);
+  git(["remote", "add", "origin", sourcePath], sourcePath, homePath);
+  writeFileSync(join(sourcePath, "README.md"), `# ${name}\n`);
+  writeFileSync(
+    join(sourcePath, ".vibe.toml"),
+    `[hooks]\npost_start = ["touch ${markerFile}"]\n`,
+  );
+  git(["add", "README.md", ".vibe.toml"], sourcePath, homePath);
+  git(["commit", "-m", `Add ${name} config`], sourcePath, homePath);
+  git(["branch", "-M", "main"], sourcePath, homePath);
+  return sourcePath;
+}
+
+function addSubmodule(
+  repoPath: string,
+  homePath: string,
+  sourcePath: string,
+  submodulePath: string,
+): void {
+  git(["config", "--global", "protocol.file.allow", "always"], repoPath, homePath);
+  git(
+    ["-c", "protocol.file.allow=always", "submodule", "add", sourcePath, submodulePath],
+    repoPath,
+    homePath,
+  );
+}
 
 describe("start command", () => {
   let cleanup: (() => Promise<void>) | null = null;
@@ -456,6 +516,88 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.hook-ran"]
 
       expect(existsSync(hookMarker)).toBe(false);
       expect(existsSync(copiedFile)).toBe(false);
+    } finally {
+      runner.dispose();
+    }
+  });
+
+  test("runs .vibe.toml from one initialized submodule", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+
+    const vibePath = getVibePath();
+    const fooSource = createSubmoduleSource(homePath, "foo", ".foo-submodule-hook-ran");
+    addSubmodule(repoPath, homePath, fooSource, "libs/foo");
+
+    writeFileSync(join(repoPath, ".vibe.toml"), '[submodules]\nconfigs = ["libs/foo"]\n');
+    git(["add", ".vibe.toml", ".gitmodules", "libs/foo"], repoPath, homePath);
+    git(["commit", "-m", "Add one submodule config"], repoPath, homePath);
+
+    await trustConfig(vibePath, repoPath, homePath);
+    await trustConfig(vibePath, fooSource, homePath);
+
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
+    try {
+      await runner.spawn(["start", "feat/one-submodule"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+
+      const parentDir = dirname(repoPath);
+      const repoName = basename(repoPath);
+      const worktreePath = `${parentDir}/${repoName}-feat-one-submodule`;
+      const submoduleWorktreePath = join(worktreePath, "libs/foo");
+
+      await assertDirectoryExists(submoduleWorktreePath);
+      expect(existsSync(join(submoduleWorktreePath, ".vibe.toml"))).toBe(true);
+      expect(existsSync(join(submoduleWorktreePath, ".foo-submodule-hook-ran"))).toBe(true);
+    } finally {
+      runner.dispose();
+    }
+  });
+
+  test("runs .vibe.toml from multiple initialized submodules", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+
+    const vibePath = getVibePath();
+    const fooSource = createSubmoduleSource(homePath, "foo", ".foo-submodule-hook-ran");
+    const barSource = createSubmoduleSource(homePath, "bar", ".bar-submodule-hook-ran");
+    addSubmodule(repoPath, homePath, fooSource, "libs/foo");
+    addSubmodule(repoPath, homePath, barSource, "vendor/bar");
+
+    writeFileSync(
+      join(repoPath, ".vibe.toml"),
+      '[submodules]\nconfigs = ["libs/foo", "vendor/bar"]\n',
+    );
+    git(["add", ".vibe.toml", ".gitmodules", "libs/foo", "vendor/bar"], repoPath, homePath);
+    git(["commit", "-m", "Add multiple submodule configs"], repoPath, homePath);
+
+    await trustConfig(vibePath, repoPath, homePath);
+    await trustConfig(vibePath, fooSource, homePath);
+    await trustConfig(vibePath, barSource, homePath);
+
+    const runner = new VibeCommandRunner(vibePath, repoPath, homePath);
+    try {
+      await runner.spawn(["start", "feat/multiple-submodules"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+
+      const parentDir = dirname(repoPath);
+      const repoName = basename(repoPath);
+      const worktreePath = `${parentDir}/${repoName}-feat-multiple-submodules`;
+      const fooWorktreePath = join(worktreePath, "libs/foo");
+      const barWorktreePath = join(worktreePath, "vendor/bar");
+
+      await assertDirectoryExists(fooWorktreePath);
+      await assertDirectoryExists(barWorktreePath);
+      expect(existsSync(join(fooWorktreePath, ".vibe.toml"))).toBe(true);
+      expect(existsSync(join(barWorktreePath, ".vibe.toml"))).toBe(true);
+      expect(existsSync(join(fooWorktreePath, ".foo-submodule-hook-ran"))).toBe(true);
+      expect(existsSync(join(barWorktreePath, ".bar-submodule-hook-ran"))).toBe(true);
     } finally {
       runner.dispose();
     }

--- a/packages/e2e/start.test.ts
+++ b/packages/e2e/start.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { basename, dirname, join } from "path";
 import { afterEach, describe, expect, test } from "vitest";
 import { getVibePath, VibeCommandRunner } from "./helpers/pty.js";
@@ -49,7 +49,7 @@ function createSubmoduleSource(
   writeFileSync(join(sourcePath, "README.md"), `# ${name}\n`);
   writeFileSync(
     join(sourcePath, ".vibe.toml"),
-    `[hooks]\npost_start = ["touch ${markerFile}"]\n`,
+    `[hooks]\npost_start = ["touch ${markerFile}"]\n[copy]\nfiles = [".env"]\n`,
   );
   git(["add", "README.md", ".vibe.toml"], sourcePath, homePath);
   git(["commit", "-m", `Add ${name} config`], sourcePath, homePath);
@@ -528,6 +528,7 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.hook-ran"]
     const vibePath = getVibePath();
     const fooSource = createSubmoduleSource(homePath, "foo", ".foo-submodule-hook-ran");
     addSubmodule(repoPath, homePath, fooSource, "libs/foo");
+    writeFileSync(join(repoPath, "libs/foo/.env"), "FOO_FROM_ORIGIN=1\n");
 
     writeFileSync(join(repoPath, ".vibe.toml"), '[submodules]\nconfigs = ["libs/foo"]\n');
     git(["add", ".vibe.toml", ".gitmodules", "libs/foo"], repoPath, homePath);
@@ -551,6 +552,9 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.hook-ran"]
 
       await assertDirectoryExists(submoduleWorktreePath);
       expect(existsSync(join(submoduleWorktreePath, ".vibe.toml"))).toBe(true);
+      expect(readFileSync(join(submoduleWorktreePath, ".env"), "utf-8")).toBe(
+        "FOO_FROM_ORIGIN=1\n",
+      );
       expect(existsSync(join(submoduleWorktreePath, ".foo-submodule-hook-ran"))).toBe(true);
     } finally {
       runner.dispose();
@@ -566,6 +570,8 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.hook-ran"]
     const barSource = createSubmoduleSource(homePath, "bar", ".bar-submodule-hook-ran");
     addSubmodule(repoPath, homePath, fooSource, "libs/foo");
     addSubmodule(repoPath, homePath, barSource, "vendor/bar");
+    writeFileSync(join(repoPath, "libs/foo/.env"), "FOO_FROM_ORIGIN=1\n");
+    writeFileSync(join(repoPath, "vendor/bar/.env"), "BAR_FROM_ORIGIN=1\n");
 
     writeFileSync(
       join(repoPath, ".vibe.toml"),
@@ -596,6 +602,12 @@ post_start = ["touch $VIBE_WORKTREE_PATH/.hook-ran"]
       await assertDirectoryExists(barWorktreePath);
       expect(existsSync(join(fooWorktreePath, ".vibe.toml"))).toBe(true);
       expect(existsSync(join(barWorktreePath, ".vibe.toml"))).toBe(true);
+      expect(readFileSync(join(fooWorktreePath, ".env"), "utf-8")).toBe(
+        "FOO_FROM_ORIGIN=1\n",
+      );
+      expect(readFileSync(join(barWorktreePath, ".env"), "utf-8")).toBe(
+        "BAR_FROM_ORIGIN=1\n",
+      );
       expect(existsSync(join(fooWorktreePath, ".foo-submodule-hook-ran"))).toBe(true);
       expect(existsSync(join(barWorktreePath, ".bar-submodule-hook-ran"))).toBe(true);
     } finally {

--- a/rust/crates/vibe-core/src/commands/start.rs
+++ b/rust/crates/vibe-core/src/commands/start.rs
@@ -3,7 +3,8 @@
 //! Ported from `packages/core/src/commands/start.ts`. The validation cascade,
 //! existing-branch navigate, same-branch idempotent re-entry, different-branch
 //! Overwrite/Reuse/Cancel select, worktree creation, and the
-//! pre_start → copy → post_start config-and-hooks sequence mirror the TS. The
+//! submodule init → pre_start → copy → post_start config-and-hooks sequence
+//! mirror the TS. The
 //! Claude-Code `--claude-code-worktree-hook` mode reads a name from stdin and
 //! outputs the worktree PATH to stdout (not a `cd`), with non-fatal post-setup.
 //!
@@ -17,7 +18,7 @@
 
 use crate::commands::Outcome;
 use crate::config::VibeConfig;
-use crate::config_loader::load_vibe_config;
+use crate::config_loader::{load_vibe_config, VIBE_TOML};
 use crate::copy::strategies::CopyExecutor;
 use crate::copy_runner::{copy_directories, copy_files, resolve_copy_concurrency};
 use crate::error::{Result, VibeError};
@@ -37,6 +38,8 @@ use crate::worktree_path::{resolve_worktree_path, ScriptRunner, WorktreePathCont
 use crate::worktree_validator::{
     check_worktree_conflict, validate_branch_for_worktree, ConflictType,
 };
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
 
 /// Flags controlling a `start` run (mirrors the TS `StartOptions`).
 #[derive(Debug, Clone, Default)]
@@ -501,8 +504,8 @@ where
     )))
 }
 
-/// Run config-driven hooks + copy: pre_start (in repo_root) → copy files + dirs →
-/// post_start (in worktree_path).
+/// Run config-driven operations: listed submodule configs → pre_start (in
+/// repo_root) → copy files + dirs → post_start (in worktree_path).
 fn run_config_and_hooks<I, G, R, S, P, Sr>(
     deps: &StartDeps<I, G, R, S, P, Sr>,
     config: Option<&VibeConfig>,
@@ -530,6 +533,35 @@ where
         deps.tracker.start();
     }
 
+    run_submodule_configs(deps, config, repo_root, worktree_path, options)?;
+
+    run_config_body(deps, config, repo_root, worktree_path, options)?;
+
+    if has_ops {
+        deps.tracker.finish();
+    }
+
+    Ok(())
+}
+
+/// Run hooks/copy for one already-loaded config. Submodule configs use this
+/// helper directly so their own `[submodules]` section is intentionally not
+/// followed recursively.
+fn run_config_body<I, G, R, S, P, Sr>(
+    deps: &StartDeps<I, G, R, S, P, Sr>,
+    config: &VibeConfig,
+    repo_root: &str,
+    worktree_path: &str,
+    options: &ConfigAndHooks,
+) -> Result<()>
+where
+    I: Io,
+    G: GitRunner,
+    R: RepoResolver,
+    S: ScriptRunner,
+    P: Prompt,
+    Sr: StdinReader,
+{
     // pre_start hooks (in repo_root).
     if !options.skip_hooks {
         run_lifecycle_hooks(
@@ -601,15 +633,13 @@ where
         )?;
     }
 
-    if has_ops {
-        deps.tracker.finish();
-    }
-
     Ok(())
 }
 
 /// Whether config has any hook/copy operation (drives starting the tracker).
 fn config_has_operations(config: &VibeConfig, options: &ConfigAndHooks) -> bool {
+    let has_submodule_configs =
+        submodule_config_paths(config).is_some_and(|paths| !paths.is_empty());
     let hooks_count = if options.skip_hooks {
         0
     } else {
@@ -634,7 +664,283 @@ fn config_has_operations(config: &VibeConfig, options: &ConfigAndHooks) -> bool 
             })
             .unwrap_or(0)
     };
-    hooks_count + copy_count > 0
+    has_submodule_configs || hooks_count + copy_count > 0
+}
+
+fn submodule_config_paths(config: &VibeConfig) -> Option<&[String]> {
+    config
+        .submodules
+        .as_ref()
+        .and_then(|s| s.configs.as_deref())
+}
+
+fn run_submodule_configs<I, G, R, S, P, Sr>(
+    deps: &StartDeps<I, G, R, S, P, Sr>,
+    config: &VibeConfig,
+    repo_root: &str,
+    worktree_path: &str,
+    options: &ConfigAndHooks,
+) -> Result<()>
+where
+    I: Io,
+    G: GitRunner,
+    R: RepoResolver,
+    S: ScriptRunner,
+    P: Prompt,
+    Sr: StdinReader,
+{
+    let Some(paths) = submodule_config_paths(config).filter(|paths| !paths.is_empty()) else {
+        return Ok(());
+    };
+
+    let paths = validate_submodule_config_paths(deps, repo_root, paths)?;
+    init_submodules(deps, worktree_path, &paths, options.dry_run)?;
+
+    for path in &paths {
+        let roots = resolve_submodule_roots(repo_root, worktree_path, path, options.dry_run)?;
+        let Some(submodule_config) =
+            load_vibe_config(deps.io, deps.resolver, deps.version, &roots.origin)?
+        else {
+            return Err(VibeError::Configuration(format!(
+                "Submodule '{path}' is listed in [submodules] configs, but {}/{} does not exist",
+                roots.origin, VIBE_TOML
+            )));
+        };
+
+        run_config_body(
+            deps,
+            &submodule_config,
+            &roots.origin,
+            &roots.worktree,
+            options,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn init_submodules<I, G, R, S, P, Sr>(
+    deps: &StartDeps<I, G, R, S, P, Sr>,
+    worktree_path: &str,
+    paths: &[String],
+    dry_run: bool,
+) -> Result<()>
+where
+    I: Io,
+    G: GitRunner,
+    R: RepoResolver,
+    S: ScriptRunner,
+    P: Prompt,
+    Sr: StdinReader,
+{
+    let joined_paths = paths.join(" ");
+    let command = format!("git -C {worktree_path} submodule update --init -- {joined_paths}");
+
+    if dry_run {
+        log_dry_run(deps.io, &format!("Would run: {command}"));
+        return Ok(());
+    }
+
+    let phase = deps.tracker.add_phase("Initializing submodules");
+    let task = deps.tracker.add_task(
+        phase,
+        &format!("git submodule update --init -- {joined_paths}"),
+    );
+    deps.tracker.start_task(task);
+    let mut args = vec!["-C", worktree_path, "submodule", "update", "--init", "--"];
+    args.extend(paths.iter().map(String::as_str));
+    let result = deps.git.run(&args);
+
+    match result {
+        Ok(_) => {
+            deps.tracker.complete_task(task);
+            Ok(())
+        }
+        Err(err) => {
+            deps.tracker.fail_task(task, &err.to_string());
+            Err(err)
+        }
+    }
+}
+
+fn validate_submodule_config_paths<I, G, R, S, P, Sr>(
+    deps: &StartDeps<I, G, R, S, P, Sr>,
+    repo_root: &str,
+    paths: &[String],
+) -> Result<Vec<String>>
+where
+    I: Io,
+    G: GitRunner,
+    R: RepoResolver,
+    S: ScriptRunner,
+    P: Prompt,
+    Sr: StdinReader,
+{
+    let mut seen = HashSet::new();
+    let mut validated = Vec::new();
+
+    for path in paths {
+        validate_submodule_config_path(path)?;
+    }
+
+    let direct_submodules = direct_submodule_paths(deps, repo_root)?;
+    for path in paths {
+        let is_direct_submodule = direct_submodules.contains(path);
+        if !is_direct_submodule {
+            return Err(VibeError::Configuration(format!(
+                "[submodules] configs entry '{path}' must exactly match a direct path in .gitmodules"
+            )));
+        }
+        let is_new = seen.insert(path.clone());
+        if is_new {
+            validated.push(path.clone());
+        }
+    }
+
+    Ok(validated)
+}
+
+fn validate_submodule_config_path(path: &str) -> Result<()> {
+    let has_surrounding_whitespace = path.trim() != path;
+    if path.is_empty() || has_surrounding_whitespace {
+        return Err(invalid_submodule_config_path(path));
+    }
+    let has_control_chars = path.chars().any(char::is_control);
+    let has_glob_chars = path
+        .chars()
+        .any(|c| matches!(c, '*' | '?' | '[' | ']' | '{' | '}'));
+    if has_control_chars || has_glob_chars {
+        return Err(invalid_submodule_config_path(path));
+    }
+
+    let candidate = Path::new(path);
+    if candidate.is_absolute() {
+        return Err(invalid_submodule_config_path(path));
+    }
+
+    let mut has_component = false;
+    for component in candidate.components() {
+        match component {
+            Component::Normal(_) => has_component = true,
+            Component::CurDir
+            | Component::ParentDir
+            | Component::RootDir
+            | Component::Prefix(_) => {
+                return Err(invalid_submodule_config_path(path));
+            }
+        }
+    }
+
+    if !has_component {
+        return Err(invalid_submodule_config_path(path));
+    }
+
+    Ok(())
+}
+
+fn invalid_submodule_config_path(path: &str) -> VibeError {
+    VibeError::Configuration(format!(
+        "[submodules] configs entry '{path}' must be a parent-repo-relative submodule path without absolute paths, traversal, glob characters, or control characters"
+    ))
+}
+
+fn direct_submodule_paths<I, G, R, S, P, Sr>(
+    deps: &StartDeps<I, G, R, S, P, Sr>,
+    repo_root: &str,
+) -> Result<HashSet<String>>
+where
+    I: Io,
+    G: GitRunner,
+    R: RepoResolver,
+    S: ScriptRunner,
+    P: Prompt,
+    Sr: StdinReader,
+{
+    let gitmodules = Path::new(repo_root).join(".gitmodules");
+    if !gitmodules.exists() {
+        return Err(VibeError::Configuration(
+            "[submodules] configs requires a .gitmodules file".to_string(),
+        ));
+    }
+
+    let output = deps.git.run(&[
+        "-C",
+        repo_root,
+        "config",
+        "--file",
+        ".gitmodules",
+        "--get-regexp",
+        r"^submodule\..*\.path$",
+    ])?;
+
+    let mut paths = HashSet::new();
+    for line in output.lines() {
+        let Some((_, path)) = line.split_once(' ') else {
+            continue;
+        };
+        paths.insert(path.trim().to_string());
+    }
+    Ok(paths)
+}
+
+struct SubmoduleRoots {
+    origin: String,
+    worktree: String,
+}
+
+fn resolve_submodule_roots(
+    repo_root: &str,
+    worktree_path: &str,
+    submodule_path: &str,
+    dry_run: bool,
+) -> Result<SubmoduleRoots> {
+    let origin_parent = canonicalize_existing(Path::new(repo_root), "repository root")?;
+    let origin = canonicalize_existing(
+        &PathBuf::from(repo_root).join(submodule_path),
+        "origin submodule",
+    )?;
+    ensure_child_path(&origin_parent, &origin, submodule_path, "origin submodule")?;
+
+    let worktree = if dry_run {
+        PathBuf::from(worktree_path).join(submodule_path)
+    } else {
+        let worktree_parent = canonicalize_existing(Path::new(worktree_path), "worktree root")?;
+        let worktree = canonicalize_existing(
+            &PathBuf::from(worktree_path).join(submodule_path),
+            "worktree submodule",
+        )?;
+        ensure_child_path(
+            &worktree_parent,
+            &worktree,
+            submodule_path,
+            "worktree submodule",
+        )?;
+        worktree
+    };
+
+    Ok(SubmoduleRoots {
+        origin: origin.to_string_lossy().into_owned(),
+        worktree: worktree.to_string_lossy().into_owned(),
+    })
+}
+
+fn canonicalize_existing(path: &Path, label: &str) -> Result<PathBuf> {
+    path.canonicalize().map_err(|e| {
+        VibeError::Configuration(format!(
+            "Failed to resolve {label} path '{}': {e}",
+            path.display()
+        ))
+    })
+}
+
+fn ensure_child_path(parent: &Path, child: &Path, submodule_path: &str, label: &str) -> Result<()> {
+    if child.starts_with(parent) {
+        return Ok(());
+    }
+
+    Err(VibeError::Configuration(format!(
+        "Resolved {label} path for '{submodule_path}' escapes its parent repository"
+    )))
 }
 
 /// Run a lifecycle hook list with a phase/tasks on the tracker.

--- a/rust/crates/vibe-core/src/commands/start.rs
+++ b/rust/crates/vibe-core/src/commands/start.rs
@@ -698,19 +698,24 @@ where
 
     for path in &paths {
         let roots = resolve_submodule_roots(repo_root, worktree_path, path, options.dry_run)?;
+        let config_root = if options.dry_run {
+            &roots.origin
+        } else {
+            &roots.worktree
+        };
         let Some(submodule_config) =
-            load_vibe_config(deps.io, deps.resolver, deps.version, &roots.origin)?
+            load_vibe_config(deps.io, deps.resolver, deps.version, config_root)?
         else {
             return Err(VibeError::Configuration(format!(
                 "Submodule '{path}' is listed in [submodules] configs, but {}/{} does not exist",
-                roots.origin, VIBE_TOML
+                config_root, VIBE_TOML
             )));
         };
 
         run_config_body(
             deps,
             &submodule_config,
-            &roots.origin,
+            config_root,
             &roots.worktree,
             options,
         )?;

--- a/rust/crates/vibe-core/src/commands/start.rs
+++ b/rust/crates/vibe-core/src/commands/start.rs
@@ -535,7 +535,7 @@ where
 
     run_submodule_configs(deps, config, repo_root, worktree_path, options)?;
 
-    run_config_body(deps, config, repo_root, worktree_path, options)?;
+    run_config_body(deps, config, repo_root, worktree_path, repo_root, options)?;
 
     if has_ops {
         deps.tracker.finish();
@@ -552,6 +552,7 @@ fn run_config_body<I, G, R, S, P, Sr>(
     config: &VibeConfig,
     repo_root: &str,
     worktree_path: &str,
+    copy_source_root: &str,
     options: &ConfigAndHooks,
 ) -> Result<()>
 where
@@ -587,7 +588,7 @@ where
                 .as_ref()
                 .and_then(|c| c.files.as_deref())
                 .unwrap_or(&[]),
-            repo_root,
+            copy_source_root,
             worktree_path,
             options.dry_run,
         );
@@ -606,7 +607,7 @@ where
                 &deps.executor,
                 &deps.tracker,
                 dirs,
-                repo_root,
+                copy_source_root,
                 worktree_path,
                 options.dry_run,
                 concurrency,
@@ -717,6 +718,7 @@ where
             &submodule_config,
             config_root,
             &roots.worktree,
+            &roots.origin,
             options,
         )?;
     }

--- a/rust/crates/vibe-core/src/commands/start_tests.rs
+++ b/rust/crates/vibe-core/src/commands/start_tests.rs
@@ -821,24 +821,28 @@ fn trusted_repo_with_submodule_config() -> (Fixture, FakeIo, TrustResolver, Stri
     let _ = fx.mkdir("repo-feat/libs/foo");
 
     let parent = "[submodules]\nconfigs = [\"libs/foo\"]\n[hooks]\npre_start = [\"echo parent\"]\n";
-    let submodule = "[hooks]\npre_start = [\"echo sub-pre\"]\npost_start = [\"echo sub-post\"]\n[copy]\nfiles = [\".env\"]\n";
+    let origin_submodule = "[hooks]\npre_start = [\"echo origin-sub-pre\"]\n";
+    let worktree_submodule = "[hooks]\npre_start = [\"echo sub-pre\"]\npost_start = [\"echo sub-post\"]\n[copy]\nfiles = [\".env\"]\n";
     fx.write("repo/.vibe.toml", parent);
     fx.write(
         "repo/.gitmodules",
         "[submodule \"libs/foo\"]\n\tpath = libs/foo\n\turl = https://example.com/foo.git\n",
     );
-    fx.write("repo/libs/foo/.vibe.toml", submodule);
-    fx.write("repo/libs/foo/.env", "SUB=1");
+    fx.write("repo/libs/foo/.vibe.toml", origin_submodule);
+    fx.write("repo-feat/libs/foo/.vibe.toml", worktree_submodule);
+    fx.write("repo-feat/libs/foo/.env", "SUB=1");
 
     let repo = repo_raw.canonicalize().unwrap();
     let submodule_origin = submodule_origin_raw.canonicalize().unwrap();
     let worktree = worktree_raw.canonicalize().unwrap();
+    let submodule_worktree = worktree.join("libs/foo").canonicalize().unwrap();
 
     let io = FakeIo::new().with_env("HOME", fx.path().to_str().unwrap());
     let mut settings = VibeSettings::default_settings();
     for (root, file, content) in [
         (&repo, ".vibe.toml", parent),
-        (&submodule_origin, ".vibe.toml", submodule),
+        (&submodule_origin, ".vibe.toml", origin_submodule),
+        (&submodule_worktree, ".vibe.toml", worktree_submodule),
     ] {
         settings.permissions.allow.push(AllowEntry {
             repo_id: RepoId {
@@ -853,7 +857,11 @@ fn trusted_repo_with_submodule_config() -> (Fixture, FakeIo, TrustResolver, Stri
     save_user_settings(&io, &settings, V).unwrap();
 
     let mut repos = HashMap::new();
-    for (root, file) in [(&repo, ".vibe.toml"), (&submodule_origin, ".vibe.toml")] {
+    for (root, file) in [
+        (&repo, ".vibe.toml"),
+        (&submodule_origin, ".vibe.toml"),
+        (&submodule_worktree, ".vibe.toml"),
+    ] {
         repos.insert(
             root.join(file).to_string_lossy().into_owned(),
             RepoInfo {
@@ -863,7 +871,6 @@ fn trusted_repo_with_submodule_config() -> (Fixture, FakeIo, TrustResolver, Stri
             },
         );
     }
-    let _ = worktree;
     (
         fx,
         io,
@@ -1041,7 +1048,7 @@ fn submodule_configs_run_before_parent_pre_start_with_submodule_roots() {
 
     let hooks = fk.hooks.calls.borrow();
     assert_eq!(hooks[0].0, "echo sub-pre");
-    assert!(hooks[0].1.ends_with("repo/libs/foo"));
+    assert!(hooks[0].1.ends_with("repo-feat/libs/foo"));
     assert_eq!(hooks[1].0, "echo sub-post");
     assert!(hooks[1].1.ends_with("repo-feat/libs/foo"));
     assert_eq!(hooks[2].0, "echo parent");
@@ -1049,7 +1056,7 @@ fn submodule_configs_run_before_parent_pre_start_with_submodule_roots() {
 
     let file_copies = fk.exec.file_copies.lock().unwrap();
     assert_eq!(file_copies.len(), 1);
-    assert!(file_copies[0].0.ends_with("repo/libs/foo/.env"));
+    assert!(file_copies[0].0.ends_with("repo-feat/libs/foo/.env"));
     assert!(file_copies[0].1.ends_with("repo-feat/libs/foo/.env"));
 }
 
@@ -1187,7 +1194,7 @@ fn submodule_config_requires_its_own_trust() {
     let _ = &fx;
     resolver
         .repos
-        .retain(|path, _| !path.ends_with("repo/libs/foo/.vibe.toml"));
+        .retain(|path, _| !path.ends_with("repo-feat/libs/foo/.vibe.toml"));
     let git = MockGit::new(
         &repo_root,
         &format!("worktree {repo_root}\nbranch refs/heads/main\n\n"),

--- a/rust/crates/vibe-core/src/commands/start_tests.rs
+++ b/rust/crates/vibe-core/src/commands/start_tests.rs
@@ -1056,7 +1056,7 @@ fn submodule_configs_run_before_parent_pre_start_with_submodule_roots() {
 
     let file_copies = fk.exec.file_copies.lock().unwrap();
     assert_eq!(file_copies.len(), 1);
-    assert!(file_copies[0].0.ends_with("repo-feat/libs/foo/.env"));
+    assert!(file_copies[0].0.ends_with("repo/libs/foo/.env"));
     assert!(file_copies[0].1.ends_with("repo-feat/libs/foo/.env"));
 }
 

--- a/rust/crates/vibe-core/src/commands/start_tests.rs
+++ b/rust/crates/vibe-core/src/commands/start_tests.rs
@@ -23,6 +23,7 @@ struct MockGit {
     local_branches: Vec<String>,
     remote_branches: Vec<String>,
     existing_revisions: Vec<String>,
+    fail_prefix: Option<Vec<String>>,
     pub calls: RefCell<Vec<Vec<String>>>,
 }
 
@@ -34,6 +35,7 @@ impl MockGit {
             local_branches: vec![],
             remote_branches: vec![],
             existing_revisions: vec![],
+            fail_prefix: None,
             calls: RefCell::new(vec![]),
         }
     }
@@ -41,11 +43,26 @@ impl MockGit {
         self.existing_revisions.push(r.to_string());
         self
     }
+    fn failing_on(mut self, prefix: &[&str]) -> Self {
+        self.fail_prefix = Some(prefix.iter().map(|s| s.to_string()).collect());
+        self
+    }
     fn calls_contain(&self, prefix: &[&str]) -> bool {
         self.calls
             .borrow()
             .iter()
             .any(|c| c.len() >= prefix.len() && c[..prefix.len()] == *prefix)
+    }
+    fn submodule_update_calls(&self) -> usize {
+        self.calls
+            .borrow()
+            .iter()
+            .filter(|c| {
+                c.iter().any(|arg| arg == "submodule")
+                    && c.iter().any(|arg| arg == "update")
+                    && c.iter().any(|arg| arg == "--init")
+            })
+            .count()
     }
 }
 
@@ -55,8 +72,43 @@ impl GitRunner for MockGit {
             .borrow_mut()
             .push(args.iter().map(|s| s.to_string()).collect());
 
+        if let Some(prefix) = &self.fail_prefix {
+            let is_matching_prefix = args.len() >= prefix.len()
+                && args
+                    .iter()
+                    .take(prefix.len())
+                    .zip(prefix.iter())
+                    .all(|(actual, expected)| actual == expected);
+            if is_matching_prefix {
+                return Err(VibeError::GitOperation {
+                    command: args.join(" "),
+                    message: "failed: submodule update".into(),
+                });
+            }
+        }
+
         if args.contains(&"--show-toplevel") {
             return Ok(self.repo_root.clone());
+        }
+        if args.contains(&"config") && args.contains(&"--file") && args.contains(&".gitmodules") {
+            let gitmodules = std::path::Path::new(&self.repo_root).join(".gitmodules");
+            let content =
+                std::fs::read_to_string(&gitmodules).map_err(|e| VibeError::GitOperation {
+                    command: args.join(" "),
+                    message: format!("failed: {e}"),
+                })?;
+            let paths = parse_gitmodules_paths_for_test(&content);
+            if paths.is_empty() {
+                return Err(VibeError::GitOperation {
+                    command: args.join(" "),
+                    message: "failed: no submodule paths".into(),
+                });
+            }
+            return Ok(paths
+                .into_iter()
+                .map(|path| format!("submodule.test.path {path}"))
+                .collect::<Vec<_>>()
+                .join("\n"));
         }
         if args.contains(&"list") && args.contains(&"worktree") {
             return Ok(self.worktree_list.clone());
@@ -95,6 +147,15 @@ impl GitRunner for MockGit {
         // worktree add / remove succeed.
         Ok(String::new())
     }
+}
+
+fn parse_gitmodules_paths_for_test(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("path"))
+        .filter_map(|line| line.trim_start().strip_prefix('='))
+        .map(|path| path.trim().trim_matches('"').to_string())
+        .collect()
 }
 
 /// Resolver returning no repo info (config load → none).
@@ -700,6 +761,12 @@ fn different_branch_cancel_emits_no_cd() {
 /// Build a trusted-config fixture + resolver, returning (fixture, io, resolver,
 /// repo_root). The config has a pre_start, a copy file, and a post_start hook.
 fn trusted_config_repo() -> (Fixture, FakeIo, TrustResolver, String) {
+    trusted_config_repo_with_content(
+        "[hooks]\npre_start = [\"echo pre\"]\npost_start = [\"echo post\"]\n[copy]\nfiles = [\".env\"]\n",
+    )
+}
+
+fn trusted_config_repo_with_content(content: &str) -> (Fixture, FakeIo, TrustResolver, String) {
     use crate::hash::hash_content;
     use crate::settings::{AllowEntry, RepoId, VibeSettings};
     use crate::settings_io::save_user_settings;
@@ -707,7 +774,6 @@ fn trusted_config_repo() -> (Fixture, FakeIo, TrustResolver, String) {
 
     let fx = Fixture::new();
     let repo = fx.mkdir("repo");
-    let content = "[hooks]\npre_start = [\"echo pre\"]\npost_start = [\"echo post\"]\n[copy]\nfiles = [\".env\"]\n";
     fx.write("repo/.vibe.toml", content);
     fx.write("repo/.env", "SECRET=1");
 
@@ -740,6 +806,113 @@ fn trusted_config_repo() -> (Fixture, FakeIo, TrustResolver, String) {
         TrustResolver { repos },
         repo.to_string_lossy().into_owned(),
     )
+}
+
+fn trusted_repo_with_submodule_config() -> (Fixture, FakeIo, TrustResolver, String) {
+    use crate::hash::hash_content;
+    use crate::settings::{AllowEntry, RepoId, VibeSettings};
+    use crate::settings_io::save_user_settings;
+    use std::collections::HashMap;
+
+    let fx = Fixture::new();
+    let repo_raw = fx.mkdir("repo");
+    let submodule_origin_raw = fx.mkdir("repo/libs/foo");
+    let worktree_raw = fx.mkdir("repo-feat");
+    let _ = fx.mkdir("repo-feat/libs/foo");
+
+    let parent = "[submodules]\nconfigs = [\"libs/foo\"]\n[hooks]\npre_start = [\"echo parent\"]\n";
+    let submodule = "[hooks]\npre_start = [\"echo sub-pre\"]\npost_start = [\"echo sub-post\"]\n[copy]\nfiles = [\".env\"]\n";
+    fx.write("repo/.vibe.toml", parent);
+    fx.write(
+        "repo/.gitmodules",
+        "[submodule \"libs/foo\"]\n\tpath = libs/foo\n\turl = https://example.com/foo.git\n",
+    );
+    fx.write("repo/libs/foo/.vibe.toml", submodule);
+    fx.write("repo/libs/foo/.env", "SUB=1");
+
+    let repo = repo_raw.canonicalize().unwrap();
+    let submodule_origin = submodule_origin_raw.canonicalize().unwrap();
+    let worktree = worktree_raw.canonicalize().unwrap();
+
+    let io = FakeIo::new().with_env("HOME", fx.path().to_str().unwrap());
+    let mut settings = VibeSettings::default_settings();
+    for (root, file, content) in [
+        (&repo, ".vibe.toml", parent),
+        (&submodule_origin, ".vibe.toml", submodule),
+    ] {
+        settings.permissions.allow.push(AllowEntry {
+            repo_id: RepoId {
+                remote_url: None,
+                repo_root: Some(root.to_string_lossy().into_owned()),
+            },
+            relative_path: file.into(),
+            hashes: vec![hash_content(content.as_bytes())],
+            skip_hash_check: None,
+        });
+    }
+    save_user_settings(&io, &settings, V).unwrap();
+
+    let mut repos = HashMap::new();
+    for (root, file) in [(&repo, ".vibe.toml"), (&submodule_origin, ".vibe.toml")] {
+        repos.insert(
+            root.join(file).to_string_lossy().into_owned(),
+            RepoInfo {
+                remote_url: None,
+                repo_root: root.to_string_lossy().into_owned(),
+                relative_path: file.into(),
+            },
+        );
+    }
+    let _ = worktree;
+    (
+        fx,
+        io,
+        TrustResolver { repos },
+        repo.to_string_lossy().into_owned(),
+    )
+}
+
+fn start_with_config(
+    content: &str,
+    fail_prefix: Option<&[&str]>,
+    flags: &StartFlags,
+) -> (
+    Fixture,
+    FakeIo,
+    TrustResolver,
+    String,
+    MockGit,
+    Fakes,
+    Result<Outcome>,
+) {
+    let (fx, io, resolver, repo_root) = trusted_config_repo_with_content(content);
+    let mut git = MockGit::new(
+        &repo_root,
+        &format!("worktree {repo_root}\nbranch refs/heads/main\n\n"),
+    );
+    if let Some(prefix) = fail_prefix {
+        git = git.failing_on(prefix);
+    }
+    let s = NoScript;
+    let p = ScriptPrompt::confirming(true);
+    let sin = FakeStdin::none();
+    let fk = Fakes::new();
+    let result = {
+        let d = StartDeps {
+            io: &io,
+            git: &git,
+            resolver: &resolver,
+            script_runner: &s,
+            prompt: &p,
+            stdin: &sin,
+            hook_runner: &fk.hooks,
+            executor: &fk.exec,
+            tracker: &fk.tracker,
+            version: V,
+        };
+        start_command(&d, "feat", flags, OutputOptions::default())
+    };
+    (fx, io, resolver, repo_root, git, fk, result)
 }
 
 struct TrustResolver {
@@ -828,6 +1001,220 @@ fn no_hooks_and_no_copy_skip_operations() {
     start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
     assert!(fk.hooks.calls.borrow().is_empty());
     assert!(fk.exec.file_copies.lock().unwrap().is_empty());
+}
+
+#[test]
+fn submodule_configs_run_before_parent_pre_start_with_submodule_roots() {
+    let (fx, io, resolver, repo_root) = trusted_repo_with_submodule_config();
+    let _ = &fx;
+    let git = MockGit::new(
+        &repo_root,
+        &format!("worktree {repo_root}\nbranch refs/heads/main\n\n"),
+    );
+    let s = NoScript;
+    let p = ScriptPrompt::confirming(true);
+    let sin = FakeStdin::none();
+    let fk = Fakes::new();
+    let d = StartDeps {
+        io: &io,
+        git: &git,
+        resolver: &resolver,
+        script_runner: &s,
+        prompt: &p,
+        stdin: &sin,
+        hook_runner: &fk.hooks,
+        executor: &fk.exec,
+        tracker: &fk.tracker,
+        version: V,
+    };
+    start_command(&d, "feat", &StartFlags::default(), OutputOptions::default()).unwrap();
+
+    assert!(git.calls_contain(&[
+        "-C",
+        &format!("{}-feat", repo_root),
+        "submodule",
+        "update",
+        "--init",
+        "--",
+        "libs/foo"
+    ]));
+
+    let hooks = fk.hooks.calls.borrow();
+    assert_eq!(hooks[0].0, "echo sub-pre");
+    assert!(hooks[0].1.ends_with("repo/libs/foo"));
+    assert_eq!(hooks[1].0, "echo sub-post");
+    assert!(hooks[1].1.ends_with("repo-feat/libs/foo"));
+    assert_eq!(hooks[2].0, "echo parent");
+    assert_eq!(hooks[2].1, repo_root);
+
+    let file_copies = fk.exec.file_copies.lock().unwrap();
+    assert_eq!(file_copies.len(), 1);
+    assert!(file_copies[0].0.ends_with("repo/libs/foo/.env"));
+    assert!(file_copies[0].1.ends_with("repo-feat/libs/foo/.env"));
+}
+
+#[test]
+fn submodule_configs_are_skipped_when_omitted() {
+    let content = "[hooks]\npre_start = [\"echo pre\"]\n";
+    let (_fx, _io, _resolver, _repo_root, git, _fk, result) =
+        start_with_config(content, None, &StartFlags::default());
+    result.unwrap();
+    assert_eq!(git.submodule_update_calls(), 0);
+}
+
+#[test]
+fn submodule_configs_respect_no_hooks_and_no_copy() {
+    let (fx, io, resolver, repo_root) = trusted_repo_with_submodule_config();
+    let _ = &fx;
+    let git = MockGit::new(
+        &repo_root,
+        &format!("worktree {repo_root}\nbranch refs/heads/main\n\n"),
+    );
+    let s = NoScript;
+    let p = ScriptPrompt::confirming(true);
+    let sin = FakeStdin::none();
+    let fk = Fakes::new();
+    let d = StartDeps {
+        io: &io,
+        git: &git,
+        resolver: &resolver,
+        script_runner: &s,
+        prompt: &p,
+        stdin: &sin,
+        hook_runner: &fk.hooks,
+        executor: &fk.exec,
+        tracker: &fk.tracker,
+        version: V,
+    };
+    let flags = StartFlags {
+        no_hooks: true,
+        no_copy: true,
+        ..Default::default()
+    };
+    start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
+
+    assert_eq!(git.submodule_update_calls(), 1);
+    assert!(fk.hooks.calls.borrow().is_empty());
+    assert!(fk.exec.file_copies.lock().unwrap().is_empty());
+}
+
+#[test]
+fn submodule_configs_dry_run_logs_without_running_git() {
+    let (fx, io, resolver, repo_root) = trusted_repo_with_submodule_config();
+    let _ = &fx;
+    std::fs::remove_dir_all(format!("{repo_root}-feat")).unwrap();
+    let git = MockGit::new(
+        &repo_root,
+        &format!("worktree {repo_root}\nbranch refs/heads/main\n\n"),
+    );
+    let s = NoScript;
+    let p = ScriptPrompt::confirming(true);
+    let sin = FakeStdin::none();
+    let fk = Fakes::new();
+    let d = StartDeps {
+        io: &io,
+        git: &git,
+        resolver: &resolver,
+        script_runner: &s,
+        prompt: &p,
+        stdin: &sin,
+        hook_runner: &fk.hooks,
+        executor: &fk.exec,
+        tracker: &fk.tracker,
+        version: V,
+    };
+    let flags = StartFlags {
+        dry_run: true,
+        ..Default::default()
+    };
+    start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
+
+    assert_eq!(git.submodule_update_calls(), 0);
+    assert!(io.stderr_text().contains("Would run: git -C"));
+    assert!(io
+        .stderr_text()
+        .contains("submodule update --init -- libs/foo"));
+}
+
+#[test]
+fn submodule_config_update_failure_aborts_remaining_operations() {
+    let (fx, io, resolver, repo_root) = trusted_repo_with_submodule_config();
+    let _ = &fx;
+    let git = MockGit::new(
+        &repo_root,
+        &format!("worktree {repo_root}\nbranch refs/heads/main\n\n"),
+    )
+    .failing_on(&["-C", &format!("{}-feat", repo_root), "submodule"]);
+    let s = NoScript;
+    let p = ScriptPrompt::confirming(true);
+    let sin = FakeStdin::none();
+    let fk = Fakes::new();
+    let d = StartDeps {
+        io: &io,
+        git: &git,
+        resolver: &resolver,
+        script_runner: &s,
+        prompt: &p,
+        stdin: &sin,
+        hook_runner: &fk.hooks,
+        executor: &fk.exec,
+        tracker: &fk.tracker,
+        version: V,
+    };
+    let result = start_command(&d, "feat", &StartFlags::default(), OutputOptions::default());
+
+    assert!(result.is_err());
+    assert!(fk.hooks.calls.borrow().is_empty());
+    assert!(fk.exec.file_copies.lock().unwrap().is_empty());
+}
+
+#[test]
+fn submodule_config_invalid_path_is_rejected_before_git_update() {
+    let content = "[submodules]\nconfigs = [\"../foo\"]\n";
+    let (_fx, _io, _resolver, _repo_root, git, _fk, result) =
+        start_with_config(content, None, &StartFlags::default());
+
+    let err = result.unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("must be a parent-repo-relative submodule path"));
+    assert_eq!(git.submodule_update_calls(), 0);
+}
+
+#[test]
+fn submodule_config_requires_its_own_trust() {
+    let (fx, io, mut resolver, repo_root) = trusted_repo_with_submodule_config();
+    let _ = &fx;
+    resolver
+        .repos
+        .retain(|path, _| !path.ends_with("repo/libs/foo/.vibe.toml"));
+    let git = MockGit::new(
+        &repo_root,
+        &format!("worktree {repo_root}\nbranch refs/heads/main\n\n"),
+    );
+    let s = NoScript;
+    let p = ScriptPrompt::confirming(true);
+    let sin = FakeStdin::none();
+    let fk = Fakes::new();
+    let d = StartDeps {
+        io: &io,
+        git: &git,
+        resolver: &resolver,
+        script_runner: &s,
+        prompt: &p,
+        stdin: &sin,
+        hook_runner: &fk.hooks,
+        executor: &fk.exec,
+        tracker: &fk.tracker,
+        version: V,
+    };
+    let err =
+        start_command(&d, "feat", &StartFlags::default(), OutputOptions::default()).unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains(".vibe.toml file is not trusted or has been modified"));
+    assert!(fk.hooks.calls.borrow().is_empty());
 }
 
 // --- claude-code worktree hook mode: stdout path ---

--- a/rust/crates/vibe-core/src/config.rs
+++ b/rust/crates/vibe-core/src/config.rs
@@ -22,6 +22,8 @@ pub struct VibeConfig {
     pub worktree: Option<WorktreeConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clean: Option<CleanConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub submodules: Option<SubmodulesConfig>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -85,6 +87,13 @@ pub struct WorktreeConfig {
 pub struct CleanConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delete_branch: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubmodulesConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configs: Option<Vec<String>>,
 }
 
 /// Parse a `VibeConfig` from TOML text, validating it like the Zod schema.
@@ -220,6 +229,16 @@ pub fn merge_configs(base: &VibeConfig, local: &VibeConfig) -> VibeConfig {
             .and_then(|c| c.delete_branch)
             .or_else(|| base.clean.as_ref().and_then(|c| c.delete_branch));
         merged.clean = Some(CleanConfig { delete_branch });
+    }
+
+    // submodules: present if either side has it; configs local > base.
+    if base.submodules.is_some() || local.submodules.is_some() {
+        let configs = local
+            .submodules
+            .as_ref()
+            .and_then(|s| s.configs.clone())
+            .or_else(|| base.submodules.as_ref().and_then(|s| s.configs.clone()));
+        merged.submodules = Some(SubmodulesConfig { configs });
     }
 
     merged
@@ -448,6 +467,47 @@ mod tests {
         );
     }
 
+    #[test]
+    fn submodules_local_configs_win() {
+        let base = VibeConfig {
+            submodules: Some(SubmodulesConfig {
+                configs: Some(vec!["libs/base".into()]),
+            }),
+            ..Default::default()
+        };
+        let local = VibeConfig {
+            submodules: Some(SubmodulesConfig {
+                configs: Some(vec!["libs/local".into()]),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            merge_configs(&base, &local).submodules.unwrap().configs,
+            Some(vec!["libs/local".into()])
+        );
+    }
+
+    #[test]
+    fn submodules_base_configs_survive_with_unrelated_local() {
+        let base = VibeConfig {
+            submodules: Some(SubmodulesConfig {
+                configs: Some(vec!["libs/base".into()]),
+            }),
+            ..Default::default()
+        };
+        let local = VibeConfig {
+            copy: Some(CopyConfig {
+                files: Some(vec!["x".into()]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            merge_configs(&base, &local).submodules.unwrap().configs,
+            Some(vec!["libs/base".into()])
+        );
+    }
+
     // --- parse_vibe_config ---
 
     #[test]
@@ -474,13 +534,30 @@ path_script = "p.sh"
 
 [clean]
 delete_branch = true
+
+[submodules]
+configs = ["libs/foo"]
 "#;
         let cfg = parse_vibe_config(toml, "/p/.vibe.toml").unwrap();
         assert_eq!(cfg.copy.as_ref().unwrap().concurrency, Some(8));
         assert_eq!(cfg.clean.as_ref().unwrap().delete_branch, Some(true));
         assert_eq!(
+            cfg.submodules.as_ref().unwrap().configs,
+            Some(vec!["libs/foo".into()])
+        );
+        assert_eq!(
             cfg.worktree.as_ref().unwrap().path_script.as_deref(),
             Some("p.sh")
+        );
+    }
+
+    #[test]
+    fn parses_submodules_configs() {
+        let cfg =
+            parse_vibe_config("[submodules]\nconfigs = [\"libs/foo\"]\n", "/p/.vibe.toml").unwrap();
+        assert_eq!(
+            cfg.submodules.unwrap().configs,
+            Some(vec!["libs/foo".into()])
         );
     }
 
@@ -494,6 +571,13 @@ delete_branch = true
     #[test]
     fn rejects_unknown_nested_property() {
         let toml = "[copy]\nbogus = 1\n";
+        let err = parse_vibe_config(toml, "/path/.vibe.toml").unwrap_err();
+        assert!(err.to_string().contains("/path/.vibe.toml"));
+    }
+
+    #[test]
+    fn rejects_unknown_submodules_field() {
+        let toml = "[submodules]\nbogus = 1\n";
         let err = parse_vibe_config(toml, "/path/.vibe.toml").unwrap_err();
         assert!(err.to_string().contains("/path/.vibe.toml"));
     }


### PR DESCRIPTION
## Summary

- Add explicit `[submodules] configs = [...]` support for trusted direct submodule setup.
- Validate configured paths against `.gitmodules`, reject nested traversal, and require each submodule `.vibe.toml` / `.vibe.local.toml` to be trusted independently.
- Initialize listed submodules in the new worktree, read each submodule config from that initialized worktree checkout, and run submodule hooks before the parent `pre_start`.
- Apply submodule `[copy]` rules from the original checkout submodule into the new worktree submodule so untracked setup files such as `.env` are carried over.
- Cover one-submodule and multi-submodule E2E flows, including submodule-local `.vibe.toml` files and copy rules.
- Update English and Japanese docs for the new behavior.

Closes #526

## Verification

- `cargo test --manifest-path rust/Cargo.toml -p vibe-core commands::start::tests::submodule`
- `pnpm -C packages/e2e test start.test.ts`
- `pnpm run check:all`
