### PR TITLE
fix: show progress tree during worktree creation

### DIFF
--- a/rust/crates/vibe-core/src/commands/start.rs
+++ b/rust/crates/vibe-core/src/commands/start.rs
@@ -227,7 +227,7 @@ where
             &format!("Running: {}", get_create_worktree_command(&create_opts)),
             opts,
         );
-        create_worktree(deps.git, &create_opts)?;
+        run_create_worktree_with_progress(deps, branch_name, &create_opts)?;
     }
 
     run_config_and_hooks(
@@ -251,6 +251,40 @@ where
     }
 
     Ok(Outcome::cd(worktree_path))
+}
+
+fn run_create_worktree_with_progress<I, G, R, S, P, Sr>(
+    deps: &StartDeps<I, G, R, S, P, Sr>,
+    branch_name: &str,
+    create_opts: &CreateWorktreeOptions<'_>,
+) -> Result<()>
+where
+    I: Io,
+    G: GitRunner,
+    R: RepoResolver,
+    S: ScriptRunner,
+    P: Prompt,
+    Sr: StdinReader,
+{
+    deps.tracker.start();
+    let phase = deps
+        .tracker
+        .add_phase(&format!("Setting up worktree {branch_name}"));
+    let task = deps.tracker.add_task(phase, "Create worktree");
+    deps.tracker.start_task(task);
+
+    match create_worktree(deps.git, create_opts) {
+        Ok(()) => {}
+        Err(err) => {
+            deps.tracker.fail_task(task, &err.to_string());
+            deps.tracker.finish();
+            return Err(err);
+        }
+    }
+
+    deps.tracker.complete_task(task);
+    deps.tracker.finish();
+    Ok(())
 }
 
 /// Outcome of resolving the `--base` flag, self-describing so the caller cannot

--- a/rust/crates/vibe-core/src/commands/start_tests.rs
+++ b/rust/crates/vibe-core/src/commands/start_tests.rs
@@ -7,7 +7,7 @@ use crate::error::VibeError;
 use crate::git::RepoInfo;
 use crate::hooks::FakeHookRunner;
 use crate::io::FakeIo;
-use crate::progress::RecordingTracker;
+use crate::progress::{RecordingTracker, TrackerEvent};
 use crate::stdin::FakeStdin;
 use crate::worktree_path::ScriptOutput;
 use std::cell::RefCell;
@@ -243,6 +243,35 @@ fn existing_branch_worktree_navigates_on_confirm() {
     assert_eq!(outcome, Outcome::cd("/wt/feat"));
     // No worktree created.
     assert!(!git.calls_contain(&["worktree", "add"]));
+}
+
+#[test]
+fn new_worktree_creation_is_tracked_even_without_config_operations() {
+    let (_fx, io) = io_with_home();
+    let git = MockGit::new("/repo", "worktree /repo\nbranch refs/heads/main\n\n");
+    let (r, s, p, sin, fk) = (
+        NoResolver,
+        NoScript,
+        ScriptPrompt::confirming(true),
+        FakeStdin::none(),
+        Fakes::new(),
+    );
+    let d = deps(&io, &git, &r, &s, &p, &sin, &fk);
+    let outcome =
+        start_command(&d, "feat", &StartFlags::default(), OutputOptions::default()).unwrap();
+
+    assert!(outcome.cd_path.is_some());
+    assert!(git.calls_contain(&["worktree", "add"]));
+
+    let events = fk.tracker.events();
+    let create_task = events.iter().any(|event| match event {
+        TrackerEvent::Task(label) => label == "Create worktree",
+        _ => false,
+    });
+    assert!(create_task, "create task should be tracked: {events:?}");
+    assert!(events.contains(&TrackerEvent::Started));
+    assert!(events.contains(&TrackerEvent::Finished));
+    assert!(events.contains(&TrackerEvent::Phase("Setting up worktree feat".into())));
 }
 
 #[test]

--- a/rust/crates/vibe-core/src/progress.rs
+++ b/rust/crates/vibe-core/src/progress.rs
@@ -79,7 +79,14 @@ impl ProgressTracker for NullTracker {
 /// Live progress tracker backed by `indicatif`, drawing to STDERR only.
 pub struct IndicatifTracker {
     multi: indicatif::MultiProgress,
-    bars: std::sync::Mutex<Vec<indicatif::ProgressBar>>,
+    bars: std::sync::Mutex<Vec<BarNode>>,
+}
+
+struct BarNode {
+    bar: indicatif::ProgressBar,
+    prefix: String,
+    label: String,
+    done: bool,
 }
 
 impl Default for IndicatifTracker {
@@ -99,48 +106,73 @@ impl IndicatifTracker {
         }
     }
 
-    fn push_bar(&self, label: &str) -> NodeId {
+    fn push_bar(&self, label: &str, prefix: &str) -> NodeId {
         let bar = self.multi.add(indicatif::ProgressBar::new_spinner());
+        let style = indicatif::ProgressStyle::with_template("{prefix}{spinner} {msg}")
+            .expect("static progress template must be valid")
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]);
+        bar.set_style(style);
+        bar.set_prefix(prefix.to_string());
         bar.set_message(label.to_string());
         let mut bars = self.bars.lock().expect("progress mutex poisoned");
         let id = NodeId(bars.len());
-        bars.push(bar);
+        bars.push(BarNode {
+            bar,
+            prefix: prefix.to_string(),
+            label: label.to_string(),
+            done: false,
+        });
         id
     }
 
-    fn with_bar(&self, id: NodeId, f: impl FnOnce(&indicatif::ProgressBar)) {
-        let bars = self.bars.lock().expect("progress mutex poisoned");
-        if let Some(bar) = bars.get(id.0) {
-            f(bar);
+    fn with_bar(&self, id: NodeId, f: impl FnOnce(&mut BarNode)) {
+        let mut bars = self.bars.lock().expect("progress mutex poisoned");
+        if let Some(node) = bars.get_mut(id.0) {
+            f(node);
         }
     }
 }
 
 impl ProgressTracker for IndicatifTracker {
     fn add_phase(&self, label: &str) -> NodeId {
-        self.push_bar(label)
+        self.push_bar(label, "┗ ")
     }
     fn add_task(&self, _phase: NodeId, label: &str) -> NodeId {
-        self.push_bar(label)
+        self.push_bar(label, "   ┗ ")
     }
     fn start_task(&self, id: NodeId) {
-        self.with_bar(id, |b| {
-            b.enable_steady_tick(std::time::Duration::from_millis(80))
+        self.with_bar(id, |node| {
+            node.bar
+                .enable_steady_tick(std::time::Duration::from_millis(80))
         });
     }
     fn complete_task(&self, id: NodeId) {
-        self.with_bar(id, |b| b.finish());
+        self.with_bar(id, |node| {
+            node.done = true;
+            node.bar.set_prefix("");
+            node.bar
+                .finish_with_message(format!("{}☒ {}", node.prefix, node.label));
+        });
     }
     fn fail_task(&self, id: NodeId, err: &str) {
         let msg = format!("failed: {err}");
-        self.with_bar(id, |b| b.abandon_with_message(msg));
+        self.with_bar(id, |node| {
+            node.done = true;
+            node.bar.set_prefix("");
+            node.bar
+                .abandon_with_message(format!("{}☒ {} ({msg})", node.prefix, node.label));
+        });
     }
     fn start(&self) {}
     fn finish(&self) {
-        let bars = self.bars.lock().expect("progress mutex poisoned");
-        for bar in bars.iter() {
-            if !bar.is_finished() {
-                bar.finish_and_clear();
+        let mut bars = self.bars.lock().expect("progress mutex poisoned");
+        for node in bars.iter_mut() {
+            let is_unfinished = !node.done;
+            if is_unfinished {
+                node.done = true;
+                node.bar.set_prefix("");
+                node.bar
+                    .finish_with_message(format!("{}☒ {}", node.prefix, node.label));
             }
         }
     }


### PR DESCRIPTION
## Summary
- track worktree creation as a visible progress phase for 
- render progress tree prefixes and completed labels in the live Indicatif tracker
- add coverage for start progress without config-driven hooks or copy operations

## Testing
- pnpm run check:rust