### PR TITLE
ci: switch npm publish auth to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -271,13 +271,12 @@ jobs:
       - name: Publish @kexi/${{ matrix.package }}
         if: steps.guard.outputs.skip != 'true'
         working-directory: packages/vibe-${{ matrix.platform }}-${{ matrix.arch }}
-        # NODE_AUTH_TOKEN authenticates the publish. OIDC trusted publishing
-        # cannot CREATE a brand-new package (it 404s on the initial PUT), so the
-        # per-platform packages need a token for their first publish; once they
-        # exist with a configured trusted publisher, OIDC takes over and this
-        # token is unused. Provenance still attaches via id-token: write.
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # Auth is OIDC trusted publishing (configured on npmjs.com per package
+        # for this repo + publish-npm.yml), granted via id-token: write. No
+        # NODE_AUTH_TOKEN on purpose: an env token takes precedence over OIDC,
+        # so a stale secret would break the publish. Caveat: OIDC cannot CREATE
+        # a brand-new package (it 404s on the initial PUT) — any future new
+        # package needs a one-off token for its first publish only.
         run: npm publish --provenance --access public
 
   # Publish @kexi/vibe (the launcher shim). It needs ALL five platform packages
@@ -337,8 +336,6 @@ jobs:
       - name: Publish @kexi/vibe
         if: steps.guard.outputs.skip != 'true'
         working-directory: packages/npm
-        # See the platform publish step: NODE_AUTH_TOKEN covers the first publish
-        # of a not-yet-existing package, which OIDC alone cannot create.
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # See the platform publish step: auth is OIDC trusted publishing;
+        # deliberately no NODE_AUTH_TOKEN.
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from both publish steps in `publish-npm.yml`; auth now relies solely on npm OIDC trusted publishing via the existing `id-token: write` permission.
- The `NPM_TOKEN` secret expired and has been deleted from the repo. Leaving the env reference in place would break publishes outright, because an env token (even an empty/stale one) takes precedence over the OIDC exchange.
- The token's only remaining purpose was first-publish of brand-new packages (OIDC 404s on the initial PUT). All six packages (`@kexi/vibe` + 5 platform packages) exist on the registry with trusted publishers configured, so that reason no longer applies. The comment now documents the caveat for any future new package.

## Prerequisites (done outside this PR)

- Trusted publisher configured on npmjs.com for each of the six packages (repo `kexi/vibe`, workflow `publish-npm.yml`, no environment)
- `NPM_TOKEN` secret deleted

## Notes

- Node 24's bundled npm 11.x satisfies the trusted-publishing requirement (npm ≥ 11.5.1)
- `--provenance` is kept explicit; it continues to attach via `id-token: write`
- Should land on `develop` before the v2.1.1 `develop` → `main` release PR so the v2.1.1 publish uses OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)