### PR TITLE
ci: pin cargo-audit install and use --locked

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -134,7 +134,10 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        # Pinned + --locked: an unpinned install resolves fresh dependency
+        # versions at publish time, which broke when kstring 2.0.4 started
+        # requiring a newer rustc than rust-toolchain.toml pins.
+        run: cargo install cargo-audit@0.22.2 --locked
 
       - name: Audit shipped Rust binary (rust/)
         run: cargo audit --file rust/Cargo.lock


### PR DESCRIPTION
## Summary

- `security-audit` in `publish-npm.yml` failed on the v2.1.1 publish: unpinned `cargo install cargo-audit` resolved `kstring@2.0.4`, which requires rustc 1.96.0, while `rust-toolchain.toml` pins 1.92.0
- Pin to `cargo-audit@0.22.2` and add `--locked` so the install builds from cargo-audit's published lockfile, immune to fresh transitive resolutions at publish time

## Test plan

- [x] `cargo install cargo-audit@0.22.2 --locked` builds locally with the pinned Rust 1.92.0 toolchain (1m08s)
- [x] `pnpm run check:all` passes
- [ ] Re-run the v2.1.1 Release workflow after merge; publish-npm (workflow_run picks up the default-branch workflow) passes security-audit and publishes via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)