### PR TITLE
ci: restructure release flow for immutable releases

### DIFF
--- a/.claude/skills/vibe-release-new-version/SKILL.md
+++ b/.claude/skills/vibe-release-new-version/SKILL.md
@@ -525,12 +525,18 @@ gh workflow run release.yml --ref main -F notes=@/tmp/release-notes.md
 **Note:** Replace the notes content above with the release notes generated in Step 7.2.
 
 Watch the run until it finishes, then confirm the release is published. Wait
-for the fresh (not yet completed) run so a stale earlier run is never watched:
+(max ~3 minutes) for the fresh (not yet completed) run so a stale earlier run
+is never watched:
 
 ```bash
+tries=0
 until RUN_ID=$(gh run list --workflow=release.yml --limit 1 \
   --json databaseId,status --jq '.[0] | select(.status != "completed") | .databaseId') \
-  && [ -n "$RUN_ID" ]; do sleep 3; done
+  && [ -n "$RUN_ID" ]; do
+  tries=$((tries + 1))
+  [ "$tries" -lt 60 ] || { echo "error: no new release.yml run appeared" >&2; exit 1; }
+  sleep 3
+done
 gh run watch "$RUN_ID" --exit-status
 gh release view vX.Y.Z --json tagName,isDraft,isPrerelease
 ```
@@ -539,7 +545,10 @@ The workflow reads the version from `package.json` on main (no version
 argument). It refuses to run off main, on a non-stable version, or when the
 tag already exists without a release. Re-running a failed run is safe: an
 already-published release short-circuits, and npm publish (publish-npm.yml)
-re-fires with its own idempotency guards.
+re-fires with its own idempotency guards. To heal a post-publish mirror
+failure (e.g. update-homebrew), use **"Re-run failed jobs"** — a full "Re-run
+all jobs" skips the whole pipeline once the release is published (green run,
+tap unchanged).
 
 ### 7.4 Generate Twitter Post Text
 

--- a/.claude/skills/vibe-release-new-version/SKILL.md
+++ b/.claude/skills/vibe-release-new-version/SKILL.md
@@ -365,8 +365,8 @@ gh pr create --base develop --title "chore: release vX.Y.Z" --body "$(cat <<'EOF
 After merging this PR:
 1. Create a PR from `develop` to `main`
 2. Merge the `develop` → `main` PR
-3. Create a GitHub Release with tag `vX.Y.Z`
-4. CI will automatically build the binaries and publish to npm
+3. Run the Release workflow (`gh workflow run release.yml --ref main`)
+4. The workflow builds the binaries, publishes the GitHub Release (tag `vX.Y.Z`), and npm publish follows automatically
 EOF
 )"
 ```
@@ -404,8 +404,8 @@ gh pr create --base main --head develop --title "chore: merge develop into main 
 ---
 
 After merging this PR:
-1. Create a GitHub Release with tag `vX.Y.Z`
-2. CI will automatically build the binaries and publish to npm
+1. Run the Release workflow (`gh workflow run release.yml --ref main`)
+2. The workflow builds the binaries, publishes the GitHub Release (tag `vX.Y.Z`), and npm publish follows automatically
 EOF
 )"
 ```
@@ -483,12 +483,18 @@ vibe is a super fast Git worktree management tool with Copy-on-Write optimizatio
 - [ ] Release link
 - [ ] Website link
 
-### 7.3 Create GitHub Release
+### 7.3 Run the Release Workflow
 
