### PR TITLE
chore: migrate CI to determinate-nix-action and retire magic-nix-cache

### DIFF
--- a/.claude/rules/ci-cd-workflows.md
+++ b/.claude/rules/ci-cd-workflows.md
@@ -17,19 +17,23 @@ Before adding a setup action, check:
 
 1. Does the job just need the standard project toolchain (bun, node, pnpm, ruby,
    rust/rustup, pinact, git)? → use `./.github/actions/setup-toolchain`.
-2. Does the job need a tool the dev shell does not provide? → add it to
+2. Does the job run bare `nix` commands and must NOT build/enter the dev shell
+   (e.g. `nix build` in `nix.yml`)? → use `./.github/actions/setup-nix` (Nix
+   install + store cache only), with a job-specific cache key.
+3. Does the job need a tool the dev shell does not provide? → add it to
    `flake.nix` `devShells.default` (so it is available locally and in CI), then
    use the composite action.
-3. Is it a one-off, distribution-specific tool (e.g. `denoland/setup-deno` for
+4. Is it a one-off, distribution-specific tool (e.g. `denoland/setup-deno` for
    JSR smoke tests, or `actions/setup-node` purely for npm registry auth)? → use
    the individual action as a fallback, on top of `setup-toolchain` if needed.
 
 ### How `setup-toolchain` works
 
-- **Linux/macOS**: installs Determinate Nix
-  (`DeterminateSystems/determinate-nix-action`), caches the Nix store with
-  `nix-community/cache-nix-action`, enters the flake dev shell, and exposes its
-  tools on `PATH` for all subsequent `run:` steps. No `nix develop --command` prefix
+- **Linux/macOS**: calls `./.github/actions/setup-nix` — the single home of the
+  `DeterminateSystems/determinate-nix-action` and
+  `nix-community/cache-nix-action` pins, which installs Determinate Nix and
+  caches the Nix store — then enters the flake dev shell and exposes its tools
+  on `PATH` for all subsequent `run:` steps. No `nix develop --command` prefix
   is needed — steps look the same as on any runner.
 - **Windows**: Nix does not run on Windows, so it falls back to
   `oven-sh/setup-bun` + `actions/setup-node` + `pnpm/action-setup`, pinned to the

--- a/.claude/rules/ci-cd-workflows.md
+++ b/.claude/rules/ci-cd-workflows.md
@@ -26,9 +26,10 @@ Before adding a setup action, check:
 
 ### How `setup-toolchain` works
 
-- **Linux/macOS**: installs Nix (`DeterminateSystems/nix-installer-action` +
-  `magic-nix-cache-action`), enters the flake dev shell, and exposes its tools
-  on `PATH` for all subsequent `run:` steps. No `nix develop --command` prefix
+- **Linux/macOS**: installs Determinate Nix
+  (`DeterminateSystems/determinate-nix-action`), caches the Nix store with
+  `nix-community/cache-nix-action`, enters the flake dev shell, and exposes its
+  tools on `PATH` for all subsequent `run:` steps. No `nix develop --command` prefix
   is needed — steps look the same as on any runner.
 - **Windows**: Nix does not run on Windows, so it falls back to
   `oven-sh/setup-bun` + `actions/setup-node` + `pnpm/action-setup`, pinned to the
@@ -75,7 +76,7 @@ steps:
 2. **Consistency**: the exact same dev shell is used locally (`nix develop`) and in CI
 3. **Simpler workflows**: one composite action instead of several setup actions
 4. **Reproducibility**: `flake.lock` pins the entire toolchain to a nixpkgs commit
-5. **Faster CI**: `magic-nix-cache-action` caches the Nix store across runs
+5. **Faster CI**: `nix-community/cache-nix-action` caches the Nix store across runs
 
 ### Adding New Tools
 

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -32,13 +32,22 @@ runs:
     # (save) step (actions/runner#2009), so `${{ inputs.* }}` would make the
     # save fail with "Input required and not supplied". `env` survives to the
     # post step.
+    # The inputs reach bash via `env:` rather than `${{ }}` interpolation in
+    # the script body, so a hostile input cannot inject shell; the newline
+    # guard exists because a newline in a value written KEY=value into
+    # GITHUB_ENV would inject arbitrary extra variables.
     - name: Export cache key to job env
       shell: bash
+      env:
+        PRIMARY_KEY: ${{ inputs.primary-key }}
+        RESTORE_PREFIX: ${{ inputs.restore-prefix }}
       run: |
-        {
-          echo "SETUP_NIX_PRIMARY_KEY=${{ inputs.primary-key }}"
-          echo "SETUP_NIX_RESTORE_PREFIX=${{ inputs.restore-prefix }}"
-        } >> "$GITHUB_ENV"
+        case "$PRIMARY_KEY$RESTORE_PREFIX" in *$'\n'*)
+          echo "::error::setup-nix cache key inputs must not contain newlines"
+          exit 1
+        esac
+        printf 'SETUP_NIX_PRIMARY_KEY=%s\n' "$PRIMARY_KEY" >> "$GITHUB_ENV"
+        printf 'SETUP_NIX_RESTORE_PREFIX=%s\n' "$RESTORE_PREFIX" >> "$GITHUB_ENV"
     - name: Nix store cache
       uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
       with:

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -25,8 +25,22 @@ runs:
     # permission is required. Note cache entries are immutable per key: on an
     # exact primary-key hit the post-step save is skipped, so the key must hash
     # everything the cached store is derived from.
