### PR TITLE
ci: make update-homebrew idempotent on release re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,5 +386,14 @@ jobs:
             git add "Formula/${VERSIONED_FORMULA}"
           fi
 
+          # Skip the commit when the formula is already up to date: on a re-run
+          # of a succeeded release the regenerated formula is byte-identical
+          # (builds are reproducible), and a bare `git commit` would exit 1 and
+          # fail the whole run, closing publish-npm's workflow_run success gate.
+          if git diff --cached --quiet; then
+            echo "Formula already up to date for $VERSION; nothing to commit."
+            exit 0
+          fi
+
           git commit -m "Update ${FORMULA_NAME} to $VERSION"
           git push --quiet https://x-access-token:${GH_TOKEN}@github.com/kexi/homebrew-tap.git HEAD:main


### PR DESCRIPTION
## Summary

- `update-homebrew` fails with exit 1 on any Release re-run whose formula is already up to date ("nothing to commit"), turning the whole run red and closing `publish-npm.yml`'s `workflow_run.conclusion == 'success'` gate
- This is exactly what happened on v2.1.1: the security-audit fix required re-triggering publish via a Release re-run, which then failed on this job; recovery required reverting the tap's formula commit just to give the re-run something to commit
- Fix: skip the commit/push when the staged formula has no diff (`git diff --cached --quiet`), logging instead

## Notes

- release.yml runs from the tag's snapshot, so this only protects future releases (v2.1.2+)
- Verified indirectly on v2.1.1: the re-run regenerated a byte-identical formula (builds are reproducible), confirming the no-diff case is the normal re-run path

🤖 Generated with [Claude Code](https://claude.com/claude-code)