-Create a release using the generated release notes:
+**Do NOT run `gh release create` by hand.** The Release workflow builds the
+binaries first and only then creates and publishes the GitHub Release with
+every asset attached — the order Immutable Releases requires (a published
+release's tag and assets are frozen, so assets can never be added afterwards).
+
+Save the release notes generated in Step 7.2 to a file, then dispatch the
+workflow on main:
 
 ```bash
-gh release create vX.Y.Z --title "vX.Y.Z" --notes "$(cat <<'EOF'
+cat > /tmp/release-notes.md <<'EOF'
 ## What's Changed
 
 ### Features
@@ -512,10 +518,25 @@ vibe is a super fast Git worktree management tool with Copy-on-Write optimizatio
 - [Release vX.Y.Z](https://github.com/kexi/vibe/releases/tag/vX.Y.Z)
 - [Website](https://vibe.kexi.dev)
 EOF
-)" --target main
+
+gh workflow run release.yml --ref main -F notes=@/tmp/release-notes.md
 ```
 
-**Note:** Replace the `--notes` content above with the release notes generated in Step 7.2.
+**Note:** Replace the notes content above with the release notes generated in Step 7.2.
+
+Watch the run until it finishes, then confirm the release is published:
+
+```bash
+sleep 5
+gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')" --exit-status
+gh release view vX.Y.Z --json tagName,isDraft,isPrerelease
+```
+
+The workflow reads the version from `package.json` on main (no version
+argument). It refuses to run off main, on a non-stable version, or when the
+tag already exists without a release. Re-running a failed run is safe: an
+already-published release short-circuits, and npm publish (publish-npm.yml)
+re-fires with its own idempotency guards.
 
 ### 7.4 Generate Twitter Post Text
 
@@ -639,14 +660,22 @@ git push origin --delete release/vX.Y.Z
 | Version format     | Semantic versioning compliant | **Abort**      |
 | Tag duplicate      | Tag does not already exist    | **Abort**      |
 
+The tag-duplicate and version-format checks are re-enforced by the Release
+workflow's `prepare` job, so a stale local check cannot slip through.
+
 ---
 
 ## Automated CI
 
-After PR merge, the following CI workflows run automatically:
+Releasing is workflow-first (Immutable Releases-safe): a GitHub Release is
+never a trigger, it is the *output* of the Release workflow.
 
-- `release.yml`: Binary build & release asset upload
-- `publish-npm.yml`: npm publish (the launcher shim + the four per-platform binary packages)
+- `release.yml` (dispatched via Step 7.3): builds the binaries and `.deb`s,
+  then creates and publishes the GitHub Release with all assets attached in
+  one `gh release create` call (the tag is burned only after every asset
+  uploaded)
+- `publish-npm.yml` (fires automatically via `workflow_run` after `release.yml`
+  succeeds): npm publish (the launcher shim + the per-platform binary packages)
 
 JSR publishing was removed with the dead TypeScript distribution in Phase 6.
 

--- a/.claude/skills/vibe-release-new-version/SKILL.md
+++ b/.claude/skills/vibe-release-new-version/SKILL.md
@@ -524,11 +524,14 @@ gh workflow run release.yml --ref main -F notes=@/tmp/release-notes.md
 
 **Note:** Replace the notes content above with the release notes generated in Step 7.2.
 
-Watch the run until it finishes, then confirm the release is published:
+Watch the run until it finishes, then confirm the release is published. Wait
+for the fresh (not yet completed) run so a stale earlier run is never watched:
 
 ```bash
-sleep 5
-gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')" --exit-status
+until RUN_ID=$(gh run list --workflow=release.yml --limit 1 \
+  --json databaseId,status --jq '.[0] | select(.status != "completed") | .databaseId') \
+  && [ -n "$RUN_ID" ]; do sleep 3; done
+gh run watch "$RUN_ID" --exit-status
 gh release view vX.Y.Z --json tagName,isDraft,isPrerelease
 ```
 

--- a/.claude/skills/vibe-release-new-version/SKILL.md
+++ b/.claude/skills/vibe-release-new-version/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Release a new version of vibe (version bump, sync, PR creation)
+description: Release a new version of vibe (version bump, sync, PR creation, Release workflow dispatch)
 argument-hint: "[patch|minor|major|X.Y.Z]"
 allowed-tools: Bash(git *), Bash(gh *), Bash(pnpm *), Bash(bun *), Read, Edit, AskUserQuestion
 context: fork
@@ -421,7 +421,7 @@ Display the PR URL and inform the user:
 
 ---
 
-## Step 7: Create Release (after develop → main PR merge)
+## Step 7: Run the Release Workflow (after develop → main PR merge)
 
 After the PR is merged, execute the following:
 

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -43,8 +43,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if gh release view "v${VERSION}" > /dev/null 2>&1; then
-            echo "Release v${VERSION} already exists, skipping"
+          # `gh release view` falls back to searching drafts, so only a
+          # published release counts as done; a draft leftover from a failed
+          # attempt is deleted and recreated by the release job.
+          if [ "$(gh release view "v${VERSION}" --json isDraft --jq .isDraft 2>/dev/null)" = "false" ]; then
+            echo "Release v${VERSION} already published, skipping"
             echo "should_release=false" >> $GITHUB_OUTPUT
           else
             echo "should_release=true" >> $GITHUB_OUTPUT
@@ -175,12 +178,42 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
-          gh release create "v${VERSION}" \
+          TAG="v${VERSION}"
+
+          # Drop leftover drafts from failed attempts. Several drafts can share
+          # one tag_name and `gh release delete` removes only the first match,
+          # so delete by id. Drafts hold no tag, so this never burns one.
+          for id in $(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+              --jq ".[] | select(.draft and .tag_name == \"$TAG\") | .id"); do
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${id}"
+            echo "Deleted leftover draft release id=${id}"
+          done
+
+          ASSETS=(artifacts/*)
+          if [ "${#ASSETS[@]}" -ne 5 ]; then
+            echo "::error::Expected 5 release assets, found ${#ASSETS[@]}: ${ASSETS[*]}"
+            exit 1
+          fi
+
+          # gh uploads the assets to an internal draft and publishes only once
+          # every upload succeeds, so the tag is burned with all assets present
+          # — the order Immutable Releases requires. --target pins the tag to
+          # the commit this run built; without it the tag would point at the
+          # default branch HEAD instead of the dispatched develop commit.
+          gh release create "$TAG" \
             --repo "${{ github.repository }}" \
-            --title "v${VERSION}" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
             --notes "Beta release from develop branch (run #${{ github.run_number }})" \
             --prerelease \
-            artifacts/*
+            "${ASSETS[@]}"
+
+          COUNT=$(gh release view "$TAG" --json assets --jq '.assets | length')
+          if [ "$COUNT" -ne 5 ]; then
+            echo "::error::Published release has $COUNT assets, expected 5"
+            exit 1
+          fi
+          echo "Published $TAG with $COUNT assets."
 
   update-homebrew:
     needs: [prepare, release]

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -204,7 +204,6 @@ jobs:
           # the commit this run built; without it the tag would point at the
           # default branch HEAD instead of the dispatched develop commit.
           gh release create "$TAG" \
-            --repo "${{ github.repository }}" \
             --target "$GITHUB_SHA" \
             --title "$TAG" \
             --notes "Beta release from develop branch (run #${{ github.run_number }})" \

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -176,6 +176,9 @@ jobs:
       - name: Create prerelease
         env:
           GH_TOKEN: ${{ github.token }}
+          # No checkout in this job, so gh has no git remote to resolve the
+          # repository from (gh ignores GITHUB_REPOSITORY): GH_REPO is required.
+          GH_REPO: ${{ github.repository }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           TAG="v${VERSION}"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - uses: ./.github/actions/setup-toolchain
+
       - name: Resolve release tag and enforce stable-release gate
         id: meta
         env:
@@ -69,7 +71,7 @@ jobs:
             exit 1
           fi
 
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION=$(bun run scripts/get-version.ts)
           # Validate the version (and thus the tag) so it cannot inject shell.
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::unexpected stable version in package.json: $VERSION"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -31,8 +31,9 @@ jobs:
   # used to name the release — and then verified against the release itself:
   #   - the triggering Release run must have succeeded (job-level `if` below),
   #   - the Release run must have been dispatched on main,
-  #   - the release must exist and be published (a dry_run leaves none — the
-  #     resulting failure here is expected and harmless),
+  #   - the release must exist and be published — "Release succeeded but no
+  #     release exists" is reachable only via dry_run (which deletes its
+  #     draft), so that case is a benign skip (proceed=false), not a failure,
   #   - the release must NOT be a prerelease (beta releases are excluded), and
   #   - the release's target commit must equal the commit that was built
   #     (release.yml passes --target "$GITHUB_SHA").
@@ -46,6 +47,7 @@ jobs:
       tag: ${{ steps.meta.outputs.tag }}
       version: ${{ steps.meta.outputs.version }}
       head_sha: ${{ github.event.workflow_run.head_sha }}
+      proceed: ${{ steps.meta.outputs.proceed }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -75,12 +77,19 @@ jobs:
           fi
           TAG="v${VERSION}"
 
+          # "Release run succeeded but no release exists for the tag" is
+          # reachable only through dry_run (it deletes its draft; every other
+          # success path leaves a published release, and create failures never
+          # pass the conclusion == success gate). Skip instead of failing so
+          # rehearsals do not produce red runs indistinguishable from a real
+          # publish breakage.
           if ! INFO=$(gh release view "$TAG" \
               --repo "${GITHUB_REPOSITORY}" \
               --json isDraft,isPrerelease,targetCommitish \
               --jq '[.isDraft, .isPrerelease, .targetCommitish] | @tsv' 2>/dev/null); then
-            echo "::error::release $TAG not found. A dry_run Release run leaves no release; this failure is expected then."
-            exit 1
+            echo "::notice::release $TAG not found — dry_run rehearsal; skipping npm publish."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           read -r IS_DRAFT IS_PRERELEASE TARGET <<<"$INFO"
 
@@ -101,11 +110,15 @@ jobs:
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
           echo "Resolved stable release: tag=$TAG version=$VERSION sha=$HEAD_SHA"
 
   # Verify all versions are in sync before any build/publish
   verify-versions:
     needs: resolve-release
+    # Skipping here propagates through `needs` to every downstream job, so a
+    # dry_run rehearsal ends the whole workflow green with nothing published.
+    if: needs.resolve-release.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,15 +1,19 @@
 name: Publish to npm
 
-# Runs AFTER the Release workflow succeeds, not on the `release` event itself.
+# Runs AFTER the Release workflow succeeds, not on the `release` event.
 #
-# Why workflow_run (security/correctness C-1): publish-platform-packages and
-# publish-cli `gh release download` the GitHub Release assets. The Release
-# workflow BUILDS those assets and is triggered by the same `release` event, so
-# firing both on `on: release` raced — the download ran while the assets were
-# still being built and failed with "asset not found". Gating on
-# `workflow_run: completed` (success) guarantees the assets exist before we
-# fetch them. The `workflows: ["Release"]` filter must match release.yml's
-# top-level `name:` ("Release").
+# Why workflow_run (security/correctness C-1): the Release workflow is
+# dispatched on main, builds the binaries, and creates + publishes the GitHub
+# Release itself with every asset attached. It does so with GITHUB_TOKEN, and
+# events raised by GITHUB_TOKEN never trigger other workflows — so an
+# `on: release` trigger here would simply never fire. Gating on
+# `workflow_run: completed` (success) is the only link that works, and it also
+# guarantees the release and its assets exist before we `gh release download`
+# them. The `workflows: ["Release"]` filter must match release.yml's top-level
+# `name:` ("Release").
+#
+# npm OIDC trusted publishing is registered against THIS file name
+# (publish-npm.yml); do not rename or merge this workflow.
 on:
   workflow_run:
     workflows: ["Release"]
@@ -20,68 +24,84 @@ permissions:
   id-token: write # Required for npm provenance
 
 jobs:
-  # Establish the release tag/version and enforce the publish gate. workflow_run
-  # does NOT set GITHUB_REF_NAME to the tag (it points at the default branch),
-  # so the tag is taken from the triggering run's head_branch (the tag a release
-  # build runs on). We also re-assert the stable-release semantics the old
-  # `on: release: types: [released]` trigger gave for free:
+  # Establish the release tag/version and enforce the publish gate. The Release
+  # workflow is dispatched on main, so workflow_run.head_branch is "main" (not
+  # the tag) and head_sha is the exact commit the release was built from. The
+  # tag is derived from that commit's package.json — the same source release.yml
+  # used to name the release — and then verified against the release itself:
   #   - the triggering Release run must have succeeded (job-level `if` below),
+  #   - the Release run must have been dispatched on main,
+  #   - the release must exist and be published (a dry_run leaves none — the
+  #     resulting failure here is expected and harmless),
   #   - the release must NOT be a prerelease (beta releases are excluded), and
-  #   - the release must target the main branch.
+  #   - the release's target commit must equal the commit that was built
+  #     (release.yml passes --target "$GITHUB_SHA").
   # All downstream jobs consume `resolve-release.outputs.{tag,version}` instead
-  # of GITHUB_REF_NAME.
+  # of GITHUB_REF_NAME, and check out `head_sha` so they validate the released
+  # commit even if main has moved on since.
   resolve-release:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.meta.outputs.tag }}
       version: ${{ steps.meta.outputs.version }}
+      head_sha: ${{ github.event.workflow_run.head_sha }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Resolve release tag and enforce stable-release gate
         id: meta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # For a Release run triggered by the `release` event, head_branch is
-          # the release tag (e.g. "v1.8.1").
-          TAG: ${{ github.event.workflow_run.head_branch }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [ -z "$TAG" ]; then
-            echo "::error::could not determine release tag from workflow_run.head_branch"
-            exit 1
-          fi
-          # Validate tag format (vX.Y.Z[-prerelease]) so it cannot inject shell.
-          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
-            echo "::error::unexpected tag format: $TAG"
+          if [ "$HEAD_BRANCH" != "main" ]; then
+            echo "::error::the Release run was not dispatched on main (got: $HEAD_BRANCH)"
             exit 1
           fi
 
-          # Read the release's prerelease flag and target branch from the API.
-          # isPrerelease distinguishes stable `released` from beta `prereleased`,
-          # which workflow_run alone cannot tell us.
-          read -r IS_PRERELEASE TARGET < <(gh release view "$TAG" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --json isPrerelease,targetCommitish \
-            --jq '[.isPrerelease, .targetCommitish] | @tsv')
+          VERSION=$(node -p "require('./package.json').version")
+          # Validate the version (and thus the tag) so it cannot inject shell.
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::unexpected stable version in package.json: $VERSION"
+            exit 1
+          fi
+          TAG="v${VERSION}"
 
+          if ! INFO=$(gh release view "$TAG" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --json isDraft,isPrerelease,targetCommitish \
+              --jq '[.isDraft, .isPrerelease, .targetCommitish] | @tsv' 2>/dev/null); then
+            echo "::error::release $TAG not found. A dry_run Release run leaves no release; this failure is expected then."
+            exit 1
+          fi
+          read -r IS_DRAFT IS_PRERELEASE TARGET <<<"$INFO"
+
+          if [ "$IS_DRAFT" != "false" ]; then
+            echo "::error::release $TAG is still a draft; nothing to publish."
+            exit 1
+          fi
           if [ "$IS_PRERELEASE" = "true" ]; then
-            echo "Release $TAG is a prerelease (beta); skipping npm publish."
             echo "::error::publish-npm only runs for stable releases (not prereleases)."
             exit 1
           fi
-          if [ "$TARGET" != "main" ]; then
-            echo "::error::Releases must target the main branch (got: $TARGET)."
+          # release.yml creates the release with --target "$GITHUB_SHA", so this
+          # proves the tag points at exactly the commit the Release run built.
+          if [ "$TARGET" != "$HEAD_SHA" ]; then
+            echo "::error::release target ($TARGET) is not the commit the Release run built ($HEAD_SHA)."
             exit 1
           fi
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-          echo "Resolved stable release: tag=$TAG version=${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved stable release: tag=$TAG version=$VERSION sha=$HEAD_SHA"
 
   # Verify all versions are in sync before any build/publish
   verify-versions:
@@ -92,7 +112,11 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
+      # Pin to the released commit: a commit landing on main between the
+      # Release run and this workflow must not shift what gets validated.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve-release.outputs.head_sha }}
 
       - uses: ./.github/actions/setup-toolchain
 
@@ -151,7 +175,7 @@ jobs:
   # packages distribute (pulls in aws-lc-rs / rustls / etc). The old napi crate
   # under packages/native was removed in Phase 6, so it is no longer audited.
   security-audit:
-    needs: verify-versions
+    needs: [resolve-release, verify-versions]
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -159,6 +183,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve-release.outputs.head_sha }}
 
       - uses: ./.github/actions/setup-toolchain
 
@@ -211,6 +237,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve-release.outputs.head_sha }}
 
       - uses: ./.github/actions/setup-toolchain
 
@@ -328,6 +356,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve-release.outputs.head_sha }}
 
       - uses: ./.github/actions/setup-toolchain
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,94 @@
 name: Release
 
+# Releasing is workflow-first: dispatching this workflow on main builds the
+# binaries and creates the GitHub Release with every asset in one
+# `gh release create` call. gh uploads assets to an internal draft and only
+# publishes once every upload succeeds, so the tag is burned only after all
+# artifacts exist — the order Immutable Releases requires. A GitHub Release is
+# therefore never a trigger here: the old `on: release` flow attached assets to
+# an already-published release, which Immutable Releases forbids.
 on:
-  release:
-    types: [released, prereleased]
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: "Release notes (markdown). Empty = auto-generated notes"
+        required: false
+        type: string
+      dry_run:
+        description: "Build and verify a draft release, then delete it (no publish)"
+        required: false
+        type: boolean
+        default: false
+
+# Serialize releases so one run's draft never races another run's publish
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 permissions:
   contents: write
 
 jobs:
-  verify-branch:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      should_release: ${{ steps.state.outputs.should_release }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
-      - name: Verify release targets main branch
-        if: github.event.action == 'released'
+      # Fail (not skip) off-main dispatches: a skipped run still completes as
+      # success, which would needlessly wake publish-npm's workflow_run gate.
+      - name: Verify dispatch is on main
         run: |
-          if [ "${{ github.event.release.target_commitish }}" != "main" ]; then
-            echo "::error::Stable releases must target the main branch."
-            echo "  Target branch: ${{ github.event.release.target_commitish }}"
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::Stable releases must be dispatched on main (got: $GITHUB_REF)"
             exit 1
           fi
-          echo "Release targets main branch"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Resolve version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid stable version: $VERSION (prerelease suffixes belong to beta-release.yml)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Determine release state
+        id: state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          # `gh release view` falls back to searching drafts, so distinguish
+          # none / draft / published via isDraft instead of exit status alone.
+          STATE=none
+          if IS_DRAFT=$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null); then
+            if [ "$IS_DRAFT" = "true" ]; then STATE=draft; else STATE=published; fi
+          fi
+          if [ "$STATE" = "published" ]; then
+            echo "Release $TAG already published; skipping build (re-run recovery path)."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # A pre-existing tag would make the published release point at a
+          # commit this run did not build; leftover drafts are handled later.
+          if [ "$STATE" = "none" ] && [ -n "$(git ls-remote --tags origin "refs/tags/$TAG")" ]; then
+            echo "::error::Tag $TAG exists without a published release; delete the tag or bump the version."
+            exit 1
+          fi
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
 
   build:
-    needs: verify-branch
+    needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -129,7 +191,7 @@ jobs:
           path: ${{ matrix.artifact }}
 
   build-deb:
-    needs: build
+    needs: [prepare, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -166,8 +228,8 @@ jobs:
         env:
           BINARY: ${{ matrix.binary }}
           ARCH: ${{ matrix.arch }}
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           chmod +x "$BINARY"
           bun run scripts/build-deb.ts "$VERSION" "$ARCH" "$BINARY"
 
@@ -241,7 +303,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: [build, build-deb, stage-platform-packages]
+    needs: [prepare, build, build-deb, stage-platform-packages]
     runs-on: ubuntu-latest
 
     steps:
@@ -254,22 +316,89 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Create Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
+      - name: Create and publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          NOTES: ${{ inputs.notes }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          # Re-check on re-runs: prepare's verdict may predate a publish that
+          # succeeded in the meantime.
+          if [ "$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null)" = "false" ]; then
+            echo "Release $TAG already published; nothing to do."
+            exit 0
+          fi
+
+          # Drop leftover drafts from failed attempts. Several drafts can share
+          # one tag_name and `gh release delete` removes only the first match,
+          # so delete by id. Drafts hold no tag, so this never burns one.
+          for id in $(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+              --jq ".[] | select(.draft and .tag_name == \"$TAG\") | .id"); do
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${id}"
+            echo "Deleted leftover draft release id=${id}"
+          done
+
           # Why not `artifacts/*`: download-artifact with `merge-multiple: true`
           # flattens the five `platform-package-*` artifacts into the same dir,
           # leaking their `package.json` / `THIRD-PARTY-LICENSES.md` into the
           # GitHub Release. publish-npm.yml regenerates those locally per-matrix
           # and only pulls the named binary via `gh release download --pattern`,
           # so restricting uploads to the binaries and .debs is safe.
-          files: |
-            artifacts/vibe-*-*
-            artifacts/vibe_*.deb
-          generate_release_notes: true
+          ASSETS=(artifacts/vibe-*-* artifacts/vibe_*.deb)
+          if [ "${#ASSETS[@]}" -ne 7 ]; then
+            echo "::error::Expected 7 release assets (5 binaries + 2 .deb), found ${#ASSETS[@]}: ${ASSETS[*]}"
+            exit 1
+          fi
+
+          if [ -n "$NOTES" ]; then
+            printf '%s\n' "$NOTES" > notes.md
+            NOTES_ARGS=(--notes-file notes.md)
+          else
+            # Anchor auto-notes to the previous stable so a beta prerelease in
+            # between does not shrink the changelog range.
+            PREV=$(gh release list --exclude-pre-releases --limit 1 \
+              --json tagName --jq '.[0].tagName')
+            NOTES_ARGS=(--generate-notes)
+            [ -n "$PREV" ] && NOTES_ARGS+=(--notes-start-tag "$PREV")
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            # Exercise the full upload path against an explicit draft, then
+            # delete it. The follow-up publish-npm run will fail on "release
+            # not found" — expected and harmless; workflow_run events cannot
+            # see this run's dispatch inputs, so it cannot be told to skip.
+            gh release create "$TAG" --draft --target "$GITHUB_SHA" \
+              --title "$TAG" "${NOTES_ARGS[@]}" "${ASSETS[@]}"
+            COUNT=$(gh release view "$TAG" --json assets --jq '.assets | length')
+            if [ "$COUNT" -ne 7 ]; then
+              echo "::error::Draft release has $COUNT assets, expected 7"
+              exit 1
+            fi
+            gh release delete "$TAG" --yes
+            echo "Dry run OK: draft carried all 7 assets and was deleted."
+            exit 0
+          fi
+
+          # gh uploads the assets to an internal draft and publishes only once
+          # every upload succeeds, so the tag is created (at --target) with all
+          # assets already present — the order Immutable Releases requires. A
+          # failed upload leaves a draft behind; the cleanup above removes it
+          # on the next attempt.
+          gh release create "$TAG" --target "$GITHUB_SHA" --latest \
+            --title "$TAG" "${NOTES_ARGS[@]}" "${ASSETS[@]}"
+
+          COUNT=$(gh release view "$TAG" --json assets --jq '.assets | length')
+          if [ "$COUNT" -ne 7 ]; then
+            echo "::error::Published release has $COUNT assets, expected 7"
+            exit 1
+          fi
+          echo "Published $TAG with $COUNT assets."
 
   update-homebrew:
-    needs: release
+    needs: [prepare, release]
+    # dry_run publishes nothing, so there is no release to mirror to the tap.
+    if: inputs.dry_run != true
     runs-on: ubuntu-latest
 
     steps:
@@ -291,17 +420,6 @@ jobs:
           echo "linux_arm64=$(sha256sum artifacts/vibe-linux-arm64 | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
           echo "linux_x64=$(sha256sum artifacts/vibe-linux-x64 | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
-      - name: Determine Formula to update
-        id: formula
-        run: |
-          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            echo "name=vibe-beta" >> $GITHUB_OUTPUT
-            echo "template=vibe-beta.rb" >> $GITHUB_OUTPUT
-          else
-            echo "name=vibe" >> $GITHUB_OUTPUT
-            echo "template=vibe.rb" >> $GITHUB_OUTPUT
-          fi
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: vibe-source
@@ -309,13 +427,15 @@ jobs:
       - name: Update Homebrew formula
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          FORMULA_NAME="${{ steps.formula.outputs.name }}"
-          FORMULA_TEMPLATE="${{ steps.formula.outputs.template }}"
+          # This job only mirrors stable releases; the beta channel formula
+          # (vibe-beta.rb) is owned by beta-release.yml.
+          FORMULA_NAME="vibe"
+          FORMULA_TEMPLATE="vibe.rb"
 
           # Validate version format
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "Error: Invalid version format: $VERSION"
             exit 1
           fi
@@ -356,35 +476,32 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add "Formula/${FORMULA_TEMPLATE}"
 
-          # Generate versioned formula for stable releases only
-          # Beta versions are handled by beta-release.yml
-          IS_PRERELEASE="${{ github.event.release.prerelease }}"
-          if [ "$IS_PRERELEASE" != "true" ]; then
-            # Compute Homebrew class_s-compatible class name via Ruby
-            CLASSNAME=$(ruby -e "
-              v = '${VERSION}'.capitalize
-              v = v.gsub(/[-_.\s]([a-zA-Z0-9])/) { Regexp.last_match(1).upcase }
-              puts v
-            ")
-            VERSIONED_FORMULA="vibe@${VERSION}.rb"
+          # Versioned formula (vibe@X.Y.Z.rb) so older stable versions stay
+          # installable side by side.
+          # Compute Homebrew class_s-compatible class name via Ruby
+          CLASSNAME=$(ruby -e "
+            v = '${VERSION}'.capitalize
+            v = v.gsub(/[-_.\s]([a-zA-Z0-9])/) { Regexp.last_match(1).upcase }
+            puts v
+          ")
+          VERSIONED_FORMULA="vibe@${VERSION}.rb"
 
-            cp "../vibe-source/Formula/vibe-versioned.rb" "Formula/${VERSIONED_FORMULA}"
-            sed -i "s/CLASSNAME_PLACEHOLDER/$CLASSNAME/g" "Formula/${VERSIONED_FORMULA}"
-            sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" "Formula/${VERSIONED_FORMULA}"
-            sed -i "s/SHA256_DARWIN_ARM64/${{ steps.sha256.outputs.darwin_arm64 }}/g" "Formula/${VERSIONED_FORMULA}"
-            sed -i "s/SHA256_DARWIN_X64/${{ steps.sha256.outputs.darwin_x64 }}/g" "Formula/${VERSIONED_FORMULA}"
-            sed -i "s/SHA256_LINUX_ARM64/${{ steps.sha256.outputs.linux_arm64 }}/g" "Formula/${VERSIONED_FORMULA}"
-            sed -i "s/SHA256_LINUX_X64/${{ steps.sha256.outputs.linux_x64 }}/g" "Formula/${VERSIONED_FORMULA}"
+          cp "../vibe-source/Formula/vibe-versioned.rb" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/CLASSNAME_PLACEHOLDER/$CLASSNAME/g" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/SHA256_DARWIN_ARM64/${{ steps.sha256.outputs.darwin_arm64 }}/g" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/SHA256_DARWIN_X64/${{ steps.sha256.outputs.darwin_x64 }}/g" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/SHA256_LINUX_ARM64/${{ steps.sha256.outputs.linux_arm64 }}/g" "Formula/${VERSIONED_FORMULA}"
+          sed -i "s/SHA256_LINUX_X64/${{ steps.sha256.outputs.linux_x64 }}/g" "Formula/${VERSIONED_FORMULA}"
 
-            # Verify all placeholders were replaced
-            if grep -q "PLACEHOLDER" "Formula/${VERSIONED_FORMULA}"; then
-              echo "Error: Placeholders were not replaced correctly in versioned formula"
-              grep "PLACEHOLDER" "Formula/${VERSIONED_FORMULA}"
-              exit 1
-            fi
-
-            git add "Formula/${VERSIONED_FORMULA}"
+          # Verify all placeholders were replaced
+          if grep -q "PLACEHOLDER" "Formula/${VERSIONED_FORMULA}"; then
+            echo "Error: Placeholders were not replaced correctly in versioned formula"
+            grep "PLACEHOLDER" "Formula/${VERSIONED_FORMULA}"
+            exit 1
           fi
+
+          git add "Formula/${VERSIONED_FORMULA}"
 
           # Skip the commit when the formula is already up to date: on a re-run
           # of a succeeded release the regenerated formula is byte-identical

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,12 @@ jobs:
           fi
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - uses: ./.github/actions/setup-toolchain
+
       - name: Resolve version from package.json
         id: version
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION=$(bun run scripts/get-version.ts)
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::Invalid stable version: $VERSION (prerelease suffixes belong to beta-release.yml)"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,6 +319,9 @@ jobs:
       - name: Create and publish release
         env:
           GH_TOKEN: ${{ github.token }}
+          # No checkout in this job, so gh has no git remote to resolve the
+          # repository from (gh ignores GITHUB_REPOSITORY): GH_REPO is required.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.prepare.outputs.tag }}
           NOTES: ${{ inputs.notes }}
           DRY_RUN: ${{ inputs.dry_run }}
@@ -365,9 +368,10 @@ jobs:
 
           if [ "$DRY_RUN" = "true" ]; then
             # Exercise the full upload path against an explicit draft, then
-            # delete it. The follow-up publish-npm run will fail on "release
-            # not found" — expected and harmless; workflow_run events cannot
-            # see this run's dispatch inputs, so it cannot be told to skip.
+            # delete it. workflow_run events cannot see this run's dispatch
+            # inputs, so the follow-up publish-npm run detects the deleted
+            # release itself and skips gracefully (resolve-release's
+            # proceed=false path).
             gh release create "$TAG" --draft --target "$GITHUB_SHA" \
               --title "$TAG" "${NOTES_ARGS[@]}" "${ASSETS[@]}"
             COUNT=$(gh release view "$TAG" --json assets --jq '.assets | length')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,8 @@ Code should follow SOLID principles:
   Releases-safe order)
 - Steps:
   1. `gh workflow run release.yml --ref main`
-  2. Watch the run: `gh run watch --exit-status` (version comes from
+  2. Watch the run: resolve the fresh run id first, then
+     `gh run watch <run-id> --exit-status` (see CONTRIBUTING.md "Releasing a
+     New Version" step 3 for the polling snippet; version comes from
      `package.json` on main)
   3. npm publish (`publish-npm.yml`) follows automatically via `workflow_run`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,9 +107,12 @@ Code should follow SOLID principles:
 
 ## Release
 
-- After merging to `main`, create and publish a release on GitHub to trigger
-  GitHub Actions build
+- After merging to `main`, dispatch the Release workflow; do NOT create a tag
+  or a GitHub Release by hand (the workflow builds the binaries first, then
+  creates and publishes the release with all assets — the Immutable
+  Releases-safe order)
 - Steps:
-  1. GitHub → Releases → Draft a new release
-  2. Create a tag (e.g., `v0.1.0`)
-  3. Write release notes and click "Publish release"
+  1. `gh workflow run release.yml --ref main`
+  2. Watch the run: `gh run watch --exit-status` (version comes from
+     `package.json` on main)
+  3. npm publish (`publish-npm.yml`) follows automatically via `workflow_run`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,27 +118,35 @@ See [AGENTS.md](./AGENTS.md) for detailed branching workflow.
 
    After the PR is merged:
 
-3. **Create and push the tag:**
+3. **Run the Release workflow:**
+
+   Do **not** create the tag or the GitHub release by hand. The Release
+   workflow builds the binaries first and only then creates and publishes the
+   GitHub Release with every asset attached — the tag is created at publish
+   time, pointing at the exact commit that was built. This is the order
+   Immutable Releases requires (a published release's tag and assets are
+   frozen, so nothing can be added afterwards).
 
    ```bash
-   # Checkout main and pull the merged changes
-   git checkout main
-   git pull origin main
+   gh workflow run release.yml --ref main
 
-   # Create and push the tag
-   git tag vX.X.X
-   git push origin vX.X.X
+   # Optionally pass hand-written release notes (empty = auto-generated):
+   #   gh workflow run release.yml --ref main -F notes=@notes.md
+   # Rehearse without publishing (builds, verifies a draft, deletes it):
+   #   gh workflow run release.yml --ref main -f dry_run=true
 
-   # Return to develop
-   git checkout develop
+   # Watch it finish, then confirm the release is published
+   sleep 5
+   gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')" --exit-status
+   gh release view vX.X.X
    ```
 
-4. **Create the GitHub release:**
-   ```bash
-   gh release create vX.X.X --generate-notes
-   ```
+   The workflow reads the version from `package.json` on main. npm publishing
+   (`publish-npm.yml`) follows automatically once the Release workflow
+   succeeds; a re-run of either workflow is safe (idempotency guards skip
+   what is already published).
 
-5. **Update Nix binary hashes, if needed:**
+4. **Update Nix binary hashes, if needed:**
 
    The default Nix package builds from source. The prebuilt binary fast path
    (`#binary`) needs `flake.nix` hashes that match the final GitHub Release
@@ -173,11 +181,13 @@ See [AGENTS.md](./AGENTS.md) for detailed branching workflow.
 
 ### Automated Release Tasks
 
-When a release is created, GitHub Actions automatically:
+When the Release workflow is dispatched, GitHub Actions automatically:
 
-1. Builds binaries for each platform
-2. Uploads binaries to the release
+1. Builds binaries for each platform (plus `.deb` packages)
+2. Creates and publishes the GitHub Release with all assets attached
+   (the tag is created at publish time)
 3. Updates the homebrew-tap formula
+4. Publishes the npm packages (`publish-npm.yml`, via `workflow_run`)
 
 ### Required Secrets
 
@@ -206,10 +216,11 @@ gh secret set HOMEBREW_TAP_TOKEN
 ### Creating a Release
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
-gh release create v0.1.0 --generate-notes
+gh workflow run release.yml --ref main
 ```
+
+Never `git tag` or `gh release create` by hand — the workflow creates the tag
+when it publishes the release (see "Releasing a New Version" above).
 
 ## CLI Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,9 +135,12 @@ See [AGENTS.md](./AGENTS.md) for detailed branching workflow.
    # Rehearse without publishing (builds, verifies a draft, deletes it):
    #   gh workflow run release.yml --ref main -f dry_run=true
 
-   # Watch it finish, then confirm the release is published
-   sleep 5
-   gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')" --exit-status
+   # Watch it finish, then confirm the release is published. Wait for the
+   # fresh (not yet completed) run so a stale earlier run is never watched.
+   until RUN_ID=$(gh run list --workflow=release.yml --limit 1 \
+     --json databaseId,status --jq '.[0] | select(.status != "completed") | .databaseId') \
+     && [ -n "$RUN_ID" ]; do sleep 3; done
+   gh run watch "$RUN_ID" --exit-status
    gh release view vX.X.X
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,11 +135,17 @@ See [AGENTS.md](./AGENTS.md) for detailed branching workflow.
    # Rehearse without publishing (builds, verifies a draft, deletes it):
    #   gh workflow run release.yml --ref main -f dry_run=true
 
-   # Watch it finish, then confirm the release is published. Wait for the
-   # fresh (not yet completed) run so a stale earlier run is never watched.
+   # Watch it finish, then confirm the release is published. Wait (max ~3 min)
+   # for the fresh (not yet completed) run so a stale earlier run is never
+   # watched.
+   tries=0
    until RUN_ID=$(gh run list --workflow=release.yml --limit 1 \
      --json databaseId,status --jq '.[0] | select(.status != "completed") | .databaseId') \
-     && [ -n "$RUN_ID" ]; do sleep 3; done
+     && [ -n "$RUN_ID" ]; do
+     tries=$((tries + 1))
+     [ "$tries" -lt 60 ] || { echo "error: no new release.yml run appeared" >&2; exit 1; }
+     sleep 3
+   done
    gh run watch "$RUN_ID" --exit-status
    gh release view vX.X.X
    ```
@@ -147,7 +153,9 @@ See [AGENTS.md](./AGENTS.md) for detailed branching workflow.
    The workflow reads the version from `package.json` on main. npm publishing
    (`publish-npm.yml`) follows automatically once the Release workflow
    succeeds; a re-run of either workflow is safe (idempotency guards skip
-   what is already published).
+   what is already published). To heal a post-publish mirror failure (e.g.
+   update-homebrew), use "Re-run failed jobs" — a full "Re-run all jobs"
+   skips the whole pipeline once the release is published.
 
 4. **Update Nix binary hashes, if needed:**
 


### PR DESCRIPTION
## Why

GitHub's Immutable Releases freeze a release's tag and assets the moment it is published. Our stable flow did the exact opposite order: a human published the Release first (`gh release create` per SKILL.md Step 7), and `release.yml` — triggered by that event — attached the binaries to the already-published release afterwards. Enabling Immutable Releases would break step one of every release.

Background: https://zenn.dev/yumemi_inc/articles/github-release-not-a-publish-trigger — a GitHub Release must be the *output* of a release pipeline, never its trigger.

## What

**`release.yml`** — `on: release` → `workflow_dispatch` (inputs: `notes`, `dry_run`):
- New `prepare` job: fails off-main dispatches (fail, not skip, so a stray dispatch never opens publish-npm's success gate), resolves the version from `package.json`, distinguishes none/draft/published (`gh release view` falls back to drafts, so exit status alone lies), and rejects a pre-existing bare tag.
- `release` job: softprops removed. Deletes leftover same-tag drafts by id (several drafts can share a tag_name), verifies 7 assets, then one `gh release create --target $GITHUB_SHA --latest` — gh uploads to an internal draft and publishes only after every upload succeeds, so the tag is burned last with all assets present.
- `dry_run=true` rehearses the full build + draft upload and deletes the draft (the follow-up publish-npm failure on "release not found" is expected; workflow_run cannot see dispatch inputs).
- `update-homebrew`: stable-only now (beta owns vibe-beta.rb), versioned formula unconditional.

**`publish-npm.yml`** — trigger, file name and `name:` untouched (npm OIDC trusted publishing is registered against this file; workflow_run remains the only viable link because GITHUB_TOKEN-created releases fire no events):
- `resolve-release`: head_branch is now "main", not the tag, so the tag is derived from the built commit's `package.json` (checked out at `workflow_run.head_sha`) and verified against the release: published, not prerelease, and **`targetCommitish == head_sha`** — a stronger guarantee than the old `== "main"` string compare (it proves the tag points at exactly the commit the Release run built).
- All downstream jobs check out `head_sha`, so a commit landing on main between release and publish can no longer skew validation.

**`beta-release.yml`** — same create-with-assets pattern (draft-leftover cleanup, asset count check), plus `--target $GITHUB_SHA`: this fixes an existing bug where the beta tag pointed at main HEAD (the `--target" default) instead of the dispatched develop commit — harmless today, unfixable once tags are immutable.

**Docs** — SKILL.md Step 7.3, CONTRIBUTING.md and AGENTS.md now say: never hand-create tags or releases; run `gh workflow run release.yml --ref main` (notes via `-F notes=@file`).

## Re-run / recovery semantics

| State | Behavior |
|---|---|
| already published, full re-run | prepare short-circuits → workflow success → publish-npm re-fires → `npm view` guards skip (doubles as an npm-only recovery path) |
| draft leftover from failed attempt | deleted by id, recreated (drafts hold no tag — nothing burns) |
| only update-homebrew failed | re-run failed jobs; empty-commit guard keeps it green |
| bare tag without release | prepare fails loudly |

## Verification

- `pnpm run check:all` passes; `actionlint` reports no errors (remaining shellcheck infos are pre-existing style, count went 19 → 15)
- After merge (suggested order): dispatch `beta-release.yml` on develop to prove the create-with-assets path; `gh workflow run release.yml --ref develop` must fail in prepare; `gh workflow run release.yml --ref main -f dry_run=true` for a full rehearsal
- Enabling Immutable Releases in repo settings is deferred until one real stable release has passed through this flow (until then every failure mode remains fully recoverable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)