+    # The inputs are copied into job-scoped env rather than passed straight
+    # through: when this action is itself nested inside another composite
+    # (setup-toolchain), the runner no longer provides the parent `inputs`
+    # context while re-evaluating the cache action's `with:` for its post
+    # (save) step (actions/runner#2009), so `${{ inputs.* }}` would make the
+    # save fail with "Input required and not supplied". `env` survives to the
+    # post step.
+    - name: Export cache key to job env
+      shell: bash
+      run: |
+        {
+          echo "SETUP_NIX_PRIMARY_KEY=${{ inputs.primary-key }}"
+          echo "SETUP_NIX_RESTORE_PREFIX=${{ inputs.restore-prefix }}"
+        } >> "$GITHUB_ENV"
     - name: Nix store cache
       uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
       with:
-        primary-key: ${{ inputs.primary-key }}
-        restore-prefixes-first-match: ${{ inputs.restore-prefix }}
+        primary-key: ${{ env.SETUP_NIX_PRIMARY_KEY }}
+        restore-prefixes-first-match: ${{ env.SETUP_NIX_RESTORE_PREFIX }}

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,32 @@
+name: Setup Nix
+description: >-
+  Install Determinate Nix and cache the Nix store. Shared by setup-toolchain
+  (dev-shell jobs) and workflows that run bare `nix` commands without the dev
+  shell (nix.yml), so the two action pins live in exactly one place.
+inputs:
+  primary-key:
+    description: >-
+      Cache key for the Nix store. Include runner.arch: Nix store paths are
+      per-architecture, and CI runs both x64 and arm64 runners for the same
+      runner.os.
+    required: true
+  restore-prefix:
+    description: Key prefix to restore from on a primary-key miss.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+    # Cache the Nix store via the standard GitHub Actions cache (actions/cache
+    # under the hood). Unlike the retired magic-nix-cache, this does not
+    # reverse-engineer GitHub's cache API, so it is not subject to the 418/429
+    # throttling that made CI flaky. purge is left off so no `actions: write`
+    # permission is required. Note cache entries are immutable per key: on an
+    # exact primary-key hit the post-step save is skipped, so the key must hash
+    # everything the cached store is derived from.
+    - name: Nix store cache
+      uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      with:
+        primary-key: ${{ inputs.primary-key }}
+        restore-prefixes-first-match: ${{ inputs.restore-prefix }}

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -10,7 +10,7 @@ runs:
     # --- Linux/macOS: Nix flake dev shell ---
     - name: Install Nix
       if: runner.os != 'Windows'
-      uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
     # Cache the Nix store via the standard GitHub Actions cache (actions/cache
     # under the hood). Unlike magic-nix-cache, this does not reverse-engineer
     # GitHub's cache API, so it is not subject to the 418/429 throttling that

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -8,22 +8,18 @@ runs:
   using: composite
   steps:
     # --- Linux/macOS: Nix flake dev shell ---
-    - name: Install Nix
+    # Keyed on the flake inputs so the cache invalidates only when the
+    # toolchain changes; the restore prefix lets unrelated changes still reuse
+    # the previous store. runner.arch is in the key because ci.yml runs both
+    # x64 (ubuntu-latest) and arm64 (ubuntu-24.04-arm) Linux runners, whose
+    # stores share no paths — an os-only key would let one arch win the save
+    # and leave the other permanently cold.
+    - name: Install Nix and cache the store
       if: runner.os != 'Windows'
-      uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-    # Cache the Nix store via the standard GitHub Actions cache (actions/cache
-    # under the hood). Unlike magic-nix-cache, this does not reverse-engineer
-    # GitHub's cache API, so it is not subject to the 418/429 throttling that
-    # made CI flaky. Keyed on the flake inputs so the cache invalidates only
-    # when the toolchain changes; restore-prefixes lets unrelated changes still
-    # reuse the previous store. purge is left off so no `actions: write`
-    # permission is required.
-    - name: Nix store cache
-      if: runner.os != 'Windows'
-      uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      uses: ./.github/actions/setup-nix
       with:
