### PR TITLE
chore: bundle non-electable license texts and add Debian copyright file

### DIFF
--- a/.claude/agents/vibe-legal-expert.md
+++ b/.claude/agents/vibe-legal-expert.md
@@ -10,7 +10,7 @@ description: >-
   dependencies, updating versions, reviewing Dependabot PRs, or auditing license
   compliance.
 tools: Read, Glob, Grep, Bash, WebFetch
-model: sonnet
+model: opus
 color: yellow
 ---
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Legal documents are compared byte-for-byte, so their line endings must not
+# depend on the checkout.
+#
+# scripts/generate-third-party-licenses.ts --check compares the file it would
+# generate against the committed one, and scripts/build-deb.ts derives the .deb
+# copyright body from LICENSE. On a Windows runner with core.autocrlf=true both
+# would be checked out with CRLF, making --check report a false "stale" and the
+# generated document differ from the committed one for no real reason.
+#
+# Why not `* text=auto eol=lf` for the whole repo: nothing else here is compared
+# byte-for-byte, and a repo-wide normalization would rewrite files (including
+# test fixtures) well outside the problem this pins down.
+THIRD-PARTY-LICENSES.md text eol=lf
+LICENSE text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
         run: bun run fmt:check
       - name: Run linter
         run: bun run lint
+      # The npm-package tests (launcher shim + the release/packaging scripts)
+      # otherwise run only in publish-npm.yml, i.e. after the merge that would
+      # have broken them. This job already has pnpm install, so they gate the PR.
+      - name: Run npm package tests
+        run: pnpm run test:npm
+      # THIRD-PARTY-LICENSES.md freshness + the `ring` link guard. Needs cargo
+      # (cargo metadata / cargo tree), which setup-toolchain provides here.
+      # publish-npm.yml also runs --check, but only immediately before publish —
+      # too late to be a PR gate.
+      - name: Check third-party license notices
+        run: pnpm run check:licenses
 
   rust-linux:
     if: github.event_name == 'push' || github.base_ref == 'main'
@@ -172,6 +183,15 @@ jobs:
         run: |
           VERSION=$(bun run scripts/get-version.ts)
           bun run scripts/build-deb.ts "$VERSION" ${{ matrix.arch }} "rust/target/${{ matrix.target }}/release/vibe"
+
+      # Inspect the archive (no install, no sudo): a package that drops
+      # usr/share/doc/vibe/copyright or THIRD-PARTY-LICENSES.md still passes the
+      # smoke test below, so the contents are asserted separately.
+      - name: Verify .deb contents
+        run: |
+          set -euo pipefail
+          VERSION=$(bun run scripts/get-version.ts)
+          bun run scripts/verify-deb.ts "vibe_${VERSION}_${{ matrix.arch }}.deb"
 
       # G-11: install the freshly built .deb and run the installed binary, so a
       # broken package layout (wrong install path, missing exec bit, bad control

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,17 @@ jobs:
           chmod +x "$BINARY"
           bun run scripts/build-deb.ts "$VERSION" "$ARCH" "$BINARY"
 
+      # Inspect the archive before it becomes a release asset: the .deb must
+      # carry usr/share/doc/vibe/copyright and THIRD-PARTY-LICENSES.md, neither
+      # of which any other release check would notice missing.
+      - name: Verify .deb contents
+        env:
+          ARCH: ${{ matrix.arch }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          bun run scripts/verify-deb.ts "vibe_${VERSION}_${ARCH}.deb"
+
       - name: Upload .deb artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -3,8 +3,12 @@
 The `vibe` binary is written in Rust and statically links the crates listed
 below. Each is distributed under a permissive license (MIT, Apache-2.0, ISC,
 BSD-3-Clause, Zlib, Unlicense, CC0-1.0, Unicode-3.0, CDLA-Permissive-2.0, or a
-dual/multi-license `OR` of these). Where a crate is multi-licensed, vibe's
-distribution elects the permissive option.
+dual/multi-license `OR` of these). Where a crate is multi-licensed with `OR`,
+vibe's distribution elects the permissive option.
+
+Some crates are licensed under a top-level `AND` conjunction instead. Those
+obligations cannot be elected away, so the license and notice files those
+crates ship are reproduced in full in the appendix at the end of this file.
 
 This list is generated from `cargo metadata` over `rust/Cargo.lock` by
 `scripts/generate-third-party-licenses.ts`. It is the full dependency graph,
@@ -185,3 +189,1115 @@ every shipped binary; listing them all is intentionally conservative.
 | wit-parser | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |
 | zeroize | 1.8.2 | Apache-2.0 OR MIT |
 | zmij | 1.0.21 | MIT |
