### PR TITLE
fix: stop leaking staged npm package files into GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,15 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
-          files: artifacts/*
+          # Why not `artifacts/*`: download-artifact with `merge-multiple: true`
+          # flattens the five `platform-package-*` artifacts into the same dir,
+          # leaking their `package.json` / `THIRD-PARTY-LICENSES.md` into the
+          # GitHub Release. publish-npm.yml regenerates those locally per-matrix
+          # and only pulls the named binary via `gh release download --pattern`,
+          # so restricting uploads to the binaries and .debs is safe.
+          files: |
+            artifacts/vibe-*-*
+            artifacts/vibe_*.deb
           generate_release_notes: true
 
   update-homebrew:


### PR DESCRIPTION
## Summary

GitHub Releases (v2.0.0, v2.1.0, …) carry two stray assets — `package.json` and `THIRD-PARTY-LICENSES.md` — alongside the actual binaries and `.deb` packages.

### Root cause

The `release` job downloads every prior-job artifact with `merge-multiple: true`. The five `platform-package-*` artifacts produced by `stage-platform-packages` each contain a `package.json` + `bin/vibe-*` + `THIRD-PARTY-LICENSES.md`; `merge-multiple` flattens them into a single `artifacts/` directory, so `artifacts/package.json` and `artifacts/THIRD-PARTY-LICENSES.md` get last-write-wins-overwritten by the five matrix variants and then uploaded by `softprops/action-gh-release` via `files: artifacts/*`.

### Why this is safe to drop

`publish-npm.yml` does **not** consume those Release assets:

- It regenerates `package.json` and `THIRD-PARTY-LICENSES.md` per-matrix-entry from the checked-out source via `scripts/stage-platform-package.ts` + `scripts/generate-third-party-licenses.ts`.
- It only pulls the named binary from the Release via `gh release download --pattern \"\$ARTIFACT\"`.

Homebrew, the `.deb` packages, and direct binary downloads also don't reference those assets.

### Change

Replace `files: artifacts/*` with an explicit list:

```yaml
files: |
  artifacts/vibe-*-*
  artifacts/vibe_*.deb
```

(`.deb` files are named `vibe_<version>_<arch>.deb` — underscore separators — so the second glob is intentionally different from the first.)

## Test plan

- [ ] CI green
- [ ] On the next release, `gh release view <tag> --json assets --jq '.assets[].name'` should list only the five binaries + the two `.deb` files (no `package.json`, no `THIRD-PARTY-LICENSES.md`)