### PR TITLE
docs: update legacy Deno references

### DIFF
--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -76,7 +76,7 @@ Vibe はゴミ箱サポート付きの高速ディレクトリ削除を提供し
 
 ```mermaid
 flowchart TD
-    A[fastRemoveDirectory] --> B{Native Trash Available?}
+    A[fast_remove_directory] --> B{Native Trash Available?}
     B -->|Yes| C[Native Trash Module]
     B -->|No| D{macOS?}
 

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -8,7 +8,7 @@
 
 ## ランタイム抽象化レイヤー
 
-Vibe はランタイム抽象化レイヤーを通じて、複数の JavaScript ランタイム（Deno と Node.js）をサポートしています。
+TypeScript 時代の実装では、Vibe はランタイム抽象化レイヤーを通じて、複数の JavaScript ランタイム（Deno と Node.js）をサポートしていました。現在の実装は単一の Rust バイナリであり、Deno はサポートしていません。
 
 ```mermaid
 flowchart TD
@@ -98,8 +98,8 @@ flowchart TD
 
 | 方法                    | プラットフォーム              | 説明                                                       |
 | ----------------------- | ----------------------------- | ---------------------------------------------------------- |
-| Native Trash            | Node.js（全プラットフォーム） | trash crate を使用した @kexi/vibe-native                   |
-| AppleScript             | Deno on macOS                 | osascript 経由の Finder フォールバック                     |
+| Native Trash            | Rust バイナリ                | trash crate を使用                                          |
+| AppleScript             | macOS の Rust バイナリ        | osascript 経由の Finder フォールバック                     |
 | /tmp + Background       | Linux（デスクトップなし）     | /tmp に移動後、バックグラウンドで削除                      |
 | Parent Dir + Background | クロスデバイス                | ネットワークマウント用の同一ファイルシステムフォールバック |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ This document describes the architecture of the Vibe CLI tool.
 
 ## Runtime Abstraction Layer
 
-Vibe supports multiple JavaScript runtimes (Deno and Node.js) through a runtime abstraction layer.
+In the TypeScript-era implementation, Vibe supported multiple JavaScript runtimes (Deno and Node.js) through a runtime abstraction layer. The current implementation is a single Rust binary and does not support Deno.
 
 ```mermaid
 flowchart TD
@@ -98,8 +98,8 @@ flowchart TD
 
 | Method                  | Platform                | Description                                 |
 | ----------------------- | ----------------------- | ------------------------------------------- |
-| Native Trash            | Node.js (all platforms) | Uses @kexi/vibe-native with trash crate     |
-| AppleScript             | Deno on macOS           | Fallback using Finder via osascript         |
+| Native Trash            | Rust binary             | Uses the trash crate                        |
+| AppleScript             | Rust binary on macOS    | Fallback using Finder via osascript         |
 | /tmp + Background       | Linux (no desktop)      | Moves to /tmp and deletes in background     |
 | Parent Dir + Background | Cross-device            | Same filesystem fallback for network mounts |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,7 +76,7 @@ Vibe provides fast directory removal with trash support.
 
 ```mermaid
 flowchart TD
-    A[fastRemoveDirectory] --> B{Native Trash Available?}
+    A[fast_remove_directory] --> B{Native Trash Available?}
     B -->|Yes| C[Native Trash Module]
     B -->|No| D{macOS?}
 

--- a/docs/specifications/clean-strategies.ja.md
+++ b/docs/specifications/clean-strategies.ja.md
@@ -25,7 +25,7 @@ Trash Strategy は、ディレクトリを即座に削除するのではなく�
 
 ### ネイティブゴミ箱サポート
 
-vibe は [trash crate](https://lib.rs/crates/trash) (`@kexi/vibe-native` 経由) を使用してクロスプラットフォームのゴミ箱機能を提供します：
+vibe は Rust バイナリから [trash crate](https://lib.rs/crates/trash) を使用してクロスプラットフォームのゴミ箱機能を提供します：
 
 - **macOS**: Finder Trash（従来と同じ）
 - **Linux**: XDG Trash (`~/.local/share/Trash`) [FreeDesktop.org 仕様](https://specifications.freedesktop.org/trash-spec/trashspec-latest.html)準拠
@@ -37,15 +37,15 @@ XDG Trash に移動されたファイルは、デスクトップ環境のゴミ�
 
 ### macOS
 
-1. **主要 (Node.js)**: ネイティブモジュール (`@kexi/vibe-native`) 経由で Finder Trash に移動
+1. **主要 (Rust)**: `trash` crate 経由で Finder Trash に移動
    - 内部的に Rust の `trash` crate を使用
    - Finder のゴミ箱フォルダに表示される
-2. **フォールバック (Deno)**: AppleScript (`osascript`) 経由で Finder Trash に移動
+2. **フォールバック (Rust/macOS)**: AppleScript (`osascript`) 経由で Finder Trash に移動
 3. **フォールバック**: 両方とも失敗した場合（例：SSH セッション）、/tmp + バックグラウンド削除にフォールバック
 
 ### Linux
 
-1. **主要 (Node.js)**: ネイティブモジュール (`@kexi/vibe-native`) 経由で XDG Trash に移動
+1. **主要 (Rust)**: `trash` crate 経由で XDG Trash に移動
    - [XDG Trash 仕様](https://specifications.freedesktop.org/trash-spec/trashspec-latest.html)を実装した Rust の `trash` crate を使用
    - ファイルは `~/.local/share/Trash/files/` に移動
    - メタデータは `~/.local/share/Trash/info/` に保存
@@ -148,7 +148,7 @@ packages/
     │       ├── isFastRemoveSupported()
     │       ├── generateTrashName()
     │       ├── moveToSystemTrash()
-    │       ├── moveToMacOSTrashViaAppleScript()
+    │       ├── move_to_macos_trash_via_osascript()
     │       ├── spawnBackgroundDelete()
     │       ├── fastRemoveDirectory()
     │       └── cleanupStaleTrash()
@@ -163,7 +163,7 @@ packages/
 | `isFastRemoveSupported()`          | プラットフォームサポートの確認                        |
 | `generateTrashName()`              | 一意のゴミ箱ディレクトリ名を生成                      |
 | `moveToSystemTrash()`              | ネイティブゴミ箱 + プラットフォーム固有フォールバック |
-| `moveToMacOSTrashViaAppleScript()` | Deno macOS フォールバック                             |
+| `move_to_macos_trash_via_osascript()` | Rust macOS フォールバック                             |
 | `spawnBackgroundDelete()`          | デタッチされたバックグラウンド削除                    |
 | `fastRemoveDirectory()`            | メインの高速削除関数                                  |
 | `cleanupStaleTrash()`              | 残存ゴミ箱ディレクトリのクリーンアップ                |

--- a/docs/specifications/clean-strategies.ja.md
+++ b/docs/specifications/clean-strategies.ja.md
@@ -82,20 +82,20 @@ Trash Strategy は、対象ディレクトリを一時的な場所に rename し
 
 **クリーンアップ機構:**
 
-`cleanupStaleTrash()` 関数は、残存する `.vibe-trash-*` ディレクトリをスキャンして削除します：
+`cleanup_stale_trash()` 関数は、残存する `.vibe-trash-*` ディレクトリをスキャンして削除します：
 
 - 削除された worktree の親ディレクトリ
 - システムの temp ディレクトリ
 
 このクリーンアップは各 clean 操作後に自動的に実行されます。
 
-**実装ファイル:** `packages/core/src/utils/fast-remove.ts`
+**実装ファイル:** `rust/crates/vibe-core/src/fast_remove.rs`
 
 ### Standard Strategy
 
 標準の `git worktree remove` コマンドを使用します。Trash Strategy が失敗した場合や無効化されている場合のフォールバックとして使用されます。
 
-**実装ファイル:** `packages/core/src/commands/clean.ts`
+**実装ファイル:** `rust/crates/vibe-core/src/commands/clean.rs`
 
 ## 設定
 
@@ -133,58 +133,60 @@ post_clean = ["echo 'Cleanup complete'"]
 ## ファイル構造
 
 ```
-packages/
-├── native/
-│   ├── Cargo.toml        # Rust 依存関係（trash crate を含む）
-│   ├── src/lib.rs        # ネイティブモジュール（moveToTrash, moveToTrashAsync）
-│   └── index.d.ts        # TypeScript 型定義
-└── core/src/
-    ├── native/
-    │   └── index.ts      # NativeTrashAdapter インターフェース
-    ├── runtime/node/
-    │   └── native.ts     # NodeNativeTrash 実装
-    ├── utils/
-    │   └── fast-remove.ts    # Trash Strategy 実装
-    │       ├── isFastRemoveSupported()
-    │       ├── generateTrashName()
-    │       ├── moveToSystemTrash()
-    │       ├── move_to_macos_trash_via_osascript()
-    │       ├── spawnBackgroundDelete()
-    │       ├── fastRemoveDirectory()
-    │       └── cleanupStaleTrash()
+rust/crates/
+├── vibe-native/
+│   └── src/lib.rs        # trash crate 経由のクロスプラットフォームゴミ箱連携
+└── vibe-core/src/
+    ├── fast_remove.rs    # Trash Strategy 実装
+    │   ├── is_fast_remove_supported()
+    │   ├── trash_name()
+    │   ├── move_to_system_trash()
+    │   ├── move_to_macos_trash_via_osascript()
+    │   ├── spawn_background_delete()
+    │   ├── fast_remove_directory()
+    │   └── cleanup_stale_trash()
     └── commands/
-        └── clean.ts          # Clean command 実装
+        └── clean.rs      # Clean command 実装
 ```
 
 **関数の説明:**
 
-| 関数                               | 説明                                                  |
-| ---------------------------------- | ----------------------------------------------------- |
-| `isFastRemoveSupported()`          | プラットフォームサポートの確認                        |
-| `generateTrashName()`              | 一意のゴミ箱ディレクトリ名を生成                      |
-| `moveToSystemTrash()`              | ネイティブゴミ箱 + プラットフォーム固有フォールバック |
-| `move_to_macos_trash_via_osascript()` | Rust macOS フォールバック                             |
-| `spawnBackgroundDelete()`          | デタッチされたバックグラウンド削除                    |
-| `fastRemoveDirectory()`            | メインの高速削除関数                                  |
-| `cleanupStaleTrash()`              | 残存ゴミ箱ディレクトリのクリーンアップ                |
+| 関数                                    | 説明                                                  |
+| --------------------------------------- | ----------------------------------------------------- |
+| `is_fast_remove_supported()`            | 高速削除サポートの確認                                |
+| `trash_name()`                          | 一意のゴミ箱ディレクトリ名を生成                      |
+| `move_to_system_trash()`                | ネイティブゴミ箱 + プラットフォーム固有フォールバック |
+| `move_to_macos_trash_via_osascript()`   | Rust macOS Finder Trash フォールバック                |
+| `spawn_background_delete()`             | デタッチされたバックグラウンド削除                    |
+| `fast_remove_directory()`               | メインの高速削除関数                                  |
+| `cleanup_stale_trash()`                 | 残存ゴミ箱ディレクトリのクリーンアップ                |
 
 ## Strategy 選択機構
 
 clean コマンドはユーザー設定に基づいて適切な strategy を自動選択します：
 
-```typescript
-// packages/core/src/commands/clean.ts より
-const settings = await loadUserSettings(ctx);
-const useFastRemove = settings.clean?.fast_remove ?? true; // デフォルト: true
+```rust
+// rust/crates/vibe-core/src/commands/clean.rs より
+let should_fast = use_fast_remove && is_fast_remove_supported();
 
-if (useFastRemove && isFastRemoveSupported()) {
-  // Trash Strategy を試行
-  const result = await fastRemoveDirectory(worktreePath, ctx);
-  if (result.success) {
-    // 成功 - git worktree クリーンアップを実行
-    return;
-  }
-  // Standard Strategy にフォールスルー
+if should_fast {
+    let result = fast_remove_directory(
+        deps.io,
+        &deps.native,
+        &deps.spawner,
+        &deps.clock,
+        &deps.random,
+        worktree_path,
+        opts,
+    );
+
+    if result.success {
+        // 空の worktree marker を再作成し、Git に登録解除させる。
+        cleanup_stale_trash(deps.io, &deps.spawner, &parent);
+        return Ok(());
+    }
+
+    // Standard Strategy にフォールスルー
 }
 
 // Standard Strategy: git worktree remove

--- a/docs/specifications/clean-strategies.md
+++ b/docs/specifications/clean-strategies.md
@@ -82,20 +82,20 @@ Example: `.vibe-trash-1705123456789-a1b2c3d4`
 
 **Cleanup mechanism:**
 
-The `cleanupStaleTrash()` function scans for and removes any leftover `.vibe-trash-*` directories from:
+The `cleanup_stale_trash()` function scans for and removes any leftover `.vibe-trash-*` directories from:
 
 - The parent directory of the removed worktree
 - The system temp directory
 
 This cleanup runs automatically after each clean operation.
 
-**Implementation file:** `packages/core/src/utils/fast-remove.ts`
+**Implementation file:** `rust/crates/vibe-core/src/fast_remove.rs`
 
 ### Standard Strategy
 
 Uses the standard `git worktree remove` command. This is used as a fallback when the Trash Strategy fails or is disabled.
 
-**Implementation file:** `packages/core/src/commands/clean.ts`
+**Implementation file:** `rust/crates/vibe-core/src/commands/clean.rs`
 
 ## Configuration
 
@@ -133,46 +133,60 @@ post_clean = ["echo 'Cleanup complete'"]
 ## File Structure
 
 ```
-packages/
-├── native/
-│   ├── Cargo.toml        # Rust dependencies (includes trash crate)
-│   ├── src/lib.rs        # Native module (moveToTrash, moveToTrashAsync)
-│   └── index.d.ts        # TypeScript type definitions
-└── core/src/
-    ├── native/
-    │   └── index.ts      # NativeTrashAdapter interface
-    ├── runtime/node/
-    │   └── native.ts     # NodeNativeTrash implementation
-    ├── utils/
-    │   └── fast-remove.ts    # Trash Strategy implementation
-    │       ├── isFastRemoveSupported()
-    │       ├── generateTrashName()
-    │       ├── moveToSystemTrash()        # Native trash + platform fallback
-    │       ├── move_to_macos_trash_via_osascript()  # Rust macOS fallback
-    │       ├── spawnBackgroundDelete()
-    │       ├── fastRemoveDirectory()
-    │       └── cleanupStaleTrash()
+rust/crates/
+├── vibe-native/
+│   └── src/lib.rs        # Cross-platform trash binding via the trash crate
+└── vibe-core/src/
+    ├── fast_remove.rs    # Trash Strategy implementation
+    │   ├── is_fast_remove_supported()
+    │   ├── trash_name()
+    │   ├── move_to_system_trash()        # Native trash + platform fallback
+    │   ├── move_to_macos_trash_via_osascript()
+    │   ├── spawn_background_delete()
+    │   ├── fast_remove_directory()
+    │   └── cleanup_stale_trash()
     └── commands/
-        └── clean.ts          # Clean command implementation
+        └── clean.rs      # Clean command implementation
 ```
+
+**Function Reference:**
+
+| Function                              | Description                               |
+| ------------------------------------- | ----------------------------------------- |
+| `is_fast_remove_supported()`          | Checks fast-remove support                |
+| `trash_name()`                        | Generates a unique trash directory name   |
+| `move_to_system_trash()`              | Native trash + platform-specific fallback |
+| `move_to_macos_trash_via_osascript()` | Rust macOS Finder Trash fallback          |
+| `spawn_background_delete()`           | Detached background deletion              |
+| `fast_remove_directory()`             | Main fast-remove function                 |
+| `cleanup_stale_trash()`               | Cleanup for leftover trash directories    |
 
 ## Strategy Selection Mechanism
 
 The clean command automatically selects the appropriate strategy based on user settings:
 
-```typescript
-// From packages/core/src/commands/clean.ts
-const settings = await loadUserSettings(ctx);
-const useFastRemove = settings.clean?.fast_remove ?? true; // Default: true
+```rust
+// From rust/crates/vibe-core/src/commands/clean.rs
+let should_fast = use_fast_remove && is_fast_remove_supported();
 
-if (useFastRemove && isFastRemoveSupported()) {
-  // Try Trash Strategy
-  const result = await fastRemoveDirectory(worktreePath, ctx);
-  if (result.success) {
-    // Success - perform git worktree cleanup
-    return;
-  }
-  // Fall through to Standard Strategy
+if should_fast {
+    let result = fast_remove_directory(
+        deps.io,
+        &deps.native,
+        &deps.spawner,
+        &deps.clock,
+        &deps.random,
+        worktree_path,
+        opts,
+    );
+
+    if result.success {
+        // Recreate the empty worktree marker and let Git unregister it.
+        cleanup_stale_trash(deps.io, &deps.spawner, &parent);
+        return Ok(());
+    }
+
+    // Fall through to Standard Strategy.
 }
 
 // Standard Strategy: git worktree remove

--- a/docs/specifications/clean-strategies.md
+++ b/docs/specifications/clean-strategies.md
@@ -25,7 +25,7 @@ Trash Strategy moves directories to a temporary location instead of deleting the
 
 ### Native Trash Support
 
-vibe uses the [trash crate](https://lib.rs/crates/trash) (via `@kexi/vibe-native`) for cross-platform trash support:
+vibe uses the [trash crate](https://lib.rs/crates/trash) through the Rust binary for cross-platform trash support:
 
 - **macOS**: Finder Trash (same as before)
 - **Linux**: XDG Trash (`~/.local/share/Trash`) following [FreeDesktop.org specification](https://specifications.freedesktop.org/trash-spec/trashspec-latest.html)
@@ -37,15 +37,15 @@ Files moved to XDG Trash appear in your desktop environment's trash folder (GNOM
 
 ### macOS
 
-1. **Primary (Node.js)**: Move to Finder Trash via native module (`@kexi/vibe-native`)
+1. **Primary (Rust)**: Move to Finder Trash via the `trash` crate
    - Uses the Rust `trash` crate internally
    - Appears in Finder's Trash folder
-2. **Fallback (Deno)**: Move to Finder Trash via AppleScript (`osascript`)
+2. **Fallback (Rust/macOS)**: Move to Finder Trash via AppleScript (`osascript`)
 3. **Fallback**: If both fail (e.g., SSH session), falls back to /tmp + background deletion
 
 ### Linux
 
-1. **Primary (Node.js)**: Move to XDG Trash via native module (`@kexi/vibe-native`)
+1. **Primary (Rust)**: Move to XDG Trash via the `trash` crate
    - Uses the Rust `trash` crate implementing [XDG Trash specification](https://specifications.freedesktop.org/trash-spec/trashspec-latest.html)
    - Files moved to `~/.local/share/Trash/files/`
    - Metadata stored in `~/.local/share/Trash/info/`
@@ -148,7 +148,7 @@ packages/
     │       ├── isFastRemoveSupported()
     │       ├── generateTrashName()
     │       ├── moveToSystemTrash()        # Native trash + platform fallback
-    │       ├── moveToMacOSTrashViaAppleScript()  # Deno macOS fallback
+    │       ├── move_to_macos_trash_via_osascript()  # Rust macOS fallback
     │       ├── spawnBackgroundDelete()
     │       ├── fastRemoveDirectory()
     │       └── cleanupStaleTrash()

--- a/docs/specifications/multi-runtime.ja.md
+++ b/docs/specifications/multi-runtime.ja.md
@@ -4,7 +4,7 @@
 
 > **歴史的な注記:** ここで説明している TypeScript 実装は、Rust 移植の Phase 6 で削除されました。vibe は現在単一の Rust バイナリであり、worktree のロジックは `rust/crates/vibe-core` にあります。このドキュメントは設計の歴史として残しています。
 
-vibe は、Deno、Node.js、Bun を含む複数の JavaScript/TypeScript ランタイムで CLI を実行できるランタイム抽象化レイヤーを提供します。
+TypeScript 時代の実装では、vibe は Deno、Node.js、Bun を含む複数の JavaScript/TypeScript ランタイムで CLI を実行できるランタイム抽象化レイヤーを提供していました。現在の実装は単一の Rust バイナリであり、Deno はサポートしていません。
 
 ## ランタイム抽象化レイヤーとは？
 

--- a/docs/specifications/multi-runtime.md
+++ b/docs/specifications/multi-runtime.md
@@ -4,7 +4,7 @@
 
 > **Historical note:** The TypeScript implementation described here was removed in Phase 6 of the Rust port. vibe is now a single Rust binary and the worktree logic lives in `rust/crates/vibe-core`. This document is retained as design history.
 
-vibe provides a runtime abstraction layer that enables the CLI to run on multiple JavaScript/TypeScript runtimes including Deno, Node.js, and Bun.
+In the TypeScript-era implementation, vibe provided a runtime abstraction layer that enabled the CLI to run on multiple JavaScript/TypeScript runtimes including Deno, Node.js, and Bun. The current implementation is a single Rust binary and does not support Deno.
 
 ## What is the Runtime Abstraction Layer?
 

--- a/docs/specifications/native-clone.ja.md
+++ b/docs/specifications/native-clone.ja.md
@@ -4,11 +4,11 @@
 
 > **歴史的な注記:** ここで説明している TypeScript ランタイムの分岐は、Rust 移植の Phase 6 で削除されました。vibe は現在単一の Rust バイナリであり、ネイティブの CoW 実装は `rust/crates/vibe-native`（`rust/crates/vibe-core` に静的リンク）にあります。このドキュメントは設計の歴史として残しています。
 
-このドキュメントでは、vibeがネイティブのCopy-on-Write（CoW）操作にRustを使用する理由と、DenoとNode.jsランタイム間での実装の違いについて説明します。
+この履歴ドキュメントでは、TypeScript 時代の実装がネイティブの Copy-on-Write（CoW）操作に Rust を使用していた理由と、Deno と Node.js ランタイム間での実装の違いについて説明します。
 
 ## なぜRustなのか？
 
-vibeは`@kexi/vibe-native`パッケージで[napi-rs](https://napi.rs/)を介したRustを使用しています。これは、JavaScriptランタイムの標準APIでは利用できないOSレベルのCoW APIを呼び出すためです。
+TypeScript 時代の実装では、JavaScript ランタイムの標準 API では利用できない OS レベルの CoW API を呼び出すため、`@kexi/vibe-native` パッケージで [napi-rs](https://napi.rs/) を介した Rust を使用していました。
 
 ### 代替案との比較
 
@@ -26,7 +26,7 @@ Rustを選択した理由：
 
 ## アーキテクチャ概要
 
-Deno 2.x以降、両ランタイムはネイティブCoW操作に同じ`@kexi/vibe-native` N-APIモジュールを使用しています。この統一により、メンテナンスが簡素化され、ランタイム間で一貫した動作が保証されます。
+TypeScript 時代の実装では、Deno 2.x と Node.js がネイティブ CoW 操作に同じ `@kexi/vibe-native` N-API モジュールを使用していました。現在の実装では Deno はサポートしておらず、Rust crate を直接使用しています。
 
 ```mermaid
 flowchart TD
@@ -89,7 +89,7 @@ pub fn clone_sync(src: String, dest: String) -> Result<()> {
 - 一般的なプラットフォーム向けのプリビルドバイナリ（macOS x64/arm64、Linux x64/arm64）
 - DenoとNode.js間で一貫した動作
 
-**要件:**
+**当時の要件:**
 
 - Deno 2.x または Node.js 18+
 - プリビルドバイナリ、またはコンパイル用のRustツールチェーン

--- a/docs/specifications/native-clone.md
+++ b/docs/specifications/native-clone.md
@@ -4,11 +4,11 @@
 
 > **Historical note:** The TypeScript runtime split described here was removed in Phase 6 of the Rust port. vibe is now a single Rust binary and the native CoW implementation lives in `rust/crates/vibe-native` (statically linked into `rust/crates/vibe-core`). This document is retained as design history.
 
-This document explains why vibe uses Rust for native Copy-on-Write (CoW) operations and how the implementation differs between Deno and Node.js runtimes.
+This historical document explains why the TypeScript-era implementation used Rust for native Copy-on-Write (CoW) operations and how that implementation differed between Deno and Node.js runtimes.
 
 ## Why Rust?
 
-vibe uses Rust (via [napi-rs](https://napi.rs/)) for the `@kexi/vibe-native` package to call OS-level CoW APIs that are not available through JavaScript runtimes' standard APIs.
+The TypeScript-era implementation used Rust (via [napi-rs](https://napi.rs/)) for the `@kexi/vibe-native` package to call OS-level CoW APIs that were not available through JavaScript runtimes' standard APIs.
 
 ### Comparison with Alternatives
 
@@ -26,7 +26,7 @@ Rust was chosen because:
 
 ## Architecture Overview
 
-As of Deno 2.x, both runtimes use the same `@kexi/vibe-native` N-API module for native CoW operations. This unification simplifies maintenance and ensures consistent behavior across runtimes.
+In the TypeScript-era implementation, Deno 2.x and Node.js used the same `@kexi/vibe-native` N-API module for native CoW operations. The current implementation no longer supports Deno and uses the Rust crates directly.
 
 ```mermaid
 flowchart TD
@@ -89,7 +89,7 @@ pub fn clone_sync(src: String, dest: String) -> Result<()> {
 - Prebuilt binaries for common platforms (macOS x64/arm64, Linux x64/arm64)
 - Consistent behavior across Deno and Node.js
 
-**Requirements:**
+**Historical requirements:**
 
 - Deno 2.x or Node.js 18+
 - Prebuilt binaries or Rust toolchain for compilation


### PR DESCRIPTION
## Summary
- update clean strategy docs to describe the Rust binary and trash crate paths
- clarify that Deno support exists only in historical TypeScript-era docs
- align macOS osascript fallback wording with the current Rust implementation

## Tests
- pnpm run fmt:check