+
+## Appendix: License texts and notices for non-electable obligations
+
+Most crates above are offered under an `OR` choice, and vibe's distribution
+elects the permissive arm. The crates in this appendix are different: their
+SPDX expression is a top-level `AND` conjunction, so every conjunct binds and
+no election can shed it. Their obligations therefore travel with the shipped
+binary, and the license and notice files each crate distributes are reproduced
+below verbatim, exactly as published on crates.io.
+
+Like the table above, this appendix is drawn from the conservative full
+dependency graph, so it may reproduce notices for crates that are not linked
+into any shipped binary. Reproducing a notice is not a representation that the
+crate is present in a given build.
+
+### aws-lc-rs 1.17.0 — ISC AND (Apache-2.0 OR ISC)
+
+#### LICENSE
+
+```
+SPDX-License-Identifier: ISC AND (Apache-2.0 OR ISC)
+
+
+Apache 2.0 license
+-------------------------------------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+ISC license
+-------------------------------------
+
+
+Copyright Amazon.com, Inc. or its affiliates.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```
+
+### aws-lc-sys 0.41.0 — ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)
+
+#### LICENSE
+
+````
+AWS Libcrypto (AWS-LC)
+
+AWS-LC is a fork of BoringSSL, which is itself a fork of OpenSSL.
+Content from these and other sources retains their original licensing,
+as described below. New files from AWS-LC are made available under the Apache-2.0 license OR the ISC
+license. These licenses are reproduced at the bottom of this file.
+
+```
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 OR ISC
+```
+
+
+================================================================================
+BoringSSL
+================================================================================
+
+BoringSSL is a Google-maintained fork of OpenSSL. Historically, code
+authored by Google for BoringSSL was licensed under the ISC License.
+BoringSSL has since relicensed upstream to Apache License 2.0. Existing
+AWS-LC code originating from BoringSSL retains its ISC license, while
+newer code taken from BoringSSL is licensed under Apache License 2.0.
+
+```
+Copyright (c) 2014-2024 Google Inc.
+SPDX-License-Identifier: ISC
+```
+
+Additional individual contributions to BoringSSL-derived code are
+covered under the ISC license:
+
+  - Brian Smith (Copyright 2016)
+  - Robert Nagy (Copyright 2022)
+  - Arm Ltd (Copyright 2020)
+
+```
+Copyright (c) 2025-2026 Google Inc.
+SPDX-License-Identifier: Apache-2.0
+```
+
+================================================================================
+OpenSSL
+================================================================================
+
+Code derived from the OpenSSL project is licensed under the
+Apache License, Version 2.0.
+
+```
+Copyright (c) 1998-2011 The OpenSSL Project. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+```
+
+Some OpenSSL-derived files also carry the original SSLeay copyright:
+
+```
+Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com). All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+```
+
+Portions of OpenSSL-derived code include contributions from:
+
+  - Sun Microsystems, Inc. (Copyright 2002)
+  - Nokia (Copyright 2005)
+  - Intel Corporation (Copyright 2012-2021)
+
+These contributions are covered under the Apache-2.0 license.
+
+================================================================================
+mlkem-native
+================================================================================
+
+Code from the mlkem-native project is licensed under Apache License 2.0 or MIT or ISC.
+
+```
+Copyright (c) The mlkem-native project authors.
+SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+```
+
+================================================================================
+mldsa-native
+================================================================================
+
+Code from the mldsa-native project is licensed under Apache License 2.0 or MIT or ISC
+
+```
+Copyright (c) The mldsa-native project authors.
+SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+```
+
+================================================================================
+Third-Party Libraries (compiled into libcrypto/libssl)
+================================================================================
+
+Fiat Cryptography
+-----------------
+Synthesizing Correct-by-Construction Code for Cryptographic Primitives.
+See third_party/fiat/LICENSE.
+
+```
+Copyright (c) 2015-2020 the fiat-crypto authors.
+SPDX-License-Identifier: MIT
+```
+
+s2n-bignum
+----------
+Integer arithmetic routines for cryptography.
+See third_party/s2n-bignum/s2n-bignum-imported/LICENSE.
+
+```
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+```
+
+Note: ML-KEM/SHA3 code within s2n-bignum is licensed as
+Apache-2.0 OR ISC OR MIT (with attribution), sourced from the
+mlkem-native project.
+
+Jitter Entropy RNG
+-------------------
+CPU Jitter Random Number Generator Library.
+See third_party/jitterentropy/jitterentropy-library/LICENSE.
+
+The Jitter Entropy library is dual-licensed under a BSD-style license
+and the GNU General Public License Version 2. Amazon expressly elects
+to distribute the package under the 3-Clause BSD License and NOT under
+GNU General Public License Version 2.
+
+```
+Copyright (C) 2017 - 2025, Stephan Mueller <smueller@chronox.de>.
+SPDX-License-Identifier: BSD-3-Clause
+```
+
+Keccak / AES Reference Implementations
+---------------------------------------
+Public domain (CC0) contributions.
+https://creativecommons.org/public-domain/cc0
+
+Code from sources and by authors listed in comments on top of the respective files.
+
+
+================================================================================
+Third-Party Libraries (NOT compiled into libcrypto/libssl)
+================================================================================
+
+The following are used for testing and build tooling only. Distributing
+code linked against AWS-LC (libcrypto/libssl) does NOT trigger these
+license obligations.
+
+Google Test
+-----------
+See third_party/googletest/LICENSE.
+
+```
+Copyright 2008 Google Inc.
+SPDX-License-Identifier: BSD-3-Clause
+```
+
+Go Standard Library
+-------------------
+Code in ssl/test/runner/ is derived from the Go standard library.
+
+```
+Copyright (c) The Go Authors. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+```
+
+Wycheproof Test Vectors
+------------------------
+Project Wycheproof is a community managed repository of test vectors that can be used by cryptography library
+developers to test against known attacks, specification inconsistencies, and other various implementation bugs.
+
+See third_party/wycheproof_testvectors/LICENSE.
+
+```
+SPDX-License-Identifier: Apache-2.0
+```
+
+
+================================================================================
+Full License Texts
+================================================================================
+
+Apache License 2.0
+------------------
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+        "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+        "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+        "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+        "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+        "Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+        "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+        "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+        "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+        "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+        "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+    2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+    3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+    4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+        (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+        (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+        (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+        (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+    5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+    6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+    7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+    8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+    9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+ISC License
+-----------
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted, provided that the
+above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+MIT License
+-----------
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+BSD 3-Clause License
+--------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+MIT No Attribution (MIT-0)
+--------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+````
+
+### ring 0.17.14 — Apache-2.0 AND ISC
+
+#### LICENSE
+
+```
+*ring* uses an "ISC" license, like BoringSSL used to use, for new code
+files. See LICENSE-other-bits for the text of that license.
+
+See LICENSE-BoringSSL for code that was sourced from BoringSSL under the
+Apache 2.0 license. Some code that was sourced from BoringSSL under the ISC
+license. In each case, the license info is at the top of the file.
+
+See src/polyfill/once_cell/LICENSE-APACHE and src/polyfill/once_cell/LICENSE-MIT
+for the license to code that was sourced from the once_cell project.
+```
+
+#### LICENSE-BoringSSL
+
+```
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+Licenses for support code
+-------------------------
+
+Parts of the TLS test suite are under the Go license. This code is not included
+in BoringSSL (i.e. libcrypto and libssl) when compiled, however, so
+distributing code linked against BoringSSL does not trigger this license:
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+BoringSSL uses the Chromium test infrastructure to run a continuous build,
+trybots etc. The scripts which manage this, and the script for generating build
+metadata, are under the Chromium license. Distributing code linked against
+BoringSSL does not trigger this license.
+
+Copyright 2015 The Chromium Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+#### LICENSE-other-bits
+
+```
+Copyright 2015-2025 Brian Smith.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```
+
+### unicode-ident 1.0.24 — (MIT OR Apache-2.0) AND Unicode-3.0
+
+#### LICENSE-APACHE
+
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+```
+
+#### LICENSE-MIT
+
+```
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+#### LICENSE-UNICODE
+
+```
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2023 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+```

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ default:
 
 # --- Aggregate check ---
 
-# All checks required before opening a PR (fmt:check + lint + check:rust + test:npm + test:e2e + check:docs).
+# All checks required before opening a PR (fmt:check + lint + check:rust + check:licenses + test:npm + test:e2e + check:docs).
 check:
     pnpm run check:all
 
@@ -37,6 +37,10 @@ run *args:
 # Rust (shipped binary) — fmt + clippy + workspace tests.
 check-rust:
     pnpm run check:rust
+
+# Third-party license notices — THIRD-PARTY-LICENSES.md freshness + the ring link guard.
+check-licenses:
+    pnpm run check:licenses
 
 # Docs package checks only (lint + format + check).
 check-docs:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:rust": "cargo test --manifest-path rust/Cargo.toml --workspace",
     "build:rust": "cargo build --manifest-path rust/Cargo.toml -p vibe --release",
     "check:rust": "pnpm run fmt:rust:check && pnpm run lint:rust && pnpm run test:rust",
+    "check:licenses": "bun run scripts/generate-third-party-licenses.ts --check && bun run scripts/check-ring-unlinked.ts",
     "get-version": "node -e \"console.log(JSON.parse(require('fs').readFileSync('package.json')).version)\"",
     "bmp": "deno run --frozen --allow-env=NO_COLOR,TERM,CI,LOG_TOKENS,LOG_STREAM --allow-read=.bmp.yml,package.json,packages/npm/package.json,packages/vibe-linux-x64/package.json,packages/vibe-linux-arm64/package.json,packages/vibe-darwin-x64/package.json,packages/vibe-darwin-arm64/package.json,packages/vibe-win32-x64/package.json,rust/crates/vibe/Cargo.toml,rust/crates/vibe-core/Cargo.toml,rust/crates/vibe-test-support/Cargo.toml,pnpm-lock.yaml --allow-write=.bmp.yml,package.json,packages/npm/package.json,packages/vibe-linux-x64/package.json,packages/vibe-linux-arm64/package.json,packages/vibe-darwin-x64/package.json,packages/vibe-darwin-arm64/package.json,packages/vibe-win32-x64/package.json,rust/crates/vibe/Cargo.toml,rust/crates/vibe-core/Cargo.toml,rust/crates/vibe-test-support/Cargo.toml,pnpm-lock.yaml jsr:@kt3k/bmp@0.3.3",
     "install:all": "pnpm install",
@@ -32,7 +33,7 @@
     "test:e2e": "cargo build --manifest-path rust/Cargo.toml -p vibe && pnpm -C packages/e2e test",
     "clean": "pnpm -r exec rm -rf node_modules dist",
     "check:docs": "pnpm -C packages/docs lint && pnpm -C packages/docs format && pnpm -C packages/docs check",
-    "check:all": "pnpm run fmt:check && pnpm run lint && pnpm run check:rust && pnpm run test:npm && pnpm run test:e2e && pnpm run check:docs"
+    "check:all": "pnpm run fmt:check && pnpm run lint && pnpm run check:rust && pnpm run check:licenses && pnpm run test:npm && pnpm run test:e2e && pnpm run check:docs"
   },
   "devDependencies": {
     "@oxlint/plugins": "^1.67.0",

--- a/packages/docs/src/content/docs/installation.mdx
+++ b/packages/docs/src/content/docs/installation.mdx
@@ -118,6 +118,11 @@ WSL2 users can use the Linux installation methods below based on their distribut
     sudo apt remove vibe
     ```
 
+    The package installs its license documentation under `/usr/share/doc/vibe/`:
+    `copyright` (vibe's own MIT terms, in Debian's machine-readable DEP-5 format)
+    and `THIRD-PARTY-LICENSES.md` (the notices for the Rust crates statically
+    linked into the binary).
+
   </TabItem>
   <TabItem label="Other Distributions">
     ```bash frame="terminal"

--- a/packages/docs/src/content/docs/ja/installation.mdx
+++ b/packages/docs/src/content/docs/ja/installation.mdx
@@ -118,6 +118,11 @@ WSL2ユーザーは、使用しているディストリビューションに応�
     sudo apt remove vibe
     ```
 
+    このパッケージは、ライセンス関連のドキュメントを `/usr/share/doc/vibe/` 配下に
+    インストールします。`copyright` は vibe 自身の MIT ライセンス条項（Debian の
+    機械可読形式 DEP-5）、`THIRD-PARTY-LICENSES.md` はバイナリに静的リンクされた
+    Rust クレート群のライセンス表示です。
+
   </TabItem>
   <TabItem label="その他のディストリビューション">
     ```bash frame="terminal"

--- a/packages/npm/test/build-deb.test.ts
+++ b/packages/npm/test/build-deb.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for scripts/build-deb.ts — the .deb packaging step, specifically the
+ * documentation it installs under /usr/share/doc/vibe.
+ *
+ * A Debian binary package has no License: control field, so the machine-readable
+ * DEP-5 copyright file is the package's only statement of terms, and
+ * THIRD-PARTY-LICENSES.md is the only place the statically-linked Rust crates'
+ * notices appear. What these guarantee:
+ *   - the copyright file is valid DEP-5 1.0: the Format URI, a Files/License
+ *     stanza, and a license body reformatted with ` .` for blank lines;
+ *   - the MIT body and the copyright holder are DERIVED from the repo LICENSE,
+ *     never hardcoded, so the .deb cannot state terms the project does not ship;
+ *   - a license text DEP-5 cannot represent (a line starting with `.`) or one
+ *     with no recognizable copyright line is a hard failure, not a silently
+ *     mangled legal document;
+ *   - staging installs both documents with explicit, umask-independent modes
+ *     (0755 dir / 0644 files) and treats either source's absence as fatal —
+ *     both are committed files, so missing means a broken checkout.
+ *
+ * Runs against a temp root (the `root` option) so the real repo is never written to.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  renderDebianCopyright,
+  formatDep5Text,
+  extractCopyrightLine,
+  stageDocFiles,
+} from "../../../scripts/build-deb";
+
+const MIT_LICENSE = `MIT License
+
+Copyright (c) 2025 Kei Nakayama (kexi) and the vibe contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction.
+`;
+
+describe("extractCopyrightLine", () => {
+  it("pulls the Copyright (c) line out of the license text", () => {
+    expect(extractCopyrightLine(MIT_LICENSE)).toBe(
+      "Copyright (c) 2025 Kei Nakayama (kexi) and the vibe contributors",
+    );
+  });
+
+  it("throws when no copyright line can be found (never invents a holder)", () => {
+    expect(() => extractCopyrightLine("Some terms with no holder\n")).toThrowError(/Copyright/);
+  });
+});
+
+describe("formatDep5Text", () => {
+  it("indents non-blank lines by one space", () => {
+    expect(formatDep5Text("alpha\nbeta\n")).toBe(" alpha\n beta");
+  });
+
+  it("represents blank lines as ' .'", () => {
+    expect(formatDep5Text("alpha\n\nbeta\n")).toBe(" alpha\n .\n beta");
+  });
+
+  it("treats a whitespace-only line as blank", () => {
+    expect(formatDep5Text("alpha\n   \nbeta\n")).toBe(" alpha\n .\n beta");
+  });
+
+  it("normalizes CRLF input", () => {
+    expect(formatDep5Text("alpha\r\n\r\nbeta\r\n")).toBe(" alpha\n .\n beta");
+  });
+
+  it("throws on a line starting with '.' (DEP-5 would read it back as blank)", () => {
+    expect(() => formatDep5Text("alpha\n.hidden\n")).toThrowError(/DEP-5/);
+  });
+});
+
+describe("renderDebianCopyright", () => {
+  const out = renderDebianCopyright({ licenseText: MIT_LICENSE });
+
+  it("declares the machine-readable DEP-5 1.0 format on the first line", () => {
+    expect(out.startsWith("Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n")).toBe(
+      true,
+    );
+  });
+
+  it("identifies the upstream project and source", () => {
+    expect(out).toContain("Upstream-Name: vibe");
+    expect(out).toContain("Source: https://github.com/kexi/vibe");
+  });
+
+  it("declares Files: * under the MIT license", () => {
+    expect(out).toContain("Files: *");
+    expect(out).toMatch(/^License: MIT$/m);
+  });
+
+  it("carries the copyright holder derived from the license text", () => {
+    expect(out).toContain(
+      "Copyright: Copyright (c) 2025 Kei Nakayama (kexi) and the vibe contributors",
+    );
+  });
+
+  it("points at the third-party notices installed beside it", () => {
+    expect(out).toContain("/usr/share/doc/vibe/THIRD-PARTY-LICENSES.md");
+  });
+
+  it("reproduces the MIT body as an indented DEP-5 block", () => {
+    expect(out).toContain(" Permission is hereby granted, free of charge, to any person obtaining a copy");
+    expect(out).toContain("\n .\n");
+  });
+
+  it("propagates a license text DEP-5 cannot represent", () => {
+    expect(() => renderDebianCopyright({ licenseText: "Copyright (c) 2025 x\n.oops\n" })).toThrowError(
+      /DEP-5/,
+    );
+  });
+});
+
+describe("stageDocFiles", () => {
+  let root: string;
+  let packageDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "vibe-deb-root-"));
+    packageDir = mkdtempSync(join(tmpdir(), "vibe-deb-pkg-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(packageDir, { recursive: true, force: true });
+  });
+
+  function seedRoot(): void {
+    writeFileSync(join(root, "LICENSE"), MIT_LICENSE);
+    writeFileSync(join(root, "THIRD-PARTY-LICENSES.md"), "# Third-Party Licenses\n");
+  }
+
+  it("installs copyright and THIRD-PARTY-LICENSES.md under usr/share/doc/vibe", async () => {
+    seedRoot();
+    await stageDocFiles(packageDir, { root });
+
+    const docDir = join(packageDir, "usr", "share", "doc", "vibe");
+    expect(readFileSync(join(docDir, "copyright"), "utf-8")).toContain("Format: https://");
+    expect(readFileSync(join(docDir, "THIRD-PARTY-LICENSES.md"), "utf-8")).toBe(
+      "# Third-Party Licenses\n",
+    );
+  });
+
+  it("copies the notices verbatim (uncompressed, byte-for-byte)", async () => {
+    writeFileSync(join(root, "LICENSE"), MIT_LICENSE);
+    const notices = "# Third-Party Licenses\n\n| Crate | Version |\n| a | 1.0 |\n";
+    writeFileSync(join(root, "THIRD-PARTY-LICENSES.md"), notices);
+
+    await stageDocFiles(packageDir, { root });
+
+    const staged = join(packageDir, "usr", "share", "doc", "vibe", "THIRD-PARTY-LICENSES.md");
+    expect(readFileSync(staged, "utf-8")).toBe(notices);
+  });
+
+  it("sets explicit 0755/0644 modes so the caller's umask cannot hide the docs", async () => {
+    seedRoot();
+    await stageDocFiles(packageDir, { root });
+
+    const docDir = join(packageDir, "usr", "share", "doc", "vibe");
+    expect(statSync(docDir).mode & 0o777).toBe(0o755);
+    expect(statSync(join(docDir, "copyright")).mode & 0o777).toBe(0o644);
+    expect(statSync(join(docDir, "THIRD-PARTY-LICENSES.md")).mode & 0o777).toBe(0o644);
+  });
+
+  it("throws when the root LICENSE is missing (a committed file: a broken checkout)", async () => {
+    writeFileSync(join(root, "THIRD-PARTY-LICENSES.md"), "# notices\n");
+    await expect(stageDocFiles(packageDir, { root })).rejects.toThrowError(/LICENSE not found/);
+  });
+
+  it("throws when THIRD-PARTY-LICENSES.md is missing (a .deb must not drop crate notices)", async () => {
+    // Unlike the npm staging step, which only warns, there is no later release
+    // gate for the .deb and the file is committed rather than a build product.
+    writeFileSync(join(root, "LICENSE"), MIT_LICENSE);
+    await expect(stageDocFiles(packageDir, { root })).rejects.toThrowError(
+      /THIRD-PARTY-LICENSES\.md not found/,
+    );
+  });
+});

--- a/packages/npm/test/third-party-licenses.test.ts
+++ b/packages/npm/test/third-party-licenses.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Tests for scripts/generate-third-party-licenses.ts — the generator behind the
+ * committed THIRD-PARTY-LICENSES.md, and the guards on the committed artifact.
+ *
+ * The shipped binary statically links its Rust dependencies. Where a crate's
+ * SPDX expression is a top-level `AND`, no `OR` election can shed the
+ * obligation, so the crate's own license/notice files must be reproduced in
+ * full. What these guarantee:
+ *   - the SPDX analysis distinguishes an electable `OR` from a binding `AND`,
+ *     including the legacy `/` shorthand, parenthesized subexpressions and
+ *     `WITH` exceptions — a misparse would silently drop a required notice;
+ *   - notice discovery lists a crate's root license files deterministically and
+ *     refuses symlinks, so a crafted crate cannot inline a file from elsewhere
+ *     on the machine into a published document;
+ *   - notice text is normalized (BOM, CRLF, trailing newline) and REJECTED
+ *     rather than repaired when oversized, non-UTF-8 or control-carrying —
+ *     a truncated or sanitized license is no longer the license;
+ *   - the code fence adapts to backtick runs in the content (aws-lc-sys's
+ *     LICENSE really does contain a ``` run, which a fixed fence would break);
+ *   - the committed THIRD-PARTY-LICENSES.md actually carries the Apache-2.0
+ *     text and an appendix section for every top-level-AND row in its table.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, symlinkSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  normalizeSpdx,
+  parseSpdx,
+  hasNonElectableObligation,
+  discoverNoticeFiles,
+  normalizeNoticeText,
+  renderNoticeAppendix,
+  fenceFor,
+} from "../../../scripts/generate-third-party-licenses";
+
+// Repo root: packages/npm/test -> ../../..
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+
+describe("normalizeSpdx", () => {
+  it("rewrites the legacy slash shorthand as an OR choice", () => {
+    expect(normalizeSpdx("MIT/Apache-2.0")).toBe("MIT OR Apache-2.0");
+  });
+
+  it("collapses redundant whitespace", () => {
+    expect(normalizeSpdx("  MIT   OR   Apache-2.0 ")).toBe("MIT OR Apache-2.0");
+  });
+
+  it("leaves a modern expression unchanged", () => {
+    expect(normalizeSpdx("ISC AND (Apache-2.0 OR ISC)")).toBe("ISC AND (Apache-2.0 OR ISC)");
+  });
+});
+
+describe("parseSpdx", () => {
+  it("parses a bare license as an atom", () => {
+    expect(parseSpdx("MIT")).toEqual({ kind: "license", id: "MIT" });
+  });
+
+  it("binds AND tighter than OR", () => {
+    // `A OR B AND C` must be A OR (B AND C), so the root is a disjunction.
+    const node = parseSpdx("MIT OR Apache-2.0 AND ISC");
+    expect(node.kind).toBe("or");
+  });
+
+  it("treats a WITH exception as a single atom", () => {
+    expect(parseSpdx("Apache-2.0 WITH LLVM-exception")).toEqual({
+      kind: "license",
+      id: "Apache-2.0 WITH LLVM-exception",
+    });
+  });
+
+  it("respects parentheses over natural precedence", () => {
+    const node = parseSpdx("(MIT OR Apache-2.0) AND Unicode-3.0");
+    expect(node.kind).toBe("and");
+  });
+
+  it("parses nested parentheses", () => {
+    const node = parseSpdx("A AND (B OR (C AND D))");
+    expect(node).toEqual({
+      kind: "and",
+      operands: [
+        { kind: "license", id: "A" },
+        {
+          kind: "or",
+          operands: [
+            { kind: "license", id: "B" },
+            {
+              kind: "and",
+              operands: [
+                { kind: "license", id: "C" },
+                { kind: "license", id: "D" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("rejects an unbalanced parenthesis", () => {
+    expect(() => parseSpdx("(MIT OR Apache-2.0")).toThrowError(/unbalanced/);
+  });
+});
+
+describe("hasNonElectableObligation", () => {
+  it("returns false for a plain OR choice", () => {
+    expect(hasNonElectableObligation("MIT OR Apache-2.0")).toBe(false);
+  });
+
+  it("returns false for the legacy slash shorthand", () => {
+    expect(hasNonElectableObligation("Unlicense/MIT")).toBe(false);
+  });
+
+  it("returns false for a single license", () => {
+    expect(hasNonElectableObligation("MIT")).toBe(false);
+  });
+
+  it("returns true for aws-lc-rs's conjunction", () => {
+    expect(hasNonElectableObligation("ISC AND (Apache-2.0 OR ISC)")).toBe(true);
+  });
+
+  it("returns true for aws-lc-sys's full expression", () => {
+    const expr =
+      "ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND " +
+      "(Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)";
+    expect(hasNonElectableObligation(expr)).toBe(true);
+  });
+
+  it("returns true for ring's conjunction", () => {
+    expect(hasNonElectableObligation("Apache-2.0 AND ISC")).toBe(true);
+  });
+
+  it("returns true for unicode-ident's parenthesized OR conjoined with Unicode-3.0", () => {
+    expect(hasNonElectableObligation("(MIT OR Apache-2.0) AND Unicode-3.0")).toBe(true);
+  });
+
+  it("returns false when an AND is nested under a top-level OR (the OR is still electable)", () => {
+    expect(hasNonElectableObligation("MIT OR (Apache-2.0 AND ISC)")).toBe(false);
+  });
+
+  it("handles a WITH exception inside a conjunction", () => {
+    expect(hasNonElectableObligation("Apache-2.0 WITH LLVM-exception AND MIT")).toBe(true);
+  });
+});
+
+describe("discoverNoticeFiles", () => {
+  let crateDir: string;
+
+  beforeEach(() => {
+    crateDir = mkdtempSync(join(tmpdir(), "vibe-notice-"));
+  });
+
+  afterEach(() => {
+    rmSync(crateDir, { recursive: true, force: true });
+  });
+
+  it("lists matching root files sorted by name", async () => {
+    writeFileSync(join(crateDir, "LICENSE-MIT"), "mit");
+    writeFileSync(join(crateDir, "LICENSE-APACHE"), "apache");
+    writeFileSync(join(crateDir, "NOTICE"), "notice");
+    writeFileSync(join(crateDir, "COPYING"), "copying");
+
+    expect(await discoverNoticeFiles(crateDir)).toEqual([
+      "COPYING",
+      "LICENSE-APACHE",
+      "LICENSE-MIT",
+      "NOTICE",
+    ]);
+  });
+
+  it("ignores files that are not license notices", async () => {
+    writeFileSync(join(crateDir, "LICENSE"), "terms");
+    writeFileSync(join(crateDir, "Cargo.toml"), "[package]");
+    writeFileSync(join(crateDir, "README.md"), "# readme");
+
+    expect(await discoverNoticeFiles(crateDir)).toEqual(["LICENSE"]);
+  });
+
+  it("excludes a symlink rather than following it out of the crate", async () => {
+    // A crate that points LICENSE at a file elsewhere on the machine would
+    // otherwise have that file's contents inlined into a published document.
+    const outside = mkdtempSync(join(tmpdir(), "vibe-outside-"));
+    const secret = join(outside, "secret");
+    writeFileSync(secret, "SECRET");
+    writeFileSync(join(crateDir, "LICENSE"), "real terms");
+    symlinkSync(secret, join(crateDir, "LICENSE-EVIL"));
+
+    expect(await discoverNoticeFiles(crateDir)).toEqual(["LICENSE"]);
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("excludes a directory that matches the notice name pattern", async () => {
+    mkdirSync(join(crateDir, "LICENSES"));
+    writeFileSync(join(crateDir, "LICENSE"), "terms");
+
+    expect(await discoverNoticeFiles(crateDir)).toEqual(["LICENSE"]);
+  });
+
+  it("returns nothing for a crate that ships no notices", async () => {
+    writeFileSync(join(crateDir, "Cargo.toml"), "[package]");
+    expect(await discoverNoticeFiles(crateDir)).toEqual([]);
+  });
+});
+
+describe("normalizeNoticeText", () => {
+  it("converts CRLF to LF", () => {
+    expect(normalizeNoticeText(Buffer.from("a\r\nb\r\n"), "x/LICENSE")).toBe("a\nb\n");
+  });
+
+  it("strips a leading BOM", () => {
+    expect(normalizeNoticeText(Buffer.from("\ufeffMIT License\n"), "x/LICENSE")).toBe(
+      "MIT License\n",
+    );
+  });
+
+  it("collapses trailing newlines to exactly one", () => {
+    expect(normalizeNoticeText(Buffer.from("terms\n\n\n"), "x/LICENSE")).toBe("terms\n");
+  });
+
+  it("appends a trailing newline when the file lacks one", () => {
+    expect(normalizeNoticeText(Buffer.from("terms"), "x/LICENSE")).toBe("terms\n");
+  });
+
+  it("preserves tabs and interior blank lines", () => {
+    expect(normalizeNoticeText(Buffer.from("a\n\n\tb\n"), "x/LICENSE")).toBe("a\n\n\tb\n");
+  });
+
+  it("rejects a file over the 1 MiB limit instead of truncating it", () => {
+    const oversized = Buffer.alloc(1024 * 1024 + 1, 0x41);
+    expect(() => normalizeNoticeText(oversized, "big/LICENSE")).toThrowError(/over the/);
+  });
+
+  it("accepts a file exactly at the limit", () => {
+    const exact = Buffer.alloc(1024 * 1024, 0x41);
+    expect(normalizeNoticeText(exact, "big/LICENSE")).toHaveLength(1024 * 1024 + 1);
+  });
+
+  it("rejects invalid UTF-8", () => {
+    expect(() => normalizeNoticeText(Buffer.from([0xff, 0xfe, 0x00]), "bad/LICENSE")).toThrowError(
+      /not valid UTF-8/,
+    );
+  });
+
+  it("rejects control characters rather than sanitizing them", () => {
+    expect(() => normalizeNoticeText(Buffer.from("a\u0007b"), "bad/LICENSE")).toThrowError(
+      /control characters/,
+    );
+  });
+
+  it("rejects an ANSI escape sequence", () => {
+    expect(() => normalizeNoticeText(Buffer.from("\u001b[31mred"), "bad/LICENSE")).toThrowError(
+      /control characters/,
+    );
+  });
+
+  it("names the crate and file but never echoes the content", () => {
+    const attempt = () => normalizeNoticeText(Buffer.from("secret\u0007payload"), "evil/LICENSE");
+    expect(attempt).toThrowError(/evil\/LICENSE/);
+    expect(attempt).not.toThrowError(/secret/);
+  });
+});
+
+describe("fenceFor", () => {
+  it("uses three backticks for content with none", () => {
+    expect(fenceFor("plain text\n")).toBe("```");
+  });
+
+  it("outgrows the longest backtick run in the content", () => {
+    expect(fenceFor("see ``` fenced\n")).toBe("````");
+    expect(fenceFor("see ````` fenced\n")).toBe("``````");
+  });
+
+  it("counts a run that appears mid-line, not only at line start", () => {
+    expect(fenceFor("prefix ```` suffix\n")).toBe("`````");
+  });
+});
+
+describe("renderNoticeAppendix", () => {
+  it("renders a heading per crate and per file", () => {
+    const out = renderNoticeAppendix([
+      {
+        name: "demo",
+        version: "1.0.0",
+        license: "Apache-2.0 AND ISC",
+        files: [
+          { name: "LICENSE", text: "terms\n" },
+          { name: "NOTICE", text: "notice\n" },
+        ],
+      },
+    ]);
+
+    expect(out).toContain("## Appendix: License texts and notices for non-electable obligations");
+    expect(out).toContain("### demo 1.0.0 — Apache-2.0 AND ISC");
+    expect(out).toContain("#### LICENSE");
+    expect(out).toContain("#### NOTICE");
+  });
+
+  it("widens the fence when a notice itself contains a triple backtick", () => {
+    // aws-lc-sys's real LICENSE contains a ``` run; a fixed three-backtick
+    // fence would end the block early and corrupt the reproduced text.
+    const out = renderNoticeAppendix([
+      {
+        name: "fencey",
+        version: "0.1.0",
+        license: "Apache-2.0 AND ISC",
+        files: [{ name: "LICENSE", text: "before\n```\ninside\n```\nafter\n" }],
+      },
+    ]);
+
+    expect(out).toContain("````\nbefore\n```\ninside\n```\nafter\n````");
+  });
+
+  it("keeps the crate order it is given", () => {
+    const out = renderNoticeAppendix([
+      { name: "alpha", version: "1.0.0", license: "A AND B", files: [{ name: "L", text: "a\n" }] },
+      { name: "beta", version: "2.0.0", license: "A AND B", files: [{ name: "L", text: "b\n" }] },
+    ]);
+    expect(out.indexOf("### alpha")).toBeLessThan(out.indexOf("### beta"));
+  });
+});
+
+describe("committed THIRD-PARTY-LICENSES.md", () => {
+  const doc = readFileSync(join(REPO_ROOT, "THIRD-PARTY-LICENSES.md"), "utf-8");
+
+  it("reproduces the Apache-2.0 body in full", () => {
+    // Both ends of the license, so a truncated reproduction fails too.
+    expect(doc).toContain("TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION");
+    expect(doc).toContain("END OF TERMS AND CONDITIONS");
+  });
+
+  it("carries the appendix section", () => {
+    expect(doc).toContain("## Appendix: License texts and notices for non-electable obligations");
+  });
+
+  it("has an appendix heading for every top-level-AND row in the crate table", () => {
+    // Drives off the committed table rather than a hardcoded crate list, so a
+    // newly added AND-licensed dependency without a reproduced notice fails.
+    const rows = [...doc.matchAll(/^\| (\S+) \| (\S+) \| (.+?) \|$/gm)]
+      .filter(([, name]) => name !== "Crate" && !name.startsWith("-"))
+      .map(([, name, version, license]) => ({ name, version, license }));
+    expect(rows.length).toBeGreaterThan(0);
+
+    const obligated = rows.filter((r) => hasNonElectableObligation(r.license));
+    expect(obligated.length).toBeGreaterThan(0);
+
+    const missing = obligated
+      .filter((r) => !doc.includes(`### ${r.name} ${r.version} — ${r.license}`))
+      .map((r) => `${r.name} ${r.version}`);
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/npm/test/verify-deb.test.ts
+++ b/packages/npm/test/verify-deb.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for scripts/verify-deb.ts — asserts that a built .deb ships the binary
+ * and the documentation Debian expects: usr/bin/vibe (a regular, executable
+ * file), the DEP-5 usr/share/doc/vibe/copyright, and THIRD-PARTY-LICENSES.md
+ * for the statically-linked Rust crates. None of these is visible from a smoke
+ * test of the installed binary, so a package that drops them would otherwise
+ * ship silently.
+ *
+ * Only the pure parsing/validation is unit-tested here; the `dpkg-deb`
+ * invocation that feeds it is exercised by the CI build-deb steps (it needs a
+ * real archive, and dpkg-deb does not exist on macOS dev machines).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseDebContents,
+  isRegularFile,
+  isExecutable,
+  findContentProblems,
+  findMarkerProblems,
+  resolveDebPath,
+} from "../../../scripts/verify-deb";
+
+/** A well-formed `dpkg-deb --contents` listing for a correct package. */
+const GOOD_CONTENTS = `drwxr-xr-x root/root         0 2025-01-01 00:00 ./
+drwxr-xr-x root/root         0 2025-01-01 00:00 ./usr/
+drwxr-xr-x root/root         0 2025-01-01 00:00 ./usr/bin/
+-rwxr-xr-x root/root   5242880 2025-01-01 00:00 ./usr/bin/vibe
+drwxr-xr-x root/root         0 2025-01-01 00:00 ./usr/share/doc/vibe/
+-rw-r--r-- root/root      1234 2025-01-01 00:00 ./usr/share/doc/vibe/copyright
+-rw-r--r-- root/root    999999 2025-01-01 00:00 ./usr/share/doc/vibe/THIRD-PARTY-LICENSES.md
+`;
+
+function entriesOf(contents: string) {
+  return parseDebContents(contents);
+}
+
+describe("parseDebContents", () => {
+  it("extracts every member with its mode, stripping the leading ./", () => {
+    const entries = entriesOf(GOOD_CONTENTS);
+    expect(entries).toHaveLength(7);
+    expect(entries).toContainEqual({ path: "usr/bin/vibe", mode: "-rwxr-xr-x" });
+    expect(entries).toContainEqual({
+      path: "usr/share/doc/vibe/copyright",
+      mode: "-rw-r--r--",
+    });
+  });
+
+  it("keeps a path that contains spaces intact", () => {
+    // Taking the last whitespace-separated field would truncate this to "name"
+    // and report the real member as missing.
+    const entries = entriesOf(
+      "-rw-r--r-- root/root  10 2025-01-01 00:00 ./usr/share/doc/vibe/a file with name\n",
+    );
+    expect(entries).toEqual([
+      { path: "usr/share/doc/vibe/a file with name", mode: "-rw-r--r--" },
+    ]);
+  });
+
+  it("records a symlink under its own name, not its target", () => {
+    const entries = entriesOf(
+      "lrwxrwxrwx root/root  0 2025-01-01 00:00 ./usr/share/doc/vibe/copyright -> ../shared/copyright\n",
+    );
+    expect(entries).toEqual([
+      { path: "usr/share/doc/vibe/copyright", mode: "lrwxrwxrwx" },
+    ]);
+  });
+
+  it("ignores blank lines and lines with too few fields", () => {
+    expect(entriesOf("\n   \ngarbage\n")).toEqual([]);
+  });
+});
+
+describe("isRegularFile", () => {
+  it("accepts a regular file and rejects directories and symlinks", () => {
+    expect(isRegularFile("-rw-r--r--")).toBe(true);
+    expect(isRegularFile("drwxr-xr-x")).toBe(false);
+    expect(isRegularFile("lrwxrwxrwx")).toBe(false);
+  });
+});
+
+describe("isExecutable", () => {
+  it("detects an execute bit in the permission triples", () => {
+    expect(isExecutable("-rwxr-xr-x")).toBe(true);
+    expect(isExecutable("-rw-r--r--")).toBe(false);
+  });
+
+  it("ignores the file-type character so a directory is not 'executable' by its d", () => {
+    // Why this matters: the type char is not a permission bit, and reading it as
+    // one made every directory look like an executable file.
+    expect(isExecutable("drw-r--r--")).toBe(false);
+  });
+});
+
+describe("findContentProblems", () => {
+  it("reports no problems for a complete, correct package", () => {
+    expect(findContentProblems(entriesOf(GOOD_CONTENTS))).toEqual([]);
+  });
+
+  it("reports a missing copyright file", () => {
+    const entries = entriesOf(GOOD_CONTENTS).filter((e) => !e.path.endsWith("/copyright"));
+    expect(findContentProblems(entries)).toEqual([
+      "missing required file: usr/share/doc/vibe/copyright",
+    ]);
+  });
+
+  it("reports a missing THIRD-PARTY-LICENSES.md", () => {
+    const entries = entriesOf(GOOD_CONTENTS).filter(
+      (e) => !e.path.endsWith("THIRD-PARTY-LICENSES.md"),
+    );
+    expect(findContentProblems(entries)).toEqual([
+      "missing required file: usr/share/doc/vibe/THIRD-PARTY-LICENSES.md",
+    ]);
+  });
+
+  it("reports a missing binary", () => {
+    const entries = entriesOf(GOOD_CONTENTS).filter((e) => e.path !== "usr/bin/vibe");
+    expect(findContentProblems(entries)).toEqual(["missing required file: usr/bin/vibe"]);
+  });
+
+  it("reports a binary that carries no execute bit", () => {
+    const entries = entriesOf(GOOD_CONTENTS).map((e) =>
+      e.path === "usr/bin/vibe" ? { ...e, mode: "-rw-r--r--" } : e,
+    );
+    expect(findContentProblems(entries)).toEqual([
+      "usr/bin/vibe is not executable (mode -rw-r--r--)",
+    ]);
+  });
+
+  it("rejects a directory occupying the binary's path", () => {
+    // A bare presence check would accept this and call the package valid.
+    const entries = entriesOf(GOOD_CONTENTS).map((e) =>
+      e.path === "usr/bin/vibe" ? { ...e, mode: "drwxr-xr-x" } : e,
+    );
+    expect(findContentProblems(entries)).toEqual([
+      "usr/bin/vibe is not a regular file (mode drwxr-xr-x)",
+    ]);
+  });
+
+  it("rejects a copyright symlink (its target need not ship in the package)", () => {
+    const entries = entriesOf(GOOD_CONTENTS).map((e) =>
+      e.path.endsWith("/copyright") ? { ...e, mode: "lrwxrwxrwx" } : e,
+    );
+    expect(findContentProblems(entries)).toEqual([
+      "usr/share/doc/vibe/copyright is not a regular file (mode lrwxrwxrwx)",
+    ]);
+  });
+
+  it("reports every problem at once rather than stopping at the first", () => {
+    expect(findContentProblems([])).toHaveLength(3);
+  });
+});
+
+describe("findMarkerProblems", () => {
+  it("returns nothing when every marker is present", () => {
+    expect(findMarkerProblems("copyright", "Format: x\nLicense: MIT\n", ["Format: x", "License: MIT"]))
+      .toEqual([]);
+  });
+
+  it("names each absent marker", () => {
+    expect(findMarkerProblems("copyright", "License: MIT", ["Format: x", "License: MIT"])).toEqual([
+      "copyright does not contain: Format: x",
+    ]);
+  });
+});
+
+describe("resolveDebPath", () => {
+  const cwd = "/work";
+
+  it("resolves a relative path inside the working directory", () => {
+    expect(resolveDebPath("vibe_1.0.0_amd64.deb", cwd)).toBe("/work/vibe_1.0.0_amd64.deb");
+  });
+
+  it("allows a nested path under the working directory", () => {
+    expect(resolveDebPath("dist/vibe_1.0.0_amd64.deb", cwd)).toBe("/work/dist/vibe_1.0.0_amd64.deb");
+  });
+
+  it("rejects an absolute path outside the working directory", () => {
+    expect(() => resolveDebPath("/etc/passwd", cwd)).toThrowError(/inside the working directory/);
+  });
+
+  it("rejects a parent-directory escape", () => {
+    expect(() => resolveDebPath("../outside.deb", cwd)).toThrowError(
+      /inside the working directory/,
+    );
+  });
+
+  it("rejects an escape hidden mid-path", () => {
+    expect(() => resolveDebPath("dist/../../outside.deb", cwd)).toThrowError(
+      /inside the working directory/,
+    );
+  });
+
+  it("rejects the working directory itself (empty and '.')", () => {
+    // Neither names a .deb file; accepting them would hand a directory to dpkg.
+    expect(() => resolveDebPath("", cwd)).toThrowError(/inside the working directory/);
+    expect(() => resolveDebPath(".", cwd)).toThrowError(/inside the working directory/);
+  });
+});

--- a/scripts/build-deb.ts
+++ b/scripts/build-deb.ts
@@ -1,16 +1,33 @@
+#!/usr/bin/env bun
+
 /**
  * Build .deb packages for Ubuntu/Debian
  * Usage: bun run scripts/build-deb.ts <version> <arch> <binary-path>
  * Example: bun run scripts/build-deb.ts 0.1.5 amd64 vibe-linux-x64
+ *
+ * Besides /usr/bin/vibe the package installs the documentation Debian expects a
+ * binary package to carry: a machine-readable DEP-5 copyright file derived from
+ * the repo's own LICENSE, and THIRD-PARTY-LICENSES.md for the Rust crates the
+ * binary statically links.
  */
 
-import { mkdir, copyFile, writeFile, chmod, rm, stat } from "node:fs/promises";
+import { mkdir, copyFile, writeFile, chmod, rm, stat, readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
+import { join } from "node:path";
+
+const DOC_DIR = "usr/share/doc/vibe";
+const THIRD_PARTY_LICENSE_FILE = "THIRD-PARTY-LICENSES.md";
+const PROJECT_LICENSE_FILE = "LICENSE";
 
 interface DebConfig {
   version: string;
   arch: string; // amd64 or arm64
   binaryPath: string;
+}
+
+export interface BuildOptions {
+  /** Repo root that LICENSE and THIRD-PARTY-LICENSES.md resolve under. */
+  root?: string;
 }
 
 async function runCommand(cmd: string, args: string[]): Promise<{ success: boolean }> {
@@ -19,13 +36,145 @@ async function runCommand(cmd: string, args: string[]): Promise<{ success: boole
       stdio: "inherit",
     });
 
+    // Why handle "error" and not only "close": a spawn failure (dpkg-deb absent
+    // from PATH) emits "error" and never "close", so without this the promise
+    // never settles and the build hangs instead of reporting a missing tool.
+    proc.on("error", (err: Error) => {
+      console.error(`${cmd}: ${err.message}`);
+      resolve({ success: false });
+    });
+
     proc.on("close", (code) => {
       resolve({ success: code === 0 });
     });
   });
 }
 
-async function createDebPackage(config: DebConfig): Promise<void> {
+/**
+ * Reformat a license body as a DEP-5 formatted-text field value: blank lines
+ * become ` .` and every other line is indented by one space, so the whole block
+ * is a single continued field.
+ *
+ * Throws on a non-blank line that already starts with `.`: DEP-5 reads ` .` as
+ * an escaped empty line, so such a line would silently come back out of the
+ * file as a blank one, corrupting the reproduced license text.
+ */
+export function formatDep5Text(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/\n+$/, "")
+    .split("\n")
+    .map((line) => {
+      const isBlank = line.trim() === "";
+      if (isBlank) {
+        return " .";
+      }
+      if (line.startsWith(".")) {
+        throw new Error(
+          "license text has a line starting with '.', which DEP-5 continuation syntax cannot represent",
+        );
+      }
+      return ` ${line}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Pull the upstream copyright holder line out of the license text.
+ * Throws rather than defaulting: a wrong or invented holder in a legal document
+ * is worse than a failed build.
+ */
+export function extractCopyrightLine(licenseText: string): string {
+  const match = licenseText.match(/^\s*(Copyright \(c\).*)$/m);
+  if (!match) {
+    throw new Error(`no "Copyright (c)" line found in ${PROJECT_LICENSE_FILE}`);
+  }
+  return match[1].trim();
+}
+
+export interface CopyrightOptions {
+  /** The project's own LICENSE text (MIT), used verbatim for the License stanza. */
+  licenseText: string;
+}
+
+/**
+ * Render `usr/share/doc/vibe/copyright` in machine-readable DEP-5 1.0 format.
+ * The MIT body is derived from the repo LICENSE rather than hardcoded, so the
+ * .deb can never state terms that differ from the ones actually shipped.
+ */
+export function renderDebianCopyright({ licenseText }: CopyrightOptions): string {
+  const copyright = extractCopyrightLine(licenseText);
+  const body = formatDep5Text(licenseText);
+
+  return `Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: vibe
+Upstream-Contact: kexi <https://github.com/kexi>
+Source: https://github.com/kexi/vibe
+
+Files: *
+Copyright: ${copyright}
+License: MIT
+Comment: The vibe binary statically links third-party Rust crates.
+ Their license notices are installed alongside this file as
+ /usr/share/doc/vibe/${THIRD_PARTY_LICENSE_FILE}.
+
+License: MIT
+${body}
+`;
+}
+
+async function readRequired(path: string, what: string): Promise<string> {
+  const exists = await stat(path).then(
+    (s) => s.isFile(),
+    () => false,
+  );
+  if (!exists) {
+    throw new Error(`${what} not found: ${path}`);
+  }
+  return readFile(path, "utf-8");
+}
+
+/**
+ * Populate `<packageDir>/usr/share/doc/vibe/` with the DEP-5 copyright file and
+ * THIRD-PARTY-LICENSES.md, with modes set explicitly (0755 dir, 0644 files) so
+ * the caller's umask cannot produce an unreadable installed document.
+ *
+ * Both sources are required. Why not warn on a missing THIRD-PARTY-LICENSES.md
+ * the way stage-platform-package.ts does: there the file is a build product a
+ * developer may not have generated yet, and the tarball verifier is the release
+ * gate. Here it is a committed file, so its absence means a broken checkout —
+ * and unlike an npm tarball, a .deb that installs no notices is a distribution
+ * that silently drops the crates' terms.
+ *
+ * The files are installed uncompressed: `dpkg-deb` does not gzip them, and
+ * `copyright` must stay plain text for the archive tooling that reads it.
+ */
+export async function stageDocFiles(packageDir: string, options: BuildOptions = {}): Promise<void> {
+  const root = options.root ?? ".";
+
+  const licenseText = await readRequired(join(root, PROJECT_LICENSE_FILE), PROJECT_LICENSE_FILE);
+  const notices = await readRequired(
+    join(root, THIRD_PARTY_LICENSE_FILE),
+    THIRD_PARTY_LICENSE_FILE,
+  );
+
+  const docDir = join(packageDir, DOC_DIR);
+  await mkdir(docDir, { recursive: true });
+  await chmod(docDir, 0o755);
+
+  const copyrightPath = join(docDir, "copyright");
+  await writeFile(copyrightPath, renderDebianCopyright({ licenseText }), "utf-8");
+  await chmod(copyrightPath, 0o644);
+
+  const noticesPath = join(docDir, THIRD_PARTY_LICENSE_FILE);
+  await writeFile(noticesPath, notices, "utf-8");
+  await chmod(noticesPath, 0o644);
+}
+
+export async function createDebPackage(
+  config: DebConfig,
+  options: BuildOptions = {},
+): Promise<void> {
   const { version, arch, binaryPath } = config;
   const packageName = `vibe_${version}_${arch}`;
   const packageDir = packageName;
@@ -41,7 +190,11 @@ async function createDebPackage(config: DebConfig): Promise<void> {
     // Set executable permissions
     await chmod(`${packageDir}/usr/bin/vibe`, 0o755);
 
-    // Create control file
+    await stageDocFiles(packageDir, options);
+
+    // Create control file. Why no License: field: the Debian binary package
+    // control format has none — the terms live in usr/share/doc/vibe/copyright,
+    // and an unknown field would make the package fail lintian/policy checks.
     const controlContent = `Package: vibe
 Version: ${version}
 Architecture: ${arch}
@@ -108,4 +261,11 @@ async function main(): Promise<void> {
   await createDebPackage({ version, arch, binaryPath });
 }
 
-main();
+// Only run the CLI when executed directly (bun sets import.meta.main); under
+// vitest import.meta.main is undefined, so importing for tests is side-effect free.
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(`build-deb: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/scripts/check-ring-unlinked.ts
+++ b/scripts/check-ring-unlinked.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env bun
+
+/**
+ * Assert that no crate in the workspace actually depends on `ring`.
+ *
+ * vibe's TLS stack elects aws-lc-rs; `ring` appears in `cargo metadata`'s
+ * conservative full graph (it is an optional/alternative backend that nothing
+ * selects) but must never end up linked into the shipped binary. `cargo tree -i`
+ * inverts the graph and prints the dependents of a package, so an empty result
+ * ("nothing to print") is the proof that the link never happens.
+ *
+ * Why this is a separate check rather than an assertion about
+ * THIRD-PARTY-LICENSES.md: `ring` is licensed `Apache-2.0 AND ISC`, so it now
+ * legitimately appears in that file's notice appendix. Its presence there says
+ * only that the conservative crate list contains it — it is no longer evidence
+ * either way about linkage, and reading it as such would silently retire the
+ * signal this check exists to provide.
+ *
+ * Usage:
+ *   bun run scripts/check-ring-unlinked.ts
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const FORBIDDEN_CRATE = "ring";
+const MANIFEST = "rust/Cargo.toml";
+
+/**
+ * True when `cargo tree -i` reported no dependents. cargo prints the
+ * "nothing to print" notice on stderr and leaves stdout empty; a real dependent
+ * would be a tree on stdout.
+ */
+export function hasNoDependents(stdout: string): boolean {
+  return stdout.trim() === "";
+}
+
+async function main(): Promise<void> {
+  const { stdout } = await execFileAsync("cargo", [
+    "tree",
+    "-i",
+    FORBIDDEN_CRATE,
+    "--manifest-path",
+    MANIFEST,
+  ]);
+
+  if (!hasNoDependents(stdout)) {
+    console.error(
+      `✗ ${FORBIDDEN_CRATE} is reachable from the workspace; vibe's TLS stack must stay on aws-lc-rs:`,
+    );
+    console.error(stdout.trimEnd());
+    process.exit(1);
+  }
+
+  console.log(`✓ ${FORBIDDEN_CRATE} has no dependents in the workspace (not linked).`);
+}
+
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(`check-ring-unlinked: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/scripts/generate-third-party-licenses.ts
+++ b/scripts/generate-third-party-licenses.ts
@@ -10,6 +10,11 @@
  * `cargo metadata` (already available) and rendered to a checked-in Markdown
  * file that the per-platform npm packages ship via their `files` list.
  *
+ * Crates whose SPDX expression is a top-level `AND` conjunction impose
+ * obligations that cannot be side-stepped by electing one arm of an `OR`
+ * (Apache-2.0's §4 notice requirement, most notably). For those the appendix
+ * reproduces the crate's own LICENSE/NOTICE files verbatim.
+ *
  * Usage:
  *   bun run scripts/generate-third-party-licenses.ts          # write the file
  *   bun run scripts/generate-third-party-licenses.ts --check  # fail if stale
@@ -17,25 +22,345 @@
  * Run this whenever rust/Cargo.lock changes (a dependency add/remove/bump).
  */
 
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, readdir, writeFile, lstat, realpath } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { dirname, join, relative, isAbsolute } from "node:path";
 
 const execFileAsync = promisify(execFile);
 
 const OUTPUT = "THIRD-PARTY-LICENSES.md";
 const OWN_CRATES = new Set(["vibe", "vibe-core", "vibe-native", "vibe-test-support"]);
 
+/** Names a crate may use for a shipped license/notice file, at its root only. */
+const NOTICE_FILE_PATTERN = /^(LICENSE|LICENCE|NOTICE|COPYING)([-._].*)?$/i;
+
+/** Per-file ceiling for a reproduced notice. */
+const MAX_NOTICE_BYTES = 1024 * 1024;
+
 interface CargoPackage {
   name: string;
   version: string;
   license: string | null;
   license_file: string | null;
+  manifest_path: string;
 }
 
 interface CargoMetadata {
   packages: CargoPackage[];
 }
+
+/** A crate's reproduced notice file: its basename and normalized UTF-8 text. */
+export interface NoticeFile {
+  name: string;
+  text: string;
+}
+
+/** One appendix entry: a crate with a non-electable obligation, plus its notices. */
+export interface NoticeEntry {
+  name: string;
+  version: string;
+  license: string;
+  files: NoticeFile[];
+}
+
+// --- SPDX ------------------------------------------------------------------
+
+/**
+ * Normalize the deprecated `/` shorthand (`MIT/Apache-2.0`) into ` OR `.
+ * crates.io still carries these in older manifests, and the parser below only
+ * understands the modern operators.
+ */
+export function normalizeSpdx(expr: string): string {
+  return expr.replace(/\//g, " OR ").replace(/\s+/g, " ").trim();
+}
+
+/** A parsed SPDX expression: a license atom or a binary conjunction/disjunction. */
+export type SpdxNode =
+  | { kind: "license"; id: string }
+  | { kind: "and"; operands: SpdxNode[] }
+  | { kind: "or"; operands: SpdxNode[] };
+
+function tokenizeSpdx(expr: string): string[] {
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < expr.length) {
+    const ch = expr[i];
+    if (ch === " ") {
+      i++;
+      continue;
+    }
+    if (ch === "(" || ch === ")") {
+      tokens.push(ch);
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j < expr.length && expr[j] !== " " && expr[j] !== "(" && expr[j] !== ")") {
+      j++;
+    }
+    tokens.push(expr.slice(i, j));
+    i = j;
+  }
+  return tokens;
+}
+
+/**
+ * Minimal recursive-descent SPDX parser. Precedence is WITH > AND > OR, per the
+ * SPDX license-expression grammar; `<id> WITH <exception>` is folded into a
+ * single atom because the exception never changes which obligations apply.
+ */
+export function parseSpdx(expr: string): SpdxNode {
+  const tokens = tokenizeSpdx(normalizeSpdx(expr));
+  let pos = 0;
+
+  const peek = (): string | undefined => tokens[pos];
+  const isOperator = (token: string | undefined, name: string): boolean =>
+    token !== undefined && token.toUpperCase() === name;
+
+  function parseAtom(): SpdxNode {
+    const token = peek();
+    if (token === undefined) {
+      throw new Error(`unexpected end of SPDX expression: ${expr}`);
+    }
+    if (token === "(") {
+      pos++;
+      const inner = parseOr();
+      if (peek() !== ")") {
+        throw new Error(`unbalanced parenthesis in SPDX expression: ${expr}`);
+      }
+      pos++;
+      return inner;
+    }
+    if (token === ")") {
+      throw new Error(`unexpected ')' in SPDX expression: ${expr}`);
+    }
+    pos++;
+    let id = token;
+    if (isOperator(peek(), "WITH")) {
+      pos++;
+      const exception = peek();
+      if (exception === undefined) {
+        throw new Error(`WITH without an exception in SPDX expression: ${expr}`);
+      }
+      pos++;
+      id = `${id} WITH ${exception}`;
+    }
+    return { kind: "license", id };
+  }
+
+  function parseAnd(): SpdxNode {
+    const operands = [parseAtom()];
+    while (isOperator(peek(), "AND")) {
+      pos++;
+      operands.push(parseAtom());
+    }
+    return operands.length === 1 ? operands[0] : { kind: "and", operands };
+  }
+
+  function parseOr(): SpdxNode {
+    const operands = [parseAnd()];
+    while (isOperator(peek(), "OR")) {
+      pos++;
+      operands.push(parseAnd());
+    }
+    return operands.length === 1 ? operands[0] : { kind: "or", operands };
+  }
+
+  const node = parseOr();
+  if (pos !== tokens.length) {
+    throw new Error(`trailing tokens in SPDX expression: ${expr}`);
+  }
+  return node;
+}
+
+/**
+ * True when the expression's top-level operator is `AND`: every conjunct binds,
+ * so no choice of `OR` arm can shed the obligation.
+ *
+ * Why not solve for the cheapest satisfying assignment (e.g. an `AND` whose
+ * conjuncts are all `OR`s that share one electable license)? That analysis has
+ * no subject in the current graph — no dependency is an electable-AND — so it
+ * would be untested machinery guarding a case that does not exist. The
+ * conservative answer only ever over-reproduces notices, which is safe.
+ */
+export function hasNonElectableObligation(expr: string): boolean {
+  return parseSpdx(expr).kind === "and";
+}
+
+// --- Notice files ----------------------------------------------------------
+
+/**
+ * List the license/notice files a crate ships at its root, sorted by name.
+ *
+ * Symlinks are excluded outright rather than resolved: a crate tarball that
+ * pointed LICENSE at /etc/shadow would otherwise have its target inlined into a
+ * committed, published document. The realpath containment check is the second
+ * layer, covering a root that is itself reached through a link.
+ */
+export async function discoverNoticeFiles(crateDir: string): Promise<string[]> {
+  const entries = await readdir(crateDir).catch(() => [] as string[]);
+  const candidates = entries.filter((name) => NOTICE_FILE_PATTERN.test(name)).sort();
+
+  const crateReal = await realpath(crateDir);
+  const found: string[] = [];
+  for (const name of candidates) {
+    const abs = join(crateDir, name);
+    const stats = await lstat(abs).catch(() => null);
+    const isPlainFile = stats !== null && stats.isFile() && !stats.isSymbolicLink();
+    if (!isPlainFile) {
+      continue;
+    }
+    const real = await realpath(abs).catch(() => null);
+    if (real === null) {
+      continue;
+    }
+    const rel = relative(crateReal, real);
+    const escapesCrate = rel.startsWith("..") || isAbsolute(rel);
+    if (escapesCrate) {
+      continue;
+    }
+    found.push(name);
+  }
+  return found;
+}
+
+/**
+ * Read a notice file and normalize it for embedding: strip a leading BOM,
+ * convert CRLF to LF, and end with exactly one newline.
+ *
+ * Rejects (rather than repairs) anything unfit for a Markdown code block —
+ * oversized, non-UTF-8, or carrying control characters. Silent truncation or
+ * sanitization would publish a license text that is not the one the crate
+ * shipped, which is the exact failure this appendix exists to prevent.
+ *
+ * Error messages name the crate and file only: echoing the offending bytes
+ * would push attacker-controlled content into CI logs.
+ */
+export function normalizeNoticeText(raw: Buffer, label: string): string {
+  if (raw.byteLength > MAX_NOTICE_BYTES) {
+    throw new Error(
+      `${label}: notice file is ${raw.byteLength} bytes, over the ${MAX_NOTICE_BYTES}-byte limit`,
+    );
+  }
+
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(raw);
+  } catch {
+    throw new Error(`${label}: notice file is not valid UTF-8`);
+  }
+
+  if (text.charCodeAt(0) === 0xfeff) {
+    text = text.slice(1);
+  }
+  text = text.replace(/\r\n/g, "\n");
+
+  // Everything in C0 except tab and newline, plus DEL and any lone CR left over.
+  // Why not rewrite this without control characters (no-control-regex): matching
+  // them IS the check — a notice carrying NUL or an ANSI escape must be rejected,
+  // and the rule's usual concern (an accidental literal in a text pattern) does
+  // not apply to a range written deliberately as escapes.
+  // oxlint-disable-next-line no-control-regex
+  const hasForbiddenControl = /[\u0000-\u0008\u000b-\u001f\u007f]/.test(text);
+  if (hasForbiddenControl) {
+    throw new Error(`${label}: notice file contains disallowed control characters`);
+  }
+
+  return `${text.replace(/\n+$/, "")}\n`;
+}
+
+async function readNoticeFile(crateDir: string, name: string, label: string): Promise<NoticeFile> {
+  const raw = await readFile(join(crateDir, name));
+  return { name, text: normalizeNoticeText(raw, `${label}/${name}`) };
+}
+
+// --- Rendering -------------------------------------------------------------
+
+/**
+ * The fence for a code block must be longer than the longest backtick run in
+ * its content, anywhere on a line — not just at line start. aws-lc-sys's LICENSE
+ * already contains a ``` run, so a fixed three-backtick fence breaks the
+ * document against today's dependency graph, not some hypothetical future one.
+ */
+export function fenceFor(content: string): string {
+  let longest = 0;
+  for (const run of content.match(/`+/g) ?? []) {
+    longest = Math.max(longest, run.length);
+  }
+  return "`".repeat(Math.max(3, longest + 1));
+}
+
+/** Render the appendix reproducing each obligated crate's shipped notices. */
+export function renderNoticeAppendix(entries: NoticeEntry[]): string {
+  const lines: string[] = [];
+  lines.push("## Appendix: License texts and notices for non-electable obligations");
+  lines.push("");
+  lines.push("Most crates above are offered under an `OR` choice, and vibe's distribution");
+  lines.push("elects the permissive arm. The crates in this appendix are different: their");
+  lines.push("SPDX expression is a top-level `AND` conjunction, so every conjunct binds and");
+  lines.push("no election can shed it. Their obligations therefore travel with the shipped");
+  lines.push("binary, and the license and notice files each crate distributes are reproduced");
+  lines.push("below verbatim, exactly as published on crates.io.");
+  lines.push("");
+  lines.push("Like the table above, this appendix is drawn from the conservative full");
+  lines.push("dependency graph, so it may reproduce notices for crates that are not linked");
+  lines.push("into any shipped binary. Reproducing a notice is not a representation that the");
+  lines.push("crate is present in a given build.");
+  lines.push("");
+
+  for (const entry of entries) {
+    lines.push(`### ${entry.name} ${entry.version} — ${entry.license}`);
+    lines.push("");
+    for (const file of entry.files) {
+      const fence = fenceFor(file.text);
+      lines.push(`#### ${file.name}`);
+      lines.push("");
+      lines.push(fence);
+      lines.push(file.text.replace(/\n$/, ""));
+      lines.push(fence);
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** Render the whole document: preamble, crate table, and the notice appendix. */
+export function render(deps: CargoPackage[], entries: NoticeEntry[]): string {
+  const lines: string[] = [];
+  lines.push("# Third-Party Licenses");
+  lines.push("");
+  lines.push("The `vibe` binary is written in Rust and statically links the crates listed");
+  lines.push("below. Each is distributed under a permissive license (MIT, Apache-2.0, ISC,");
+  lines.push("BSD-3-Clause, Zlib, Unlicense, CC0-1.0, Unicode-3.0, CDLA-Permissive-2.0, or a");
+  lines.push("dual/multi-license `OR` of these). Where a crate is multi-licensed with `OR`,");
+  lines.push("vibe's distribution elects the permissive option.");
+  lines.push("");
+  lines.push("Some crates are licensed under a top-level `AND` conjunction instead. Those");
+  lines.push("obligations cannot be elected away, so the license and notice files those");
+  lines.push("crates ship are reproduced in full in the appendix at the end of this file.");
+  lines.push("");
+  lines.push("This list is generated from `cargo metadata` over `rust/Cargo.lock` by");
+  lines.push("`scripts/generate-third-party-licenses.ts`. It is the full dependency graph,");
+  lines.push("including platform-gated crates (e.g. Windows/wasm) that are not linked into");
+  lines.push("every shipped binary; listing them all is intentionally conservative.");
+  lines.push("");
+  lines.push("| Crate | Version | License (SPDX) |");
+  lines.push("| ----- | ------- | -------------- |");
+  for (const dep of deps) {
+    lines.push(`| ${dep.name} | ${dep.version} | ${licenseOf(dep)} |`);
+  }
+  lines.push("");
+  lines.push(renderNoticeAppendix(entries));
+  return lines.join("\n");
+}
+
+function licenseOf(pkg: CargoPackage): string {
+  return pkg.license ?? (pkg.license_file ? `see ${pkg.license_file}` : "UNKNOWN");
+}
+
+// --- Driver ----------------------------------------------------------------
 
 async function loadDependencies(): Promise<CargoPackage[]> {
   const { stdout } = await execFileAsync("cargo", ["metadata", "--format-version", "1"], {
@@ -48,53 +373,105 @@ async function loadDependencies(): Promise<CargoPackage[]> {
   return deps;
 }
 
-function render(deps: CargoPackage[]): string {
-  const lines: string[] = [];
-  lines.push("# Third-Party Licenses");
-  lines.push("");
-  lines.push("The `vibe` binary is written in Rust and statically links the crates listed");
-  lines.push("below. Each is distributed under a permissive license (MIT, Apache-2.0, ISC,");
-  lines.push("BSD-3-Clause, Zlib, Unlicense, CC0-1.0, Unicode-3.0, CDLA-Permissive-2.0, or a");
-  lines.push("dual/multi-license `OR` of these). Where a crate is multi-licensed, vibe's");
-  lines.push("distribution elects the permissive option.");
-  lines.push("");
-  lines.push("This list is generated from `cargo metadata` over `rust/Cargo.lock` by");
-  lines.push("`scripts/generate-third-party-licenses.ts`. It is the full dependency graph,");
-  lines.push("including platform-gated crates (e.g. Windows/wasm) that are not linked into");
-  lines.push("every shipped binary; listing them all is intentionally conservative.");
-  lines.push("");
-  lines.push("| Crate | Version | License (SPDX) |");
-  lines.push("| ----- | ------- | -------------- |");
+/**
+ * Collect the appendix entries for every dependency whose SPDX expression
+ * carries a non-electable obligation, in the same name→version order as the
+ * table so the rendered document is byte-stable across runs and platforms.
+ */
+async function collectNoticeEntries(deps: CargoPackage[]): Promise<NoticeEntry[]> {
+  const entries: NoticeEntry[] = [];
   for (const dep of deps) {
-    const license = dep.license ?? (dep.license_file ? `see ${dep.license_file}` : "UNKNOWN");
-    lines.push(`| ${dep.name} | ${dep.version} | ${license} |`);
+    const license = dep.license;
+    if (license === null || !hasNonElectableObligation(license)) {
+      continue;
+    }
+
+    const label = `${dep.name} ${dep.version}`;
+    const crateDir = dirname(dep.manifest_path);
+    const names = await discoverNoticeFiles(crateDir);
+    if (names.length === 0) {
+      throw new Error(
+        `${label} has a non-electable obligation (${license}) but ships no ` +
+          `LICENSE/NOTICE/COPYING file at its crate root; its terms cannot be reproduced`,
+      );
+    }
+
+    const files: NoticeFile[] = [];
+    for (const name of names) {
+      files.push(await readNoticeFile(crateDir, name, label));
+    }
+    entries.push({ name: dep.name, version: dep.version, license, files });
   }
-  lines.push("");
-  return lines.join("\n");
+  return entries;
+}
+
+/**
+ * Locate the first differing line between the committed and regenerated
+ * documents. The file runs past a thousand lines of reproduced license text, so
+ * a bare "is stale" leaves the reader diffing by hand to find what moved.
+ */
+export function describeFirstDifference(existing: string, generated: string): string {
+  const a = existing.split("\n");
+  const b = generated.split("\n");
+  const shared = Math.min(a.length, b.length);
+  for (let i = 0; i < shared; i++) {
+    if (a[i] !== b[i]) {
+      return `first difference at line ${i + 1}`;
+    }
+  }
+  if (a.length !== b.length) {
+    const verb = b.length > a.length ? "adds" : "removes";
+    return `identical through line ${shared}; regeneration ${verb} ${Math.abs(b.length - a.length)} line(s)`;
+  }
+  return "content differs";
 }
 
 async function main(): Promise<void> {
   const checkOnly = process.argv.slice(2).includes("--check");
   const deps = await loadDependencies();
-  const content = render(deps);
+  const entries = await collectNoticeEntries(deps);
+
+  // Why not tolerate an empty appendix: today's graph has four obligated
+  // crates, so zero means the SPDX parser regressed and stopped recognizing
+  // `AND` — a failure whose whole symptom is that the appendix silently
+  // vanishes while the run still exits 0.
+  if (entries.length === 0) {
+    throw new Error(
+      "no crate with a non-electable obligation was found; the SPDX analysis has regressed " +
+        "(the dependency graph is expected to contain top-level AND expressions)",
+    );
+  }
+
+  const content = render(deps, entries);
 
   if (checkOnly) {
-    const existing = await readFile(OUTPUT, "utf-8").catch(() => "");
+    const raw = await readFile(OUTPUT, "utf-8").catch(() => "");
+    // Compare against LF-normalized text. .gitattributes pins this file to LF,
+    // but a Windows checkout that predates it (or ignores it) would otherwise
+    // report a stale file whose only difference is the line ending.
+    const existing = raw.replace(/\r\n/g, "\n");
     if (existing !== content) {
-      console.error(`${OUTPUT} is stale. Run: bun run scripts/generate-third-party-licenses.ts`);
+      const where = describeFirstDifference(existing, content);
+      console.error(
+        `${OUTPUT} is stale (${where}). Run: bun run scripts/generate-third-party-licenses.ts`,
+      );
       process.exit(1);
     }
-    console.log(`${OUTPUT} is up to date (${deps.length} crates).`);
+    console.log(
+      `${OUTPUT} is up to date (${deps.length} crates, ${entries.length} reproduced notices).`,
+    );
     return;
   }
 
   await writeFile(OUTPUT, content, "utf-8");
-  console.log(`Wrote ${OUTPUT} (${deps.length} crates).`);
+  console.log(`Wrote ${OUTPUT} (${deps.length} crates, ${entries.length} reproduced notices).`);
 }
 
-main().catch((err: unknown) => {
-  console.error(
-    `generate-third-party-licenses: ${err instanceof Error ? err.message : String(err)}`,
-  );
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(
+      `generate-third-party-licenses: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  });
+}

--- a/scripts/verify-deb.ts
+++ b/scripts/verify-deb.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env bun
+
+/**
+ * Assert that a built .deb carries the binary and the required documentation.
+ *
+ * A .deb that installs /usr/bin/vibe but drops usr/share/doc/vibe/copyright
+ * ships a Debian package with no statement of terms, and one without
+ * THIRD-PARTY-LICENSES.md drops the notices for the Rust crates the binary
+ * statically links. Neither failure is visible from a smoke test of the
+ * installed binary, so this checks the package contents directly.
+ *
+ * Inspection only: `dpkg-deb --contents` / `--fsys-tarfile` read the archive
+ * without installing it, so no sudo (and no mutation of the runner) is needed.
+ *
+ * Usage:
+ *   bun run scripts/verify-deb.ts vibe_1.2.3_amd64.deb
+ */
+
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { once } from "node:events";
+import { resolve, relative, isAbsolute } from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+const BINARY_PATH = "usr/bin/vibe";
+const COPYRIGHT_PATH = "usr/share/doc/vibe/copyright";
+const NOTICES_PATH = "usr/share/doc/vibe/THIRD-PARTY-LICENSES.md";
+
+/** Substrings each documentation file must contain to count as the real thing. */
+const COPYRIGHT_MARKERS = [
+  "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/",
+  "License: MIT",
+  "Permission is hereby granted, free of charge",
+];
+const NOTICES_MARKERS = ["TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION"];
+
+/** One entry of `dpkg-deb --contents`: the member path and its mode string. */
+export interface DebEntry {
+  path: string;
+  mode: string;
+}
+
+/**
+ * Parse `dpkg-deb --contents` output. Lines look like
+ *   -rwxr-xr-x root/root  5242880 2025-01-01 00:00 ./usr/bin/vibe
+ * The leading `./` is stripped so callers compare against plain archive paths.
+ *
+ * Why not take the last whitespace-separated field as the name: paths may
+ * contain spaces, which would truncate the member to its last word and report a
+ * required file as missing. Only the first five fields (mode, owner, size, date,
+ * time) are fixed-width-ish; everything after them is the name, so the name is
+ * rejoined rather than indexed.
+ */
+export function parseDebContents(stdout: string): DebEntry[] {
+  const entries: DebEntry[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") {
+      continue;
+    }
+    const fields = trimmed.split(/\s+/);
+    const hasEnoughFields = fields.length >= 6;
+    if (!hasEnoughFields) {
+      continue;
+    }
+    const mode = fields[0];
+    // A symlink/hardlink line reads `<name> -> <target>`; the member is
+    // everything before the arrow. Otherwise the name runs to end of line.
+    const arrowIndex = fields.indexOf("->", 5);
+    const nameFields = arrowIndex === -1 ? fields.slice(5) : fields.slice(5, arrowIndex);
+    const rawPath = nameFields.join(" ");
+    if (rawPath === "") {
+      continue;
+    }
+    entries.push({ path: rawPath.replace(/^\.\//, ""), mode });
+  }
+  return entries;
+}
+
+/** True when a `dpkg-deb --contents` mode string denotes a regular file. */
+export function isRegularFile(mode: string): boolean {
+  return mode.startsWith("-");
+}
+
+/** True when a `dpkg-deb --contents` mode string carries any execute bit. */
+export function isExecutable(mode: string): boolean {
+  return mode.slice(1).includes("x");
+}
+
+/**
+ * Check the archive listing for the required members. Pure so it can be
+ * unit-tested without dpkg. Returns the list of problems (empty = OK).
+ *
+ * Each required member must be a REGULAR file: `dpkg-deb --contents` lists
+ * directories and symlinks in the same table, so a bare presence check would
+ * accept a directory named usr/bin/vibe, or a copyright symlink pointing
+ * somewhere that is not shipped in the package at all.
+ */
+export function findContentProblems(entries: DebEntry[]): string[] {
+  const byPath = new Map(entries.map((e) => [e.path, e]));
+  const problems: string[] = [];
+
+  for (const required of [BINARY_PATH, COPYRIGHT_PATH, NOTICES_PATH]) {
+    const entry = byPath.get(required);
+    if (!entry) {
+      problems.push(`missing required file: ${required}`);
+      continue;
+    }
+    if (!isRegularFile(entry.mode)) {
+      problems.push(`${required} is not a regular file (mode ${entry.mode})`);
+    }
+  }
+
+  const binary = byPath.get(BINARY_PATH);
+  const isNonExecutableFile = binary && isRegularFile(binary.mode) && !isExecutable(binary.mode);
+  if (isNonExecutableFile) {
+    problems.push(`${BINARY_PATH} is not executable (mode ${binary.mode})`);
+  }
+
+  return problems;
+}
+
+/** Check a documentation file's text for the markers that identify it. */
+export function findMarkerProblems(path: string, content: string, markers: string[]): string[] {
+  return markers
+    .filter((marker) => !content.includes(marker))
+    .map((marker) => `${path} does not contain: ${marker}`);
+}
+
+/**
+ * Resolve the .deb argument and require it to stay under the working directory.
+ * The path reaches this script from CI job inputs, and reading an arbitrary
+ * absolute path would let a crafted value point the verifier at a file outside
+ * the workspace that it then reports on.
+ */
+export function resolveDebPath(arg: string, cwd: string): string {
+  const abs = resolve(cwd, arg);
+  const rel = relative(cwd, abs);
+  const escapes = rel === "" || rel.startsWith("..") || isAbsolute(rel);
+  if (escapes) {
+    throw new Error(`.deb path must be inside the working directory: ${arg}`);
+  }
+  return abs;
+}
+
+/**
+ * Read one member's text out of the .deb without unpacking it to disk.
+ *
+ * Why not `sh -c 'dpkg-deb --fsys-tarfile ... | tar -xO ...'`: that would put a
+ * caller-supplied path through a shell. The two processes are spawned with argv
+ * arrays instead and wired together in-process.
+ */
+async function readMember(debPath: string, member: string): Promise<string> {
+  const dpkg = spawn("dpkg-deb", ["--fsys-tarfile", debPath], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  const tar = spawn("tar", ["-xO", `./${member}`], {
+    stdio: ["pipe", "pipe", "inherit"],
+  });
+  dpkg.stdout.pipe(tar.stdin);
+
+  const chunks: Buffer[] = [];
+  tar.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+
+  const [dpkgCode, tarCode] = await Promise.all([
+    once(dpkg, "close").then(([code]) => code as number | null),
+    once(tar, "close").then(([code]) => code as number | null),
+  ]);
+
+  // The producer's status is checked too: dpkg-deb failing on a corrupt archive
+  // still closes the pipe, which tar reports as a clean end-of-input, so
+  // ignoring it would turn an unreadable package into an empty extraction.
+  if (dpkgCode !== 0) {
+    throw new Error(`dpkg-deb could not read the package (exit ${dpkgCode})`);
+  }
+  if (tarCode !== 0) {
+    throw new Error(`could not extract ${member} from the package (tar exit ${tarCode})`);
+  }
+
+  const content = Buffer.concat(chunks).toString("utf-8");
+  // tar exits 0 when asked for a member that does not match anything, so an
+  // empty result is the only signal distinguishing "absent" from "empty file".
+  if (content === "") {
+    throw new Error(`extracted ${member} from the package but it was empty`);
+  }
+  return content;
+}
+
+async function main(): Promise<void> {
+  const arg = process.argv[2];
+  if (!arg) {
+    console.error("Usage: bun run scripts/verify-deb.ts <path-to-.deb>");
+    process.exit(1);
+  }
+  const debPath = resolveDebPath(arg, process.cwd());
+
+  const { stdout } = await execFileAsync("dpkg-deb", ["--contents", debPath], {
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const entries = parseDebContents(stdout);
+
+  const problems = findContentProblems(entries);
+  if (problems.length === 0) {
+    const copyright = await readMember(debPath, COPYRIGHT_PATH);
+    problems.push(...findMarkerProblems(COPYRIGHT_PATH, copyright, COPYRIGHT_MARKERS));
+    const notices = await readMember(debPath, NOTICES_PATH);
+    problems.push(...findMarkerProblems(NOTICES_PATH, notices, NOTICES_MARKERS));
+  }
+
+  if (problems.length > 0) {
+    console.error(`✗ ${arg}: package contents are incomplete:`);
+    for (const p of problems) {
+      console.error(`  - ${p}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`✓ ${arg}: ships ${BINARY_PATH}, ${COPYRIGHT_PATH}, ${NOTICES_PATH}`);
+}
+
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(`verify-deb: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to #563 (MIT relicense). Closes #564, closes #565.

- **#564** — `scripts/generate-third-party-licenses.ts` now appends an appendix to `THIRD-PARTY-LICENSES.md` reproducing, verbatim, the notice files shipped by every crate whose SPDX expression carries a top-level `AND` (a non-electable obligation): aws-lc-rs, aws-lc-sys, ring, unicode-ident — 8 notice files including the full Apache-2.0 text four times over. Texts are read from the crate sources cargo already vendored (no canonical copies to maintain, no network).
- **#565** — `scripts/build-deb.ts` derives a DEP-5 `usr/share/doc/vibe/copyright` from the root `LICENSE` and stages it, together with `THIRD-PARTY-LICENSES.md`, into the `.deb` (Debian Policy §12.5).

## Hardening & gates

- SPDX parsing: minimal recursive-descent parser (`WITH` > `AND` > `OR`, parens, legacy `/`); zero-obligation result hard-fails as a parser-regression guard.
- Untrusted notice content: dynamic code-fence length (aws-lc-sys's LICENSE already contains ``` today), symlinks rejected unconditionally, 1 MiB cap, UTF-8 fatal decode, C0/DEL rejection — all hard failures that never echo file contents.
- `check:licenses` (freshness `--check` + a standalone `cargo tree -i ring` emptiness guard, since ring's appendix entry no longer signals linkage) is wired into `check:all` **and** the CI lint job; `test:npm` now runs on PRs too.
- New `scripts/verify-deb.ts` inspects the built `.deb` (regular-file + exec-bit + marker checks, `dpkg-deb` via argv-only spawn, no sudo/install) in `ci.yml` and `release.yml`.
- `.gitattributes` pins `LICENSE` / `THIRD-PARTY-LICENSES.md` to LF so the Windows CI leg stays byte-identical; `--check` also normalizes CRLF before comparing.

## Tests

- 85 new tests (`third-party-licenses.test.ts` 43, `build-deb.test.ts` 19, `verify-deb.test.ts` 23); npm suite now 156 passing.
- `pnpm run check:all` passes end-to-end; `--check` is idempotent against the regenerated file.

## Review

Design by vibe-architect-expert; pre-implementation security review, post-implementation code review, security audit, and license audit all completed — no Critical/High findings remain. The license audit confirmed the appendix satisfies Apache-2.0 §4(a)–(d) (no NOTICE files exist in the covered crates) and the DEP-5 output is spec-conformant.

Also includes a one-line agent-config change promoting vibe-legal-expert from sonnet to opus (first-tier auditor, separate commit).

## Follow-up candidates (out of scope, pre-existing gaps)

- Reproduce copyright/permission notices for the ~150 OR/single-license crates (identifier-only today).
- Homebrew and Nix channels still ship no `THIRD-PARTY-LICENSES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)