### PR TITLE
fix: replace tee /dev/stderr with capture-then-print in the Windows CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,10 @@ jobs:
           set -euo pipefail
           # --lib: a single test target, so exactly one `test result:` line and
           # the count below cannot accidentally read a doc-test summary.
+          # Capture then print (no `tee /dev/stderr` — Git Bash on the Windows
+          # runner has no /dev/stderr, and under pipefail the dead tee fails
+          # the step before cargo's exit code is even seen).
+          status=0
           out=$(cargo test --manifest-path rust/Cargo.toml -p vibe-core --lib -- --exact \
             commands::doctor::tests::windows_uses_appdata_and_userprofile_documents \
             commands::doctor::tests::windows_also_probes_onedrive_documents_when_set \
@@ -148,7 +152,11 @@ jobs:
             commands::doctor::tests::windows_continues_past_an_invalid_appdata \
             commands::doctor::tests::the_windows_no_root_message_names_the_windows_variables \
             fast_remove::tests::background_delete_passes_path_as_own_argv_element_on_windows \
-            2>&1 | tee /dev/stderr)
+            2>&1) || status=$?
+          printf '%s\n' "$out"
+          if [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
           passed=$(printf '%s\n' "$out" | sed -n 's/^test result: ok\. \([0-9][0-9]*\) passed.*/\1/p' | tail -n1)
           if [ -z "$passed" ] || [ "$passed" -lt 6 ]; then
             echo "::error::expected 6 cfg(windows) tests to run, got '${passed:-none}' — a test was renamed or removed"


### PR DESCRIPTION
Second hotfix for the `rust-windows` job: the scoped test step (#571) died on `tee: /dev/stderr: No such file or directory` — Git Bash on the Windows runner has no `/dev/stderr`, and with `set -euo pipefail` the dead `tee` failed the command substitution before `cargo test`'s own result mattered. (The remaining failures in the previous develop run — lint / e2e-test / build-deb — were transient network errors and passed on rerun.)

The step now captures output, prints it, propagates cargo's exit code, and only then applies the 6-test count guard. No change to which tests run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFQdQUb1tdTv7G6YvmWu93