-        primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
-        restore-prefixes-first-match: nix-${{ runner.os }}-
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+        restore-prefix: nix-${{ runner.os }}-${{ runner.arch }}-
     - name: Load dev shell into environment
       if: runner.os != 'Windows'
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # "/" covers .github/workflows only; composite actions must be listed
+    # explicitly or their `uses:` pins are never bumped (the SHA-pinned
+    # third-party actions now live in .github/actions/setup-nix).
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -23,7 +23,8 @@ jobs:
   # verified `nix build .#fromSource` on macOS locally, and CI previously only
   # exercised Linux, so a macOS-specific source-build break (e.g. the clonefile
   # cfg path or a Darwin-only dependency) could slip through. nix-on-macOS in CI
-  # is heavier (no magic-nix-cache hits on a cold runner) but catches that gap.
+  # is heavier (a cold runner starts from an empty Nix store) but catches that
+  # gap.
   nix-build:
     strategy:
       fail-fast: false
@@ -63,11 +64,20 @@ jobs:
         if: steps.nix_changes.outputs.should_run == 'false'
         run: echo "No Nix-relevant changes; required check passes without running Nix."
 
-      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
         if: steps.nix_changes.outputs.should_run == 'true'
 
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+      # Same store-caching approach as setup-toolchain (see its rationale for
+      # preferring cache-nix-action over the retired magic-nix-cache). The key
+      # prefix is `nix-build-` — distinct from the dev-shell cache — because
+      # cache entries are immutable per key: sharing the key would let the
+      # dev-shell store win the save and the `.#fromSource` build dependencies
+      # would never be cached.
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         if: steps.nix_changes.outputs.should_run == 'true'
+        with:
+          primary-key: nix-build-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-build-${{ runner.os }}-
 
       - name: Check flake
         if: steps.nix_changes.outputs.should_run == 'true'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,6 +18,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   # G-8: build the source derivation on BOTH Linux and macOS. The dev only
   # verified `nix build .#fromSource` on macOS locally, and CI previously only
@@ -64,20 +67,21 @@ jobs:
         if: steps.nix_changes.outputs.should_run == 'false'
         run: echo "No Nix-relevant changes; required check passes without running Nix."
 
-      - uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        if: steps.nix_changes.outputs.should_run == 'true'
-
-      # Same store-caching approach as setup-toolchain (see its rationale for
-      # preferring cache-nix-action over the retired magic-nix-cache). The key
-      # prefix is `nix-build-` — distinct from the dev-shell cache — because
-      # cache entries are immutable per key: sharing the key would let the
+      # setup-nix rather than setup-toolchain: this job runs bare `nix` builds
+      # and must not build/enter the dev shell. The key prefix is `nix-build-`
+      # — distinct from the dev-shell cache — because cache entries are
+      # immutable per key: sharing the key across workflows would let the
       # dev-shell store win the save and the `.#fromSource` build dependencies
-      # would never be cached.
-      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      # would never be cached. rust/Cargo.lock is hashed in for the same
+      # reason: the fromSource build vendors its crate deps from it (flake.nix
+      # `cargoLock.lockFile`), and with an exact primary-key hit the save is
+      # skipped, so a key that ignored Cargo.lock would never cache a new
+      # dependency set.
+      - uses: ./.github/actions/setup-nix
         if: steps.nix_changes.outputs.should_run == 'true'
         with:
-          primary-key: nix-build-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
-          restore-prefixes-first-match: nix-build-${{ runner.os }}-
+          primary-key: nix-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.nix', 'flake.lock', 'rust/Cargo.lock') }}
+          restore-prefix: nix-build-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Check flake
         if: steps.nix_changes.outputs.should_run == 'true'


### PR DESCRIPTION
## Why

- Determinate Systems is consolidating on Determinate Nix: since January 2026 `nix-installer-action` no longer installs upstream Nix, and the recommended successor `determinate-nix-action` supports explicit pinning of the Nix release itself.
- The magic-nix-cache service has been shut down, so the remaining `magic-nix-cache-action` step in `nix.yml` was a silent no-op — every `nix-build` run started from a cold store.

## What

- Replace `DeterminateSystems/nix-installer-action@v22` with `DeterminateSystems/determinate-nix-action@v3.21.8` in both `setup-toolchain` and `nix.yml` (SHA-pinned via `pinact run`, verified with `pinact run --verify`).
- Replace `magic-nix-cache-action` in `nix.yml` with `nix-community/cache-nix-action@v7.0.2` — the same action `setup-toolchain` already uses — under a distinct `nix-build-` cache key. Cache entries are immutable per key, so sharing the dev-shell key would let the dev-shell store win the save and the `.#fromSource` build dependencies would never be cached.
- Update `.claude/rules/ci-cd-workflows.md`, which still described the pre-`cache-nix-action` setup.

No FlakeHub features are enabled, so no `id-token: write` permission is needed.

## Verification

- `pinact run --verify` passes (SHA/tag correspondence).
- `pnpm run check:all` passes locally.
- This PR touches `nix.yml`, so the `nix-build` change-detection gate runs the full build on both ubuntu and macos with the new installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)