### PR TITLE
chore: relicense from Apache-2.0 to MIT

### DIFF
--- a/.claude/agents/vibe-legal-expert.md
+++ b/.claude/agents/vibe-legal-expert.md
@@ -3,48 +3,57 @@ name: vibe-legal-expert
 description: >-
   License compliance and legal auditor for the vibe project. Audits the Rust
   crate graph that ships in the binary (plus the dev-only pnpm surface) for
-  license compatibility with Apache-2.0, detects GPL/LGPL contamination in
-  statically linked transitive dependencies, checks known vulnerabilities (CVEs)
-  in changed dependencies, keeps THIRD-PARTY-LICENSES.md honest, and flags
-  external API terms of service concerns. Use when adding dependencies, updating
-  versions, reviewing Dependabot PRs, or auditing license compliance.
+  license compatibility with vibe's MIT outbound license, detects GPL/LGPL
+  contamination in statically linked transitive dependencies, checks known
+  vulnerabilities (CVEs) in changed dependencies, keeps THIRD-PARTY-LICENSES.md
+  honest, and flags external API terms of service concerns. Use when adding
+  dependencies, updating versions, reviewing Dependabot PRs, or auditing license
+  compliance.
 tools: Read, Glob, Grep, Bash, WebFetch
 model: sonnet
 color: yellow
 ---
 
-You are a license compliance auditor for the **vibe** project — an Apache-2.0 licensed Rust CLI binary for Git worktree management.
+You are a license compliance auditor for the **vibe** project — an MIT licensed Rust CLI binary for Git worktree management. (Releases up to v2.x were Apache-2.0; MIT applies from v3.0.0 onward — see issue #553. Audits concern the current MIT outbound license.)
 
-Your role is to verify that all dependencies are license-compatible with Apache-2.0, detect GPL contamination in transitive dependency chains, check known vulnerabilities in changed dependencies, and flag external API terms of service concerns.
+Your role is to verify that all dependencies are license-compatible with MIT outbound distribution, detect GPL contamination in transitive dependency chains, check known vulnerabilities in changed dependencies, and flag external API terms of service concerns.
 
 **What actually ships (audit scope):**
 
 - The **Rust binary** (`rust/crates/vibe`, with `vibe-core` and `vibe-native` statically linked). Its dependencies are crates declared in `rust/Cargo.toml` (`[workspace.dependencies]`) and the per-crate `rust/crates/*/Cargo.toml`, resolved by `rust/Cargo.lock`. **This is the primary audit surface** — every crate is statically linked into the distributed artifact.
-- `packages/npm` — the launcher shim `bin/vibe.cjs`. **No runtime dependencies**; `optionalDependencies` are the five per-platform binary packages only.
-- `packages/vibe-{linux,darwin}-{x64,arm64}` and `packages/vibe-win32-x64` — ship `bin/` (the Rust release binary) plus `THIRD-PARTY-LICENSES.md`, generated from `cargo metadata` by `scripts/generate-third-party-licenses.ts`.
+- `packages/npm` — the launcher shim `bin/vibe.cjs`. **No runtime dependencies**; `optionalDependencies` are the five per-platform binary packages only. The root `LICENSE` is copied in at publish time (npm includes a top-level LICENSE regardless of `files`).
+- `packages/vibe-{linux,darwin}-{x64,arm64}` and `packages/vibe-win32-x64` — ship `bin/` (the Rust release binary), `LICENSE` (vibe's MIT terms) and `THIRD-PARTY-LICENSES.md`, generated from `cargo metadata` by `scripts/generate-third-party-licenses.ts`. Both are staged by `scripts/stage-platform-package.ts` and asserted present by `scripts/verify-platform-tarball.ts`.
 
 Everything else is dev-only and not distributed: `scripts/` (release scripts run by bun), `packages/e2e`, `packages/docs`.
 
 ---
 
-## Apache-2.0 License Compatibility Matrix
+## MIT-Outbound License Compatibility Matrix
+
+vibe distributes under MIT. The question for every dependency is therefore: *can
+its terms be satisfied while the combined work is offered under MIT?* MIT imposes
+almost nothing on the outbound side, so the constraint is entirely what each
+**inbound** license demands of a redistributor.
 
 | Category             | Licenses                                                                                                   | Verdict          | Action                                                                      |
 | -------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------- | --------------------------------------------------------------------------- |
-| **Permissive**       | MIT, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, Unlicense, CC0-1.0, Zlib, CC-BY-4.0, BlueOak-1.0.0, Python-2.0 | Compatible       | None                                                                        |
-| **Same**             | Apache-2.0                                                                                                 | Compatible       | None                                                                        |
+| **Permissive**       | MIT, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, Unlicense, CC0-1.0, Zlib, CC-BY-4.0, BlueOak-1.0.0, Python-2.0 | Compatible       | Preserve the copyright/permission notice in `THIRD-PARTY-LICENSES.md`       |
+| **Permissive (notice obligations)** | Apache-2.0                                                                                  | Compatible with conditions | Apache §4 notice-preservation obligations survive per crate — see Key Rules |
 | **Weak copyleft**    | LGPL-2.1-only, LGPL-2.1-or-later, LGPL-3.0-only, LGPL-3.0-or-later                                         | Caution          | **Rust crates are statically linked — treat as HIGH**; OK only for dev-only npm deps |
 | **Weak copyleft**    | MPL-2.0                                                                                                    | Caution          | File-level copyleft; OK if MPL-licensed files are not modified              |
 | **Weak copyleft**    | EPL-1.0, EPL-2.0                                                                                           | Caution          | May be compatible with secondary license clause; requires review            |
-| **Strong copyleft**  | GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later                                             | **Incompatible** | CRITICAL — cannot distribute with Apache-2.0                                |
+| **Strong copyleft**  | GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later                                             | **Incompatible** | CRITICAL — cannot be distributed inside an MIT-licensed binary              |
 | **Network copyleft** | AGPL-3.0-only, AGPL-3.0-or-later                                                                           | **Incompatible** | CRITICAL — even stronger restrictions than GPL                              |
 | **Custom / Unknown** | "SEE LICENSE IN ...", UNLICENSED, proprietary, or missing                                                  | Unknown          | HIGH — must inspect LICENSE file manually                                   |
 
 ### Key Rules
 
-- **GPL-2.0 + Apache-2.0**: Incompatible in both directions. Apache-2.0 has patent clauses GPL-2.0 does not accept.
-- **GPL-3.0 + Apache-2.0**: One-way compatible (Apache code can be included in GPL-3.0 projects, but NOT the reverse). vibe cannot include GPL-3.0 dependencies.
+- **Direction matters — do not conflate the two.** MIT code *may* be taken into a GPL project (vibe → GPL, "inbound to GPL"); that is a statement about someone else redistributing vibe, and it is irrelevant here. The audit question is the opposite direction: bundling a GPL dependency *into* vibe (GPL → vibe). That remains **impossible** — GPL §5 requires the whole combined work be offered under the GPL, which vibe's MIT distribution does not do. A GPL/AGPL crate in the shipped graph is CRITICAL regardless of MIT's GPL-compatibility.
+- **GPL-2.0 / GPL-3.0**: Both are CRITICAL as inbound dependencies. The relicense to MIT changed nothing about this; it removed only the *outbound* Apache patent-clause friction with GPL-2.0, which was never what blocked a GPL dependency.
 - **LGPL**: The dynamic-linking safe harbour does **not** apply to the shipped binary — Rust crates are statically linked into it (`lto = "fat"`), which triggers LGPL §4/§6 relinking obligations. An LGPL crate in the binary's dependency graph is a HIGH finding, not a CAUTION. LGPL remains low-risk only for dev-only npm packages, which are never distributed.
+- **Apache-2.0 dependencies are permissive but not obligation-free.** vibe's own license is MIT, yet each Apache-2.0 crate keeps its §4 duties on the redistributor: retain copyright/patent/attribution notices and ship any `NOTICE` file content. These obligations attach **per crate**, not to vibe as a whole, and are discharged by `THIRD-PARTY-LICENSES.md` shipping in every channel. A stale notice file is therefore a genuine compliance defect, not a formality.
+- **`aws-lc-sys` has a non-electable Apache-2.0 conjunct.** Its SPDX expression contains `AND Apache-2.0` (alongside ISC/OpenSSL terms), so unlike a plain `MIT OR Apache-2.0` crate there is no disjunct to elect away from — the Apache notice obligations above apply unavoidably as long as it is linked. Verify it is still represented in `THIRD-PARTY-LICENSES.md` on any crypto-provider or feature-flag change.
+- **Patents**: MIT grants no express patent license, so vibe's own outbound terms convey none. That does not reduce what vibe *receives*: each Apache-2.0 dependency still grants its §3 patent license for that crate's contribution, and that grant is unaffected by vibe redistributing under MIT. Losing an Apache-2.0 crate's express grant (e.g. swapping it for an unlicensed or custom-licensed equivalent) is worth flagging.
 - **Multi-licensed crates**: Most Rust crates are `MIT OR Apache-2.0`. An `OR` expression is compatible if **any** disjunct is compatible — vibe elects the permissive option (see the header of `THIRD-PARTY-LICENSES.md`). An `AND` expression requires **every** conjunct to be compatible.
 - **devDependencies / dev-only crates**: Not distributed — GPL in `[dev-dependencies]` or in `packages/{e2e,docs}` does not infect the output. Still flag for awareness, but at lower severity.
 
@@ -182,7 +191,7 @@ be dropped by narrowing features rather than replacing the parent.
 | Scope                              | Published?         | Risk Level   | Scrutiny                                                                                       |
 | ---------------------------------- | ------------------ | ------------ | ---------------------------------------------------------------------------------------------- |
 | `rust/crates/*` deps (Cargo.lock)  | Yes (in binary)    | **Critical** | Statically linked into every channel (npm, Homebrew, .deb, Nix). Must be fully compatible; notices must appear in `THIRD-PARTY-LICENSES.md` |
-| `packages/vibe-<platform>-<arch>`  | Yes (npm)          | High         | Ships the binary + `THIRD-PARTY-LICENSES.md`; verify the notice file is current                 |
+| `packages/vibe-<platform>-<arch>`  | Yes (npm)          | High         | Ships the binary + `LICENSE` + `THIRD-PARTY-LICENSES.md`; verify the notice file is current      |
 | `packages/npm`                     | Yes (npm)          | Low          | Shim only; no runtime deps. `optionalDependencies` are first-party binary packages              |
 | Rust `[dev-dependencies]`          | No                 | Low          | Test-only (`tempfile`, `vibe-test-support`); not linked into the release binary                 |
 | `scripts/`                         | No                 | Low          | Release tooling run by bun; not distributed                                                     |
@@ -273,8 +282,8 @@ Report findings using the following severity structure:
 
 ### PASSED
 
-- N shipped crates checked (`rust/Cargo.lock`) — all Apache-2.0 compatible
-- `THIRD-PARTY-LICENSES.md` up to date
+- N shipped crates checked (`rust/Cargo.lock`) — all compatible with MIT outbound distribution
+- `THIRD-PARTY-LICENSES.md` up to date (Apache-2.0 §4 notices preserved)
 - N dev-only dependencies checked — no distribution concerns
 - No new external API integrations detected
 ```

--- a/.github/actions/assert-license-era/action.yml
+++ b/.github/actions/assert-license-era/action.yml
@@ -1,0 +1,43 @@
+name: Assert LICENSE matches the licensing era
+description: >-
+  Fail-closed guard for the two-era licensing boundary drawn by the relicense
+  (#553): releases on the 2.x line were published under Apache-2.0 and must
+  stay that way; everything from 3.0.0 on is MIT. Both arms assert the license
+  text they REQUIRE rather than the one they reject. Why not "fail if 2.x sees
+  MIT": that shape passes a 3.x built from a stale Apache tree, and any
+  rewording of LICENSE (e.g. "The MIT License (MIT)") silently disables it — a
+  missing match would mean "allowed" instead of "stop". Requiring a positive
+  match fails closed on both an unexpected version/license pairing and on
+  wording drift. This action is the single home of the era rule so the stable
+  and beta release workflows cannot drift apart.
+
+inputs:
+  version:
+    description: >-
+      The version being released, without a leading "v". A -beta.N suffix
+      never affects the 2.* prefix match.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Assert LICENSE matches the release version's licensing era
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        case "$VERSION" in
+          2.*)
+            EXPECTED="Apache License"
+            ERA="the 2.x line is Apache-2.0"
+            ;;
+          *)
+            EXPECTED="MIT License"
+            ERA="releases from 3.0.0 on are MIT"
+            ;;
+        esac
+        if ! grep -q "$EXPECTED" LICENSE; then
+          echo "::error::Refusing to release v$VERSION: LICENSE does not contain \"$EXPECTED\" ($ERA — see #553)."
+          exit 1
+        fi
+        echo "License/version consistency check passed for $VERSION (LICENSE contains \"$EXPECTED\")"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -37,29 +37,15 @@ jobs:
           echo "version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Beta version: ${BETA_VERSION}"
 
-      # Same fail-closed assert as release.yml: betas are cut from develop, the
-      # branch where a half-applied relicense actually lands, so a mixed tree
-      # would otherwise ship a beta whose LICENSE contradicts its version. The
-      # 2.* match is on BASE_VERSION's prefix; the -beta.N suffix never affects it.
+      # Same fail-closed assert as release.yml (shared composite action, so the
+      # two workflows cannot drift): betas are cut from develop, the branch
+      # where a half-applied relicense actually lands, so a mixed tree would
+      # otherwise ship a beta whose LICENSE contradicts its version. The 2.*
+      # match is on BASE_VERSION's prefix; the -beta.N suffix never affects it.
       - name: Assert LICENSE matches the release version's licensing era
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          case "$VERSION" in
-            2.*)
-              EXPECTED="Apache License"
-              ERA="the 2.x line is Apache-2.0"
-              ;;
-            *)
-              EXPECTED="MIT License"
-              ERA="releases from 3.0.0 on are MIT"
-              ;;
-          esac
-          if ! grep -q "$EXPECTED" LICENSE; then
-            echo "::error::Refusing to release v$VERSION: LICENSE does not contain \"$EXPECTED\" ($ERA — see #553)."
-            exit 1
-          fi
-          echo "License/version consistency check passed for $VERSION (LICENSE contains \"$EXPECTED\")"
+        uses: ./.github/actions/assert-license-era
+        with:
+          version: ${{ steps.version.outputs.version }}
 
       - name: Check if release already exists
         id: check
@@ -314,11 +300,9 @@ jobs:
 
           # The tap is a separately-published statement of vibe's license; a
           # formula still claiming the pre-v3 Apache-2.0 terms must not ship.
-          if ! grep -q 'license "MIT"' Formula/vibe-beta.rb; then
-            echo "::error::Formula/vibe-beta.rb does not declare license \"MIT\" (vibe is MIT-licensed from v3.0.0)"
-            grep -n "license" Formula/vibe-beta.rb || true
-            exit 1
-          fi
+          # The check itself is shared with release.yml (../vibe-source is
+          # this repo's checkout — the same tree the formula was copied from).
+          bash ../vibe-source/scripts/assert-formula-license.sh Formula/vibe-beta.rb
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -37,6 +37,30 @@ jobs:
           echo "version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Beta version: ${BETA_VERSION}"
 
+      # Same fail-closed assert as release.yml: betas are cut from develop, the
+      # branch where a half-applied relicense actually lands, so a mixed tree
+      # would otherwise ship a beta whose LICENSE contradicts its version. The
+      # 2.* match is on BASE_VERSION's prefix; the -beta.N suffix never affects it.
+      - name: Assert LICENSE matches the release version's licensing era
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          case "$VERSION" in
+            2.*)
+              EXPECTED="Apache License"
+              ERA="the 2.x line is Apache-2.0"
+              ;;
+            *)
+              EXPECTED="MIT License"
+              ERA="releases from 3.0.0 on are MIT"
+              ;;
+          esac
+          if ! grep -q "$EXPECTED" LICENSE; then
+            echo "::error::Refusing to release v$VERSION: LICENSE does not contain \"$EXPECTED\" ($ERA — see #553)."
+            exit 1
+          fi
+          echo "License/version consistency check passed for $VERSION (LICENSE contains \"$EXPECTED\")"
+
       - name: Check if release already exists
         id: check
         env:
@@ -285,6 +309,14 @@ jobs:
           if grep -q "PLACEHOLDER" Formula/vibe-beta.rb; then
             echo "Error: Placeholders were not replaced correctly"
             grep "PLACEHOLDER" Formula/vibe-beta.rb
+            exit 1
+          fi
+
+          # The tap is a separately-published statement of vibe's license; a
+          # formula still claiming the pre-v3 Apache-2.0 terms must not ship.
+          if ! grep -q 'license "MIT"' Formula/vibe-beta.rb; then
+            echo "::error::Formula/vibe-beta.rb does not declare license \"MIT\" (vibe is MIT-licensed from v3.0.0)"
+            grep -n "license" Formula/vibe-beta.rb || true
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,12 +345,18 @@ jobs:
       # Bun on Windows (Bun's execFile cannot launch the npm.cmd shim). The
       # Windows leg's real purpose — that the shim execs the binary — is covered
       # by the steps below, which run npm/pnpm through Git Bash, not Bun.
-      - name: Assert platform tarball contents (G-3)
+      - name: Assert platform and shim tarball contents (G-3)
         if: runner.os != 'Windows'
         env:
           PLATFORM: ${{ matrix.platform }}
           ARCH: ${{ matrix.arch }}
-        run: bun run scripts/verify-platform-tarball.ts --package "vibe-${PLATFORM}-${ARCH}"
+        run: |
+          bun run scripts/verify-platform-tarball.ts --package "vibe-${PLATFORM}-${ARCH}"
+          # Mirror publish-npm.yml's shim staging so the shim leg of G-3 (npm's
+          # implicit top-level-LICENSE inclusion actually firing for this
+          # package.json) is proven here in PR CI, not first at publish time.
+          cp LICENSE packages/npm/LICENSE
+          bun run scripts/verify-platform-tarball.ts --package npm
 
       - name: Pack shim and platform tarballs
         id: pack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,13 +332,16 @@ jobs:
             --platform "$PLATFORM" --arch "$ARCH" \
             --binary "$BIN"
 
-      # G-3: the published tarball MUST contain bin/vibe (executable) and
-      # THIRD-PARTY-LICENSES.md. Assert it before packing so a bad `files` glob
-      # fails here rather than shipping an empty package.
+      # G-3: the published tarball MUST contain bin/vibe (executable), LICENSE
+      # and THIRD-PARTY-LICENSES.md. Assert it before packing so a bad `files`
+      # glob fails here rather than shipping an empty package.
       #
       # Skipped on Windows: the assertion is platform-INDEPENDENT (the `files`
       # glob is the same package.json on every OS, already verified by the
-      # ubuntu/macos legs), and the script's `npm pack` spawn does not work under
+      # ubuntu/macos legs; LICENSE is not in `files` at all — npm's implicit
+      # top-level-LICENSE rule is equally OS-independent, and a missing staged
+      # LICENSE already fails stage-platform-package.ts on every leg, Windows
+      # included), and the script's `npm pack` spawn does not work under
       # Bun on Windows (Bun's execFile cannot launch the npm.cmd shim). The
       # Windows leg's real purpose — that the shim execs the binary — is covered
       # by the steps below, which run npm/pnpm through Git Bash, not Bun.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -303,7 +303,7 @@ jobs:
           bun run scripts/stage-platform-package.ts \
             --platform "$PLATFORM" --arch "$ARCH" --binary "dist-bin/$ARTIFACT"
 
-      - name: Assert tarball contents (bin/vibe + THIRD-PARTY-LICENSES.md) (G-3)
+      - name: Assert tarball contents (bin/vibe + LICENSE + THIRD-PARTY-LICENSES.md) (G-3)
         if: steps.guard.outputs.skip != 'true'
         env:
           PLATFORM: ${{ matrix.platform }}
@@ -409,6 +409,39 @@ jobs:
           fi
 
           echo "Version validation passed: $TAG_VERSION"
+
+      - name: Stage LICENSE into the shim package
+        if: steps.guard.outputs.skip != 'true'
+        # npm includes a top-level LICENSE in the tarball irrespective of
+        # `files`, so copying it here is enough to publish vibe's terms. Not
+        # committed under packages/npm/: the root LICENSE is canonical and a
+        # checked-in copy would be a second place to keep in sync.
+        run: |
+          cp LICENSE packages/npm/LICENSE
+          test -s packages/npm/LICENSE
+
+      - name: Assert shim tarball includes LICENSE (G-3)
+        if: steps.guard.outputs.skip != 'true'
+        working-directory: packages/npm
+        # Asserting the source file exists only proves the cp ran; this checks
+        # what npm will actually pack. `files` does not list LICENSE, so the
+        # tarball's contents rest entirely on npm's implicit-inclusion
+        # behaviour — verify it here rather than trusting it, exactly as the
+        # platform packages do via scripts/verify-platform-tarball.ts.
+        run: |
+          npm pack --dry-run --json > "$RUNNER_TEMP/shim-pack.json"
+          if ! node -e '
+            const r = require(process.env.RUNNER_TEMP + "/shim-pack.json");
+            const files = (r[0] && r[0].files || []).map((f) => f.path);
+            if (!files.includes("LICENSE")) {
+              console.error("packed files: " + files.join(", "));
+              process.exit(1);
+            }
+          '; then
+            echo "::error::@kexi/vibe tarball would not include LICENSE"
+            exit 1
+          fi
+          echo "OK: @kexi/vibe tarball includes LICENSE"
 
       - name: Publish @kexi/vibe
         if: steps.guard.outputs.skip != 'true'

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -420,28 +420,14 @@ jobs:
           cp LICENSE packages/npm/LICENSE
           test -s packages/npm/LICENSE
 
-      - name: Assert shim tarball includes LICENSE (G-3)
+      - name: Assert shim tarball contents (bin/vibe.cjs + LICENSE) (G-3)
         if: steps.guard.outputs.skip != 'true'
-        working-directory: packages/npm
         # Asserting the source file exists only proves the cp ran; this checks
         # what npm will actually pack. `files` does not list LICENSE, so the
         # tarball's contents rest entirely on npm's implicit-inclusion
-        # behaviour — verify it here rather than trusting it, exactly as the
-        # platform packages do via scripts/verify-platform-tarball.ts.
-        run: |
-          npm pack --dry-run --json > "$RUNNER_TEMP/shim-pack.json"
-          if ! node -e '
-            const r = require(process.env.RUNNER_TEMP + "/shim-pack.json");
-            const files = (r[0] && r[0].files || []).map((f) => f.path);
-            if (!files.includes("LICENSE")) {
-              console.error("packed files: " + files.join(", "));
-              process.exit(1);
-            }
-          '; then
-            echo "::error::@kexi/vibe tarball would not include LICENSE"
-            exit 1
-          fi
-          echo "OK: @kexi/vibe tarball includes LICENSE"
+        # behaviour — verify it here rather than trusting it, with the same
+        # unit-tested script the platform packages use.
+        run: bun run scripts/verify-platform-tarball.ts --package npm
 
       - name: Publish @kexi/vibe
         if: steps.guard.outputs.skip != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,33 +63,13 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
-      # The relicense (#553) draws the line at v3.0.0: 2.x was published under
-      # Apache-2.0 and must stay that way, everything from 3.0.0 on is MIT.
-      # Both arms assert the license they REQUIRE rather than the one they
-      # reject. Why not "fail if 2.x sees MIT": that shape passes a 3.x built
-      # from a stale Apache tree, and any rewording of LICENSE (e.g. "The MIT
-      # License (MIT)") silently disables it — a missing match would mean
-      # "allowed" instead of "stop". Requiring a positive match fails closed on
-      # both an unexpected version/license pairing and on wording drift.
+      # The era rule (2.x = Apache-2.0, >=3.0.0 = MIT, #553) lives in the
+      # shared composite action so this workflow and beta-release.yml cannot
+      # drift apart; see the action for the full fail-closed rationale.
       - name: Assert LICENSE matches the release version's licensing era
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          case "$VERSION" in
-            2.*)
-              EXPECTED="Apache License"
-              ERA="the 2.x line is Apache-2.0"
-              ;;
-            *)
-              EXPECTED="MIT License"
-              ERA="releases from 3.0.0 on are MIT"
-              ;;
-          esac
-          if ! grep -q "$EXPECTED" LICENSE; then
-            echo "::error::Refusing to release v$VERSION: LICENSE does not contain \"$EXPECTED\" ($ERA — see #553)."
-            exit 1
-          fi
-          echo "License/version consistency check passed for $VERSION (LICENSE contains \"$EXPECTED\")"
+        uses: ./.github/actions/assert-license-era
+        with:
+          version: ${{ steps.version.outputs.version }}
 
       - name: Determine release state
         id: state
@@ -508,11 +488,9 @@ jobs:
 
           # The tap is a separately-published statement of vibe's license; a
           # formula still claiming the pre-v3 Apache-2.0 terms must not ship.
-          if ! grep -q 'license "MIT"' "Formula/${FORMULA_TEMPLATE}"; then
-            echo "::error::Formula/${FORMULA_TEMPLATE} does not declare license \"MIT\" (vibe is MIT-licensed from v3.0.0)"
-            grep -n "license" "Formula/${FORMULA_TEMPLATE}" || true
-            exit 1
-          fi
+          # The check itself is shared with beta-release.yml (../vibe-source is
+          # this repo's checkout — the same tree the formula was copied from).
+          bash ../vibe-source/scripts/assert-formula-license.sh "Formula/${FORMULA_TEMPLATE}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -543,11 +521,7 @@ jobs:
             exit 1
           fi
 
-          if ! grep -q 'license "MIT"' "Formula/${VERSIONED_FORMULA}"; then
-            echo "::error::Formula/${VERSIONED_FORMULA} does not declare license \"MIT\" (vibe is MIT-licensed from v3.0.0)"
-            grep -n "license" "Formula/${VERSIONED_FORMULA}" || true
-            exit 1
-          fi
+          bash ../vibe-source/scripts/assert-formula-license.sh "Formula/${VERSIONED_FORMULA}"
 
           git add "Formula/${VERSIONED_FORMULA}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,34 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
+      # The relicense (#553) draws the line at v3.0.0: 2.x was published under
+      # Apache-2.0 and must stay that way, everything from 3.0.0 on is MIT.
+      # Both arms assert the license they REQUIRE rather than the one they
+      # reject. Why not "fail if 2.x sees MIT": that shape passes a 3.x built
+      # from a stale Apache tree, and any rewording of LICENSE (e.g. "The MIT
+      # License (MIT)") silently disables it — a missing match would mean
+      # "allowed" instead of "stop". Requiring a positive match fails closed on
+      # both an unexpected version/license pairing and on wording drift.
+      - name: Assert LICENSE matches the release version's licensing era
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          case "$VERSION" in
+            2.*)
+              EXPECTED="Apache License"
+              ERA="the 2.x line is Apache-2.0"
+              ;;
+            *)
+              EXPECTED="MIT License"
+              ERA="releases from 3.0.0 on are MIT"
+              ;;
+          esac
+          if ! grep -q "$EXPECTED" LICENSE; then
+            echo "::error::Refusing to release v$VERSION: LICENSE does not contain \"$EXPECTED\" ($ERA — see #553)."
+            exit 1
+          fi
+          echo "License/version consistency check passed for $VERSION (LICENSE contains \"$EXPECTED\")"
+
       - name: Determine release state
         id: state
         env:
@@ -478,6 +506,14 @@ jobs:
             exit 1
           fi
 
+          # The tap is a separately-published statement of vibe's license; a
+          # formula still claiming the pre-v3 Apache-2.0 terms must not ship.
+          if ! grep -q 'license "MIT"' "Formula/${FORMULA_TEMPLATE}"; then
+            echo "::error::Formula/${FORMULA_TEMPLATE} does not declare license \"MIT\" (vibe is MIT-licensed from v3.0.0)"
+            grep -n "license" "Formula/${FORMULA_TEMPLATE}" || true
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add "Formula/${FORMULA_TEMPLATE}"
@@ -504,6 +540,12 @@ jobs:
           if grep -q "PLACEHOLDER" "Formula/${VERSIONED_FORMULA}"; then
             echo "Error: Placeholders were not replaced correctly in versioned formula"
             grep "PLACEHOLDER" "Formula/${VERSIONED_FORMULA}"
+            exit 1
+          fi
+
+          if ! grep -q 'license "MIT"' "Formula/${VERSIONED_FORMULA}"; then
+            echo "::error::Formula/${VERSIONED_FORMULA} does not declare license \"MIT\" (vibe is MIT-licensed from v3.0.0)"
+            grep -n "license" "Formula/${VERSIONED_FORMULA}" || true
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ packages/vibe-*/bin/*
 # THIRD-PARTY-LICENSES.md is also staged into each platform package at build time
 # (the canonical copy lives at the repo root and is checked in).
 packages/vibe-*/THIRD-PARTY-LICENSES.md
+# LICENSE is likewise staged into each publishable package at build/release time
+# from the repo root. npm includes a top-level LICENSE in the tarball regardless
+# of `files`, so the published packages carry vibe's terms without a committed
+# duplicate per package (which would be N copies to keep in sync).
+packages/vibe-*/LICENSE
+packages/npm/LICENSE
 
 # OS
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,15 @@ This project follows [GNU Coding Standards](https://www.gnu.org/prep/standards/)
 - Use long options with `--` prefix (e.g., `--verbose`)
 - Use short options with `-` prefix (e.g., `-v`)
 
+## License
+
+vibe is released under the MIT License (see [LICENSE](LICENSE)). By submitting a
+contribution, you agree that it is licensed under the same terms as the project
+itself — inbound license equals outbound license. No separate CLA is required.
+
+Releases up to and including v2.x were published under Apache-2.0; MIT applies
+from v3.0.0 onward (see [#553](https://github.com/kexi/vibe/issues/553)).
+
 ## Security Guidelines
 
 When contributing to vibe, please keep these security considerations in mind:

--- a/Formula/vibe-beta.rb
+++ b/Formula/vibe-beta.rb
@@ -2,7 +2,7 @@ class VibeBeta < Formula
   desc "Git worktree helper CLI (beta channel)"
   homepage "https://github.com/kexi/vibe"
   version "VERSION_PLACEHOLDER"
-  license "Apache-2.0"
+  license "MIT"
 
 
   on_macos do

--- a/Formula/vibe-versioned.rb
+++ b/Formula/vibe-versioned.rb
@@ -2,7 +2,7 @@ class VibeATCLASSNAME_PLACEHOLDER < Formula
   desc "Git worktree helper CLI (versioned)"
   homepage "https://github.com/kexi/vibe"
   version "VERSION_PLACEHOLDER"
-  license "Apache-2.0"
+  license "MIT"
   keg_only :versioned_formula
 
   on_macos do

--- a/Formula/vibe.rb
+++ b/Formula/vibe.rb
@@ -2,7 +2,7 @@ class Vibe < Formula
   desc "Git worktree helper CLI"
   homepage "https://github.com/kexi/vibe"
   version "VERSION_PLACEHOLDER"
-  license "Apache-2.0"
+  license "MIT"
 
   on_macos do
     on_arm do

--- a/LICENSE
+++ b/LICENSE
@@ -1,190 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2025 Kei Nakayama (kexi) and the vibe contributors
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2025 kexi
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ja.md
+++ b/README.ja.md
@@ -635,4 +635,6 @@ Vibe は CLI ツールのセキュリティベストプラクティスに従っ�
 
 ## ライセンス
 
-Apache-2.0
+MIT — [LICENSE](./LICENSE) を参照してください。
+
+v2.x までのリリースは Apache-2.0 で公開されています。MIT ライセンスは v3.0.0 以降に適用されます（[#553](https://github.com/kexi/vibe/issues/553) 参照）。

--- a/README.md
+++ b/README.md
@@ -635,4 +635,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
 ## License
 
-Apache-2.0
+MIT — see [LICENSE](./LICENSE).
+
+Releases up to and including v2.x were published under Apache-2.0.
+The MIT license applies from v3.0.0 onward (see [#553](https://github.com/kexi/vibe/issues/553)).

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
 
           commonMeta = with pkgs.lib; {
             homepage = "https://github.com/kexi/vibe";
-            license = licenses.asl20;
+            license = licenses.mit;
             platforms = systems;
             mainProgram = "vibe";
           };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git+https://github.com/kexi/vibe.git"
   },
-  "license": "Apache-2.0",
+  "license": "MIT",
   "packageManager": "pnpm@10.26.2",
   "engines": {
     "node": ">=18.0.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -2,6 +2,7 @@
   "name": "docs",
   "type": "module",
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -139,4 +139,7 @@ See the [full documentation](https://vibe.kexi.dev).
 
 ## License
 
-Apache-2.0
+MIT
+
+Releases up to and including v2.x were published under Apache-2.0.
+The MIT license applies from v3.0.0 onward (see [#553](https://github.com/kexi/vibe/issues/553)).

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -42,7 +42,7 @@
     "workflow"
   ],
   "author": "kexi",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/npm/test/license-consistency.test.ts
+++ b/packages/npm/test/license-consistency.test.ts
@@ -1,0 +1,163 @@
+/**
+ * License coherence guards for the MIT relicense (#553).
+ *
+ * vibe declares its license in eight independent places — the root and every
+ * package manifest, the Rust workspace, three Homebrew formulae, the Nix
+ * derivation meta, and the LICENSE text itself. Nothing derives one from
+ * another, so a partial relicense (or a new package copy-pasted from a
+ * pre-v3 manifest) would publish contradictory terms without any build failing.
+ *
+ * What these guarantee:
+ *   - every non-private package under packages/ declares "MIT", and none omits
+ *     the license field — enumerated by SCANNING packages/ on disk, not from a
+ *     hardcoded list, so a future sixth platform package cannot silently ship
+ *     without a license;
+ *   - the root package.json and the Rust workspace declare MIT;
+ *   - all three Homebrew formula templates declare `license "MIT"` (they are
+ *     published to the tap, a separate statement of vibe's terms);
+ *   - flake.nix's meta says licenses.mit and no longer licenses.asl20;
+ *   - LICENSE is the MIT text, with no Apache wording left behind.
+ *
+ * Reads the REAL repo files (resolved from the repo root, three levels up from
+ * this test dir): these assert the committed configuration, not a fixture.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+// Repo root: packages/npm/test -> ../../..
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+
+const EXPECTED_LICENSE = "MIT";
+
+interface PackageManifest {
+  name?: string;
+  private?: boolean;
+  license?: string;
+}
+
+function readRepoFile(rel: string): string {
+  return readFileSync(join(REPO_ROOT, rel), "utf-8");
+}
+
+function readRepoJson<T>(rel: string): T {
+  return JSON.parse(readRepoFile(rel)) as T;
+}
+
+/**
+ * Every packages/<dir>/package.json on disk, discovered by directory scan.
+ * A hardcoded list would not fail when a new package dir is added, which is
+ * precisely the drift this file exists to catch.
+ */
+function discoverPackageManifests(): { dir: string; rel: string; pkg: PackageManifest }[] {
+  const packagesDir = join(REPO_ROOT, "packages");
+  return readdirSync(packagesDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => ({ dir: e.name, rel: `packages/${e.name}/package.json` }))
+    .filter((e) => existsSync(join(REPO_ROOT, e.rel)))
+    .map((e) => ({ ...e, pkg: readRepoJson<PackageManifest>(e.rel) }));
+}
+
+/**
+ * `private: true` is npm's own publish blocker, so anything without it is
+ * publishable by default and must state its terms. Why not key off
+ * publishConfig.access: that is opt-IN, so a new package that simply forgot to
+ * declare a license would also lack publishConfig and be skipped entirely —
+ * the drift would hide in the very gap this file exists to close.
+ */
+function isPublishable(pkg: PackageManifest): boolean {
+  return pkg.private !== true;
+}
+
+const manifests = discoverPackageManifests();
+
+describe("package manifest licenses", () => {
+  it("finds the shim and all five platform packages by disk scan", () => {
+    const publishable = manifests.filter((m) => isPublishable(m.pkg)).map((m) => m.dir);
+    // Sanity-check the discovery itself: if the scan silently found nothing,
+    // every per-package assertion below would vacuously pass.
+    expect(publishable).toContain("npm");
+    expect(publishable.filter((d) => d.startsWith("vibe-")).length).toBe(5);
+  });
+
+  it.each(manifests.filter((m) => isPublishable(m.pkg)).map((m) => [m.rel, m.pkg] as const))(
+    "%s declares MIT",
+    (_rel, pkg) => {
+      expect(pkg.license).toBe(EXPECTED_LICENSE);
+    },
+  );
+
+  it("has no non-private packages/* manifest missing or contradicting the license field", () => {
+    // Asserted over the scanned set rather than per-package so a NEW publishable
+    // package that omits `license` entirely fails here — an absent field would
+    // otherwise never be compared against anything.
+    const wrong = manifests
+      .filter((m) => isPublishable(m.pkg) && m.pkg.license !== EXPECTED_LICENSE)
+      .map((m) => `${m.rel}: ${m.pkg.license ?? "<no license field>"}`);
+    expect(wrong).toEqual([]);
+  });
+
+  it("has no packages/* manifest declaring a non-MIT license", () => {
+    // Covers private manifests too: a license field, if present at all, must
+    // not contradict the project's terms.
+    const wrong = manifests
+      .filter((m) => m.pkg.license !== undefined && m.pkg.license !== EXPECTED_LICENSE)
+      .map((m) => `${m.rel}: ${m.pkg.license}`);
+    expect(wrong).toEqual([]);
+  });
+
+  it("declares MIT in the root package.json", () => {
+    expect(readRepoJson<PackageManifest>("package.json").license).toBe(EXPECTED_LICENSE);
+  });
+});
+
+describe("Rust workspace license", () => {
+  it("declares MIT in [workspace.package] (every crate inherits it)", () => {
+    // Anchored to the license line only. Why not also assert the file mentions
+    // no "Apache": a comment explaining, say, aws-lc-sys's Apache-2.0 conjunct
+    // would trip it — a false positive about prose, not about the declaration.
+    expect(readRepoFile("rust/Cargo.toml")).toMatch(/^license = "MIT"$/m);
+  });
+});
+
+describe("Homebrew formula licenses", () => {
+  const formulae = ["Formula/vibe.rb", "Formula/vibe-beta.rb", "Formula/vibe-versioned.rb"];
+
+  it.each(formulae)("%s declares an MIT license stanza", (rel) => {
+    expect(readRepoFile(rel)).toContain('license "MIT"');
+  });
+
+  it("enumerates every formula in the repo (no unchecked template)", () => {
+    const onDisk = readdirSync(join(REPO_ROOT, "Formula"))
+      .filter((f) => f.endsWith(".rb"))
+      .map((f) => `Formula/${f}`)
+      .sort();
+    expect(onDisk).toEqual([...formulae].sort());
+  });
+});
+
+describe("Nix derivation meta", () => {
+  it("uses licenses.mit and no longer licenses.asl20", () => {
+    const flake = readRepoFile("flake.nix");
+    expect(flake).toContain("licenses.mit");
+    expect(flake).not.toContain("asl20");
+  });
+});
+
+describe("LICENSE text", () => {
+  const license = readRepoFile("LICENSE");
+
+  it("is the MIT license", () => {
+    expect(license).toContain("MIT License");
+    expect(license).toContain("Permission is hereby granted, free of charge");
+  });
+
+  it("retains no Apache-2.0 wording", () => {
+    expect(license).not.toContain("Apache");
+  });
+
+  it("carries the project copyright line", () => {
+    expect(license).toContain("Copyright (c) 2025 Kei Nakayama (kexi) and the vibe contributors");
+  });
+});

--- a/packages/npm/test/license-consistency.test.ts
+++ b/packages/npm/test/license-consistency.test.ts
@@ -119,6 +119,25 @@ describe("Rust workspace license", () => {
     // would trip it — a false positive about prose, not about the declaration.
     expect(readRepoFile("rust/Cargo.toml")).toMatch(/^license = "MIT"$/m);
   });
+
+  it("every crate inherits the workspace license (no per-crate override)", () => {
+    // The workspace assertion above proves nothing about the crates: a crate
+    // that replaces `license.workspace = true` with its own `license = "..."`
+    // wins over the workspace value and would ship under different terms while
+    // every check here still passed. Scanned from disk for the same reason as
+    // the packages/ manifests.
+    const cratesDir = join(REPO_ROOT, "rust", "crates");
+    const crates = readdirSync(cratesDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .filter((e) => existsSync(join(cratesDir, e.name, "Cargo.toml")));
+    expect(crates.length).toBeGreaterThan(0);
+    for (const crate of crates) {
+      const rel = `rust/crates/${crate.name}/Cargo.toml`;
+      const manifest = readRepoFile(rel);
+      expect(manifest, rel).toMatch(/^license\.workspace = true$/m);
+      expect(manifest, rel).not.toMatch(/^license = /m);
+    }
+  });
 });
 
 describe("Homebrew formula licenses", () => {

--- a/packages/npm/test/stage-platform-package.test.ts
+++ b/packages/npm/test/stage-platform-package.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for scripts/stage-platform-package.ts — copies a built Rust binary into
  * its per-platform npm package (`packages/vibe-<plat>-<arch>/bin/vibe`) and
- * stages THIRD-PARTY-LICENSES.md beside it for publishing.
+ * stages LICENSE + THIRD-PARTY-LICENSES.md beside it for publishing.
  *
  * What these guarantee:
  *   - parseArgs rejects unsupported platform/arch and unknown flags;
@@ -9,8 +9,14 @@
  *     copies THIRD-PARTY-LICENSES.md when present (the file glob the platform
  *     package's `files` list publishes — G-3 would ship an empty package if
  *     this regressed);
- *   - a missing license is a warning, not a hard failure (the binary still
- *     stages), and a missing source binary IS a hard failure.
+ *   - staging also copies the project's own LICENSE, so the published tarball
+ *     carries vibe's MIT terms (npm includes a top-level LICENSE regardless of
+ *     `files`);
+ *   - a missing THIRD-PARTY-LICENSES.md is a warning, not a hard failure (it is
+ *     a build product, and the tarball verifier is the release gate), whereas a
+ *     missing root LICENSE or source binary IS a hard failure — LICENSE is a
+ *     committed file, so its absence means a broken checkout, and the tarball
+ *     verifier does not run on the Windows CI leg to catch it.
  *
  * Runs against a temp root (the `root` option) so the real packages/ tree is
  * never written to.
@@ -68,9 +74,10 @@ describe("parseArgs", () => {
 });
 
 describe("stagePlatformPackage", () => {
-  it("copies the binary to bin/vibe (executable) and stages THIRD-PARTY-LICENSES.md", async () => {
+  it("copies the binary to bin/vibe (executable) and stages both license files", async () => {
     const binary = writeBinary("vibe-built", "BINARY-BYTES");
     writeBinary("THIRD-PARTY-LICENSES.md", "# notices");
+    writeBinary("LICENSE", "MIT License\n");
 
     const dest = await stagePlatformPackage(
       { platform: "darwin", arch: "arm64", binary },
@@ -85,14 +92,28 @@ describe("stagePlatformPackage", () => {
     expect(mode & 0o111).not.toBe(0);
 
     // THIRD-PARTY-LICENSES.md must land in the package root (it is in `files`).
-    const license = join(root, "packages", "vibe-darwin-arm64", "THIRD-PARTY-LICENSES.md");
-    expect(readFileSync(license, "utf-8")).toBe("# notices");
+    const pkgDir = join(root, "packages", "vibe-darwin-arm64");
+    expect(readFileSync(join(pkgDir, "THIRD-PARTY-LICENSES.md"), "utf-8")).toBe("# notices");
+
+    // vibe's own LICENSE must ship too, so the tarball states its MIT terms.
+    expect(readFileSync(join(pkgDir, "LICENSE"), "utf-8")).toBe("MIT License\n");
+  });
+
+  it("stages LICENSE for the Windows package as well", async () => {
+    const binary = writeBinary("vibe.exe", "WIN-BINARY-BYTES");
+    writeBinary("LICENSE", "MIT License\n");
+
+    await stagePlatformPackage({ platform: "win32", arch: "x64", binary }, { root });
+
+    const license = join(root, "packages", "vibe-win32-x64", "LICENSE");
+    expect(readFileSync(license, "utf-8")).toBe("MIT License\n");
   });
 
   it("stages the Windows binary as bin/vibe.exe (keeps the extension)", async () => {
     // On Windows the cargo artifact is vibe.exe and the staged name keeps the
     // .exe so Node can spawn the PE and the shim resolves bin/vibe.exe.
     const binary = writeBinary("vibe.exe", "WIN-BINARY-BYTES");
+    writeBinary("LICENSE", "MIT License\n");
 
     const dest = await stagePlatformPackage(
       { platform: "win32", arch: "x64", binary },
@@ -104,7 +125,10 @@ describe("stagePlatformPackage", () => {
   });
 
   it("warns but still stages the binary when THIRD-PARTY-LICENSES.md is absent", async () => {
+    // The notice file is a build product: not having generated it yet is a
+    // recoverable state, and verify-platform-tarball.ts is the release gate.
     const binary = writeBinary("vibe-built", "BINARY-BYTES");
+    writeBinary("LICENSE", "MIT License\n");
     const warnings: string[] = [];
 
     const dest = await stagePlatformPackage(
@@ -114,6 +138,15 @@ describe("stagePlatformPackage", () => {
 
     expect(readFileSync(dest, "utf-8")).toBe("BINARY-BYTES");
     expect(warnings.some((w) => w.includes("THIRD-PARTY-LICENSES.md not found"))).toBe(true);
+  });
+
+  it("throws when the root LICENSE is absent (a committed file: a warn would let a license-less package ship)", async () => {
+    const binary = writeBinary("vibe-built", "BINARY-BYTES");
+    writeBinary("THIRD-PARTY-LICENSES.md", "# notices");
+
+    await expect(
+      stagePlatformPackage({ platform: "linux", arch: "x64", binary }, { root }),
+    ).rejects.toThrowError(/LICENSE not found/);
   });
 
   it("throws when the source binary does not exist", async () => {

--- a/packages/npm/test/verify-platform-tarball.test.ts
+++ b/packages/npm/test/verify-platform-tarball.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for scripts/verify-platform-tarball.ts (G-3) — asserts that a platform
- * package's planned npm tarball includes bin/vibe (executable) AND
- * THIRD-PARTY-LICENSES.md, so a wrong `files` glob or a skipped staging step
- * cannot publish an empty / non-runnable package.
+ * package's planned npm tarball includes bin/vibe (executable),
+ * THIRD-PARTY-LICENSES.md AND the project's own LICENSE, so a wrong `files`
+ * glob or a skipped staging step cannot publish an empty / non-runnable /
+ * license-less package.
  *
  * Only the pure validation (findTarballProblems) is unit-tested here; the
  * `npm pack --dry-run --json` invocation that feeds it is exercised by the CI
@@ -24,11 +25,12 @@ describe("binaryPathFor", () => {
 });
 
 describe("findTarballProblems", () => {
-  it("returns no problems when bin/vibe (executable) and the license are present", () => {
+  it("returns no problems when bin/vibe (executable) and both licenses are present", () => {
     const problems = findTarballProblems(
       [
         { path: "bin/vibe", size: 100, mode: execMode },
         { path: "THIRD-PARTY-LICENSES.md", size: 10, mode: plainMode },
+        { path: "LICENSE", size: 10, mode: plainMode },
         { path: "package.json", size: 50, mode: plainMode },
       ],
       "bin/vibe",
@@ -42,6 +44,7 @@ describe("findTarballProblems", () => {
         // Windows tarball entries carry no meaningful unix mode bits.
         { path: "bin/vibe.exe", size: 100, mode: plainMode },
         { path: "THIRD-PARTY-LICENSES.md", size: 10, mode: plainMode },
+        { path: "LICENSE", size: 10, mode: plainMode },
         { path: "package.json", size: 50, mode: plainMode },
       ],
       "bin/vibe.exe",
@@ -53,6 +56,7 @@ describe("findTarballProblems", () => {
     const problems = findTarballProblems(
       [
         { path: "THIRD-PARTY-LICENSES.md", size: 10, mode: plainMode },
+        { path: "LICENSE", size: 10, mode: plainMode },
         { path: "package.json", size: 50, mode: plainMode },
       ],
       "bin/vibe",
@@ -64,6 +68,7 @@ describe("findTarballProblems", () => {
     const problems = findTarballProblems(
       [
         { path: "bin/vibe", size: 100, mode: execMode },
+        { path: "LICENSE", size: 10, mode: plainMode },
         { path: "package.json", size: 50, mode: plainMode },
       ],
       "bin/vibe",
@@ -71,11 +76,24 @@ describe("findTarballProblems", () => {
     expect(problems.some((p) => p.includes("THIRD-PARTY-LICENSES.md"))).toBe(true);
   });
 
+  it("flags a missing LICENSE (vibe's own terms must ship in the tarball)", () => {
+    const problems = findTarballProblems(
+      [
+        { path: "bin/vibe", size: 100, mode: execMode },
+        { path: "THIRD-PARTY-LICENSES.md", size: 10, mode: plainMode },
+        { path: "package.json", size: 50, mode: plainMode },
+      ],
+      "bin/vibe",
+    );
+    expect(problems).toEqual(["missing required file: LICENSE"]);
+  });
+
   it("flags a non-executable unix binary", () => {
     const problems = findTarballProblems(
       [
         { path: "bin/vibe", size: 100, mode: plainMode },
         { path: "THIRD-PARTY-LICENSES.md", size: 10, mode: plainMode },
+        { path: "LICENSE", size: 10, mode: plainMode },
       ],
       "bin/vibe",
     );
@@ -87,7 +105,7 @@ describe("findTarballProblems", () => {
       [{ path: "package.json", size: 50, mode: plainMode }],
       "bin/vibe",
     );
-    // Both required files missing.
-    expect(problems.length).toBe(2);
+    // Binary + both license files missing.
+    expect(problems.length).toBe(3);
   });
 });

--- a/packages/npm/test/verify-platform-tarball.test.ts
+++ b/packages/npm/test/verify-platform-tarball.test.ts
@@ -1,17 +1,22 @@
 /**
- * Tests for scripts/verify-platform-tarball.ts (G-3) — asserts that a platform
- * package's planned npm tarball includes bin/vibe (executable),
- * THIRD-PARTY-LICENSES.md AND the project's own LICENSE, so a wrong `files`
- * glob or a skipped staging step cannot publish an empty / non-runnable /
- * license-less package.
+ * Tests for scripts/verify-platform-tarball.ts (G-3) — asserts that a published
+ * package's planned npm tarball includes everything its expectation requires:
+ * for platform packages bin/vibe (executable), THIRD-PARTY-LICENSES.md AND the
+ * project's own LICENSE; for the shim (packages/npm) the committed launcher and
+ * LICENSE. A wrong `files` glob or a skipped staging step cannot publish an
+ * empty / non-runnable / license-less package.
  *
- * Only the pure validation (findTarballProblems) is unit-tested here; the
- * `npm pack --dry-run --json` invocation that feeds it is exercised by the CI
- * publish/verify step (it needs a staged binary on disk).
+ * Only the pure validation (expectationFor + findTarballProblems) is
+ * unit-tested here; the `npm pack --dry-run --json` invocation that feeds it is
+ * exercised by the CI publish/verify step (it needs a staged binary on disk).
  */
 
 import { describe, it, expect } from "vitest";
-import { findTarballProblems, binaryPathFor } from "../../../scripts/verify-platform-tarball";
+import {
+  findTarballProblems,
+  binaryPathFor,
+  expectationFor,
+} from "../../../scripts/verify-platform-tarball";
 
 const execMode = 0o755;
 const plainMode = 0o644;
@@ -24,7 +29,33 @@ describe("binaryPathFor", () => {
   });
 });
 
+describe("expectationFor", () => {
+  it("requires binary + both license files (binary executable) for unix platform packages", () => {
+    expect(expectationFor("packages/vibe-linux-x64")).toEqual({
+      requiredFiles: ["bin/vibe", "THIRD-PARTY-LICENSES.md", "LICENSE"],
+      executableEntry: "bin/vibe",
+    });
+  });
+
+  it("skips the exec-bit requirement for the win32 package (.exe modes are meaningless)", () => {
+    expect(expectationFor("packages/vibe-win32-x64")).toEqual({
+      requiredFiles: ["bin/vibe.exe", "THIRD-PARTY-LICENSES.md", "LICENSE"],
+      executableEntry: undefined,
+    });
+  });
+
+  it("requires the committed launcher + LICENSE (no notices, no exec bit) for the shim", () => {
+    // The shim ships no statically-linked code, so no THIRD-PARTY-LICENSES.md;
+    // its launcher is committed 0644 and npm wires the bin at install time.
+    expect(expectationFor("packages/npm")).toEqual({
+      requiredFiles: ["bin/vibe.cjs", "LICENSE"],
+    });
+  });
+});
+
 describe("findTarballProblems", () => {
+  const platformExpectation = expectationFor("packages/vibe-linux-x64");
+
   it("returns no problems when bin/vibe (executable) and both licenses are present", () => {
     const problems = findTarballProblems(
       [
@@ -33,7 +64,7 @@ describe("findTarballProblems", () => {
         { path: "LICENSE", size: 10, mode: plainMode },
         { path: "package.json", size: 50, mode: plainMode },
       ],
-      "bin/vibe",
+      platformExpectation,
     );
     expect(problems).toEqual([]);
   });
@@ -47,7 +78,21 @@ describe("findTarballProblems", () => {
         { path: "LICENSE", size: 10, mode: plainMode },
         { path: "package.json", size: 50, mode: plainMode },
       ],
-      "bin/vibe.exe",
+      expectationFor("packages/vibe-win32-x64"),
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it("returns no problems for a shim tarball with the launcher and LICENSE", () => {
+    const problems = findTarballProblems(
+      [
+        // The committed launcher carries no exec bit; npm wires it at install.
+        { path: "bin/vibe.cjs", size: 100, mode: plainMode },
+        { path: "LICENSE", size: 10, mode: plainMode },
+        { path: "README.md", size: 20, mode: plainMode },
+        { path: "package.json", size: 50, mode: plainMode },
+      ],
+      expectationFor("packages/npm"),
     );
     expect(problems).toEqual([]);
   });
@@ -59,7 +104,7 @@ describe("findTarballProblems", () => {
         { path: "LICENSE", size: 10, mode: plainMode },
         { path: "package.json", size: 50, mode: plainMode },
       ],
-      "bin/vibe",
+      platformExpectation,
     );
     expect(problems.some((p) => p.includes("bin/vibe"))).toBe(true);
   });
@@ -71,7 +116,7 @@ describe("findTarballProblems", () => {
         { path: "LICENSE", size: 10, mode: plainMode },
         { path: "package.json", size: 50, mode: plainMode },
       ],
-      "bin/vibe",
+      platformExpectation,
     );
     expect(problems.some((p) => p.includes("THIRD-PARTY-LICENSES.md"))).toBe(true);
   });
@@ -83,7 +128,19 @@ describe("findTarballProblems", () => {
         { path: "THIRD-PARTY-LICENSES.md", size: 10, mode: plainMode },
         { path: "package.json", size: 50, mode: plainMode },
       ],
-      "bin/vibe",
+      platformExpectation,
+    );
+    expect(problems).toEqual(["missing required file: LICENSE"]);
+  });
+
+  it("flags a shim tarball whose LICENSE staging did not run", () => {
+    const problems = findTarballProblems(
+      [
+        { path: "bin/vibe.cjs", size: 100, mode: plainMode },
+        { path: "README.md", size: 20, mode: plainMode },
+        { path: "package.json", size: 50, mode: plainMode },
+      ],
+      expectationFor("packages/npm"),
     );
     expect(problems).toEqual(["missing required file: LICENSE"]);
   });
@@ -95,7 +152,7 @@ describe("findTarballProblems", () => {
         { path: "THIRD-PARTY-LICENSES.md", size: 10, mode: plainMode },
         { path: "LICENSE", size: 10, mode: plainMode },
       ],
-      "bin/vibe",
+      platformExpectation,
     );
     expect(problems.some((p) => p.includes("not executable"))).toBe(true);
   });
@@ -103,7 +160,7 @@ describe("findTarballProblems", () => {
   it("reports every problem at once (empty tarball)", () => {
     const problems = findTarballProblems(
       [{ path: "package.json", size: 50, mode: plainMode }],
-      "bin/vibe",
+      platformExpectation,
     );
     // Binary + both license files missing.
     expect(problems.length).toBe(3);

--- a/packages/vibe-darwin-arm64/package.json
+++ b/packages/vibe-darwin-arm64/package.json
@@ -12,7 +12,7 @@
     "bin/",
     "THIRD-PARTY-LICENSES.md"
   ],
-  "license": "Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kexi/vibe.git"

--- a/packages/vibe-darwin-x64/package.json
+++ b/packages/vibe-darwin-x64/package.json
@@ -12,7 +12,7 @@
     "bin/",
     "THIRD-PARTY-LICENSES.md"
   ],
-  "license": "Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kexi/vibe.git"

--- a/packages/vibe-linux-arm64/package.json
+++ b/packages/vibe-linux-arm64/package.json
@@ -12,7 +12,7 @@
     "bin/",
     "THIRD-PARTY-LICENSES.md"
   ],
-  "license": "Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kexi/vibe.git"

--- a/packages/vibe-linux-x64/package.json
+++ b/packages/vibe-linux-x64/package.json
@@ -12,7 +12,7 @@
     "bin/",
     "THIRD-PARTY-LICENSES.md"
   ],
-  "license": "Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kexi/vibe.git"

--- a/packages/vibe-win32-x64/package.json
+++ b/packages/vibe-win32-x64/package.json
@@ -12,7 +12,7 @@
     "bin/",
     "THIRD-PARTY-LICENSES.md"
   ],
-  "license": "Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kexi/vibe.git"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-license = "Apache-2.0"
+license = "MIT"
 repository = "https://github.com/kexi/vibe"
 
 [workspace.lints.clippy]

--- a/scripts/assert-formula-license.sh
+++ b/scripts/assert-formula-license.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Fail unless a Homebrew formula declares vibe's MIT license.
+#
+# The tap is a separately-published statement of vibe's license; a formula
+# still claiming the pre-v3 Apache-2.0 terms must not ship (#553). Kept as a
+# shell script (not TypeScript like the other release scripts) because the
+# tap-push steps run with the tap repo as cwd, where only bash and the
+# ../vibe-source checkout are guaranteed — no project toolchain is set up.
+#
+# Usage: assert-formula-license.sh <formula-path>
+set -euo pipefail
+
+formula="${1:?usage: assert-formula-license.sh <formula-path>}"
+
+if ! grep -q 'license "MIT"' "$formula"; then
+  echo "::error::${formula} does not declare license \"MIT\" (vibe is MIT-licensed from v3.0.0)"
+  grep -n "license" "$formula" || true
+  exit 1
+fi

--- a/scripts/stage-platform-package.ts
+++ b/scripts/stage-platform-package.ts
@@ -28,7 +28,7 @@
  */
 
 import { copyFile, mkdir, chmod, stat } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 const SUPPORTED_PLATFORMS = ["linux", "darwin", "win32"] as const;
 const SUPPORTED_ARCHES = ["x64", "arm64"] as const;
@@ -100,17 +100,26 @@ Options:
 }
 
 export interface StageOptions {
-  /** Repo root the `packages/` tree and THIRD-PARTY-LICENSES.md resolve under. */
+  /** Repo root the `packages/` tree, LICENSE and THIRD-PARTY-LICENSES.md resolve under. */
   root?: string;
-  /** Sink for the not-found-license warning; defaults to console.error. */
+  /** Sink for the not-found-notice warning; defaults to console.error. */
   warn?: (msg: string) => void;
 }
 
 /**
  * Copy the built binary into `packages/vibe-<platform>-<arch>/bin/vibe`
- * (`bin/vibe.exe` on win32, 0o755) and stage THIRD-PARTY-LICENSES.md beside it.
- * Returns the staged binary path. Throws if the source binary does not exist.
- * The root is injected so tests run against a temp dir instead of the real repo.
+ * (`bin/vibe.exe` on win32, 0o755) and stage LICENSE + THIRD-PARTY-LICENSES.md
+ * beside it. Returns the staged binary path. Throws if the source binary or the
+ * root LICENSE does not exist. The root is injected so tests run against a temp
+ * dir instead of the real repo.
+ *
+ * Why LICENSE throws but THIRD-PARTY-LICENSES.md only warns: LICENSE is a
+ * committed file, so its absence never means "not generated yet" — it means the
+ * checkout is broken, and continuing would stage a package that ships no terms
+ * at all. THIRD-PARTY-LICENSES.md is a build product that a caller may legitimately
+ * not have generated yet, and verify-platform-tarball.ts is the gate that stops it
+ * from reaching a release. That gate is skipped on the Windows CI leg, which is
+ * the other reason LICENSE cannot rely on it.
  */
 export async function stagePlatformPackage(
   args: Args,
@@ -140,21 +149,41 @@ export async function stagePlatformPackage(
 
   // The platform package's `files` list includes THIRD-PARTY-LICENSES.md (the
   // statically-linked Rust crates' notices), so stage it alongside the binary.
-  const licenseSource = join(root, "THIRD-PARTY-LICENSES.md");
-  const licenseExists = await stat(licenseSource).then(
-    (s) => s.isFile(),
-    () => false,
-  );
-  if (licenseExists) {
-    await copyFile(licenseSource, join(pkgDir, "THIRD-PARTY-LICENSES.md"));
-  } else {
+  const stagedNotices = await copyIfPresent(root, pkgDir, "THIRD-PARTY-LICENSES.md");
+  if (!stagedNotices) {
     warn(
-      `stage-platform-package: warning: THIRD-PARTY-LICENSES.md not found; ` +
+      "stage-platform-package: warning: THIRD-PARTY-LICENSES.md not found; " +
         "run scripts/generate-third-party-licenses.ts first",
     );
   }
 
+  // vibe's own LICENSE. Not listed in `files`: npm includes a top-level LICENSE
+  // in the tarball irrespective of `files`, and the canonical copy lives at the
+  // repo root — checking a duplicate into each package dir would be N copies to
+  // keep in sync.
+  const stagedLicense = await copyIfPresent(root, pkgDir, "LICENSE");
+  if (!stagedLicense) {
+    throw new Error(`LICENSE not found at ${resolve(root, "LICENSE")}`);
+  }
+
   return dest;
+}
+
+/**
+ * Copy `<root>/<name>` into the package dir. Returns false (without copying)
+ * when the source is absent, leaving the caller to decide whether that is fatal.
+ */
+async function copyIfPresent(root: string, pkgDir: string, name: string): Promise<boolean> {
+  const source = join(root, name);
+  const exists = await stat(source).then(
+    (s) => s.isFile(),
+    () => false,
+  );
+  if (!exists) {
+    return false;
+  }
+  await copyFile(source, join(pkgDir, name));
+  return true;
 }
 
 async function main(): Promise<void> {

--- a/scripts/verify-platform-tarball.ts
+++ b/scripts/verify-platform-tarball.ts
@@ -9,12 +9,14 @@
  * thing that controls what `npm publish` includes, so a wrong glob (or a missing
  * staging step) would silently publish an empty / non-runnable package. This
  * script runs `npm pack --dry-run --json` (no tarball written) and fails unless
- * the planned contents include BOTH:
- *   - bin/vibe, with an executable mode bit set, and
- *   - THIRD-PARTY-LICENSES.md.
+ * the planned contents include ALL of:
+ *   - bin/vibe, with an executable mode bit set,
+ *   - THIRD-PARTY-LICENSES.md, and
+ *   - LICENSE (vibe's own MIT terms; npm includes a top-level LICENSE
+ *     irrespective of `files`, so its absence means staging did not run).
  *
  * It must run AFTER scripts/stage-platform-package.ts has staged the binary and
- * the license into the package dir (the bin/ dirs are gitignored).
+ * the licenses into the package dir (the bin/ dirs are gitignored).
  *
  * Usage:
  *   bun run scripts/verify-platform-tarball.ts --package vibe-linux-x64
@@ -38,7 +40,9 @@ interface PackResult {
 
 // The Windows package ships `bin/vibe.exe`; every other platform ships the
 // extensionless `bin/vibe`. The caller derives the right name from the package.
-const LICENSE_FILE = "THIRD-PARTY-LICENSES.md";
+const THIRD_PARTY_LICENSE_FILE = "THIRD-PARTY-LICENSES.md";
+const PROJECT_LICENSE_FILE = "LICENSE";
+const REQUIRED_LICENSE_FILES = [THIRD_PARTY_LICENSE_FILE, PROJECT_LICENSE_FILE];
 
 /** The staged binary's path inside the tarball for a given package directory. */
 export function binaryPathFor(dir: string): string {
@@ -77,7 +81,7 @@ export function findTarballProblems(files: PackEntry[], binName: string): string
   const byPath = new Map(files.map((f) => [f.path, f]));
   const problems: string[] = [];
 
-  for (const required of [binName, LICENSE_FILE]) {
+  for (const required of [binName, ...REQUIRED_LICENSE_FILES]) {
     if (!byPath.has(required)) {
       problems.push(`missing required file: ${required}`);
     }
@@ -119,7 +123,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  console.log(`✓ ${dir}: tarball includes ${binName}, ${LICENSE_FILE}`);
+  console.log(`✓ ${dir}: tarball includes ${binName}, ${REQUIRED_LICENSE_FILES.join(", ")}`);
 }
 
 if (import.meta.main) {

--- a/scripts/verify-platform-tarball.ts
+++ b/scripts/verify-platform-tarball.ts
@@ -1,31 +1,37 @@
 #!/usr/bin/env bun
 
 /**
- * Assert that a per-platform npm package would publish its required files.
+ * Assert that a published npm package would pack its required files.
  *
  * A platform package (`packages/vibe-<platform>-<arch>`) is useless without the
  * staged binary, and ships incomplete legal notices without
- * THIRD-PARTY-LICENSES.md. The `files` glob list in its package.json is the only
- * thing that controls what `npm publish` includes, so a wrong glob (or a missing
- * staging step) would silently publish an empty / non-runnable package. This
- * script runs `npm pack --dry-run --json` (no tarball written) and fails unless
- * the planned contents include ALL of:
- *   - bin/vibe, with an executable mode bit set,
- *   - THIRD-PARTY-LICENSES.md, and
- *   - LICENSE (vibe's own MIT terms; npm includes a top-level LICENSE
- *     irrespective of `files`, so its absence means staging did not run).
+ * THIRD-PARTY-LICENSES.md. The shim package (`packages/npm`) is useless without
+ * its committed launcher. The `files` glob list in each package.json is the
+ * only thing that controls what `npm publish` includes, so a wrong glob (or a
+ * missing staging step) would silently publish an empty / non-runnable package.
+ * This script runs `npm pack --dry-run --json` (no tarball written) and fails
+ * unless the planned contents include ALL of the package's expectation:
+ *   - platform packages: bin/vibe (executable; bin/vibe.exe on win32),
+ *     THIRD-PARTY-LICENSES.md, and LICENSE;
+ *   - the shim: bin/vibe.cjs and LICENSE (committed non-executable — npm wires
+ *     the bin at install time — and it ships no THIRD-PARTY-LICENSES.md since
+ *     nothing is statically linked into it).
+ * LICENSE is vibe's own MIT terms; npm includes a top-level LICENSE
+ * irrespective of `files`, so its absence means staging did not run.
  *
- * It must run AFTER scripts/stage-platform-package.ts has staged the binary and
- * the licenses into the package dir (the bin/ dirs are gitignored).
+ * It must run AFTER the staging step has copied the files into the package dir
+ * (scripts/stage-platform-package.ts for platform packages; a `cp LICENSE`
+ * step for the shim — the bin/ dirs and staged LICENSE copies are gitignored).
  *
  * Usage:
  *   bun run scripts/verify-platform-tarball.ts --package vibe-linux-x64
+ *   bun run scripts/verify-platform-tarball.ts --package npm
  *   bun run scripts/verify-platform-tarball.ts --dir packages/vibe-linux-x64
  */
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 const execFileAsync = promisify(execFile);
 
@@ -38,15 +44,68 @@ interface PackResult {
   files: PackEntry[];
 }
 
-// The Windows package ships `bin/vibe.exe`; every other platform ships the
-// extensionless `bin/vibe`. The caller derives the right name from the package.
 const THIRD_PARTY_LICENSE_FILE = "THIRD-PARTY-LICENSES.md";
 const PROJECT_LICENSE_FILE = "LICENSE";
-const REQUIRED_LICENSE_FILES = [THIRD_PARTY_LICENSE_FILE, PROJECT_LICENSE_FILE];
 
+/** What a given package's planned tarball must contain. */
+export interface TarballExpectation {
+  /** Entries that must be present in the packed file list. */
+  requiredFiles: string[];
+  /** Entry whose mode must carry an execute bit; absent when none applies. */
+  executableEntry?: string;
+}
+
+// The Windows package ships `bin/vibe.exe`; every other platform ships the
+// extensionless `bin/vibe`. The caller derives the right name from the package.
 /** The staged binary's path inside the tarball for a given package directory. */
 export function binaryPathFor(dir: string): string {
   return dir.includes("win32") ? "bin/vibe.exe" : "bin/vibe";
+}
+
+/** The expectation for a package dir (`packages/npm` or `packages/vibe-*`). */
+export function expectationFor(dir: string): TarballExpectation {
+  const isShim = basename(dir) === "npm";
+  if (isShim) {
+    // The launcher is committed 0644 (npm chmods the wired bin at install
+    // time), so no executable-bit requirement applies.
+    return { requiredFiles: ["bin/vibe.cjs", PROJECT_LICENSE_FILE] };
+  }
+
+  const bin = binaryPathFor(dir);
+  return {
+    requiredFiles: [bin, THIRD_PARTY_LICENSE_FILE, PROJECT_LICENSE_FILE],
+    // npm tarball mode bits are not meaningful for Windows binaries.
+    executableEntry: bin.endsWith(".exe") ? undefined : bin,
+  };
+}
+
+/**
+ * Validate a `npm pack --dry-run --json` result against an expectation. Pure so
+ * it can be unit-tested without invoking npm. Returns the list of problems
+ * (empty = OK): a missing required file, or the executable entry present but
+ * not executable.
+ */
+export function findTarballProblems(files: PackEntry[], expectation: TarballExpectation): string[] {
+  const byPath = new Map(files.map((f) => [f.path, f]));
+  const problems: string[] = [];
+
+  for (const required of expectation.requiredFiles) {
+    if (!byPath.has(required)) {
+      problems.push(`missing required file: ${required}`);
+    }
+  }
+
+  // The shim chmods +x at launch if needed, but a non-executable published bin
+  // is still a smell (and breaks `bin` wiring on some installs), so require the
+  // staged mode to carry an execute bit where one is expected.
+  const bin = expectation.executableEntry ? byPath.get(expectation.executableEntry) : undefined;
+  if (bin && (bin.mode & 0o111) === 0) {
+    problems.push(
+      `${expectation.executableEntry} is not executable (mode ${bin.mode.toString(8)})`,
+    );
+  }
+
+  return problems;
 }
 
 function parseDir(argv: string[]): string {
@@ -71,34 +130,6 @@ function parseDir(argv: string[]): string {
   throw new Error("missing required --package <name> or --dir <path>");
 }
 
-/**
- * Validate a `npm pack --dry-run --json` result. Pure so it can be unit-tested
- * without invoking npm. `binName` is the expected binary entry (e.g. `bin/vibe`
- * or `bin/vibe.exe`). Returns the list of problems (empty = OK): a missing
- * required file, or the binary present but not executable.
- */
-export function findTarballProblems(files: PackEntry[], binName: string): string[] {
-  const byPath = new Map(files.map((f) => [f.path, f]));
-  const problems: string[] = [];
-
-  for (const required of [binName, ...REQUIRED_LICENSE_FILES]) {
-    if (!byPath.has(required)) {
-      problems.push(`missing required file: ${required}`);
-    }
-  }
-
-  // The shim chmods +x at launch if needed, but a non-executable published bin
-  // is still a smell (and breaks `bin` wiring on some installs), so require the
-  // staged mode to carry an execute bit. (Skipped for the .exe: npm tarball mode
-  // bits are not meaningful for Windows binaries.)
-  const bin = byPath.get(binName);
-  if (bin && !binName.endsWith(".exe") && (bin.mode & 0o111) === 0) {
-    problems.push(`${binName} is not executable (mode ${bin.mode.toString(8)})`);
-  }
-
-  return problems;
-}
-
 async function main(): Promise<void> {
   const dir = parseDir(process.argv.slice(2));
 
@@ -113,8 +144,8 @@ async function main(): Promise<void> {
     throw new Error(`unexpected npm pack output for ${dir}`);
   }
 
-  const binName = binaryPathFor(dir);
-  const problems = findTarballProblems(result.files, binName);
+  const expectation = expectationFor(dir);
+  const problems = findTarballProblems(result.files, expectation);
   if (problems.length > 0) {
     console.error(`✗ ${dir}: tarball is missing required content:`);
     for (const p of problems) {
@@ -123,7 +154,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  console.log(`✓ ${dir}: tarball includes ${binName}, ${REQUIRED_LICENSE_FILES.join(", ")}`);
+  console.log(`✓ ${dir}: tarball includes ${expectation.requiredFiles.join(", ")}`);
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
## Summary

Relicenses vibe from **Apache-2.0** to the **MIT License**, effective from **v3.0.0** (releases up to and including 2.x remain Apache-2.0). Rationale is laid out in #553; both external code contributors gave explicit written consent there (@7tsuno, @tainakanchu — thank you! 🙏).

Closes #553

## What changed

### License declarations
- `LICENSE` replaced with the verbatim MIT text (`Copyright (c) 2025 Kei Nakayama (kexi) and the vibe contributors`)
- All 7 `package.json` manifests, `rust/Cargo.toml` (workspace, inherited by all 4 crates), 3 Homebrew formula templates, and `flake.nix` now declare MIT
- `README.md` / `README.ja.md` / `packages/npm/README.md`: License sections rewritten with a note that v2.x was published under Apache-2.0
- `CONTRIBUTING.md`: new License section making inbound = outbound (MIT) explicit, so no future relicense ever needs another consent round
- `.claude/agents/vibe-legal-expert.md`: compatibility matrix rewritten for MIT-outbound (Apache-2.0 deps become "compatible with notice obligations"; GPL/AGPL stay CRITICAL, LGPL static-linking stays HIGH — deliberately unchanged, since MIT outbound makes copyleft contamination more dangerous, not less)

### Guardrails for the two-era boundary
- `release.yml` + `beta-release.yml`: new fail-closed assert that the LICENSE text matches the version's licensing era in **both** directions (a 2.x cut from the MIT tree fails, and a 3.x cut from a stale Apache tree fails too)
- `release.yml` + `beta-release.yml`: Formula sync now asserts `license "MIT"` after placeholder substitution, before anything is pushed to the tap
- New `packages/npm/test/license-consistency.test.ts` (19 tests): disk-scans `packages/*`, `rust/Cargo.toml`, `Formula/*.rb`, `flake.nix`, and the LICENSE body, so a future package cannot ship without a MIT declaration
- `packages/docs` is now correctly `"private": true` (unpublished site that previously had neither `private` nor a license field)

### LICENSE now ships in npm tarballs
- `stage-platform-package.ts` stages the root LICENSE into each platform package (missing LICENSE is fatal — it is a committed file, so absence always means a broken checkout); `verify-platform-tarball.ts` asserts it in the packed contents (G-3)
- `publish-npm.yml` stages LICENSE into the shim and asserts via `npm pack --dry-run --json` that npm will actually pack it
- Staged copies are gitignored — the root LICENSE stays the single canonical copy

## What deliberately did NOT change
- `THIRD-PARTY-LICENSES.md` — generated inventory of *inbound* dependency licenses; unaffected by the outbound change
- Version numbers — v3.0.0 is cut later via `release.yml`; after this merges, no 2.x release may be cut from `develop` (the new CI guard enforces this mechanically; a 2.x hotfix would need a branch from the v2 tag)
- Past releases and tags — nothing is retagged or republished

## Review
Full cycle run via `/vibe-implement`: design (architect) → design security review → implementation → code review + security audit + license audit → fix round → re-review. Final result: 0 Critical / 0 Warning across all three reviewers. The license audit independently verified the MIT text is verbatim, consent coverage is complete (no third human contributor exists in `git log --all`), and the `aws-lc-sys` non-electable `AND Apache-2.0` conjunct remains properly discharged via `THIRD-PARTY-LICENSES.md`.

Follow-ups (filed separately): appending full Apache-2.0 text for notice-bearing deps to the THIRD-PARTY generator, and adding a Debian `usr/share/doc/vibe/copyright` file to the `.deb`.

## Checks
`pnpm run check:all` passes (fmt, lint, Rust fmt+clippy+tests, npm tests 65, e2e 45, docs). `nix flake check` passes. Guards exercised locally across 15 version×license combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)