### PR TITLE
test: make the vibe-core unit suite pass on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,8 +7,9 @@
 # would be checked out with CRLF, making --check report a false "stale" and the
 # generated document differ from the committed one for no real reason.
 #
-# Why not `* text=auto eol=lf` for the whole repo: only the files listed here are
-# compared byte-for-byte, and a repo-wide normalization would rewrite files
+# Why not `* text=auto eol=lf` for the whole repo: only the files listed here
+# have their exact line endings asserted (whole-file comparisons below, and one
+# multi-line substring match), and a repo-wide normalization would rewrite files
 # (including test fixtures) well outside the problem this pins down.
 THIRD-PARTY-LICENSES.md text eol=lf
 LICENSE text eol=lf
@@ -22,3 +23,15 @@ LICENSE text eol=lf
 # These are shell scripts besides: zsh and fish both choke on CRLF line endings,
 # so an LF checkout is what a user should get on any platform anyway.
 rust/crates/vibe-core/src/completion/snapshots/*.snap text eol=lf
+
+# packages/npm/test/bmp-manifest-registration.test.ts reads the RAW lockfile
+# bytes and asserts each platform's importer entry as a multi-line string —
+# `'@kexi/<pkg>':\n        specifier: <version>` — to catch the specifier drift
+# that broke the v2.1.0/v2.1.1 releases. That literal carries a real `\n`, so a
+# CRLF checkout would fail the assertion over the checkout rather than over any
+# real drift.
+#
+# CI runs `test:npm` on ubuntu only, so this is currently a guard for Windows
+# CONTRIBUTORS running `just check` locally — and for the day that suite is added
+# to a Windows leg. Pinning the lockfile costs nothing either way.
+pnpm-lock.yaml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,8 +7,18 @@
 # would be checked out with CRLF, making --check report a false "stale" and the
 # generated document differ from the committed one for no real reason.
 #
-# Why not `* text=auto eol=lf` for the whole repo: nothing else here is compared
-# byte-for-byte, and a repo-wide normalization would rewrite files (including
-# test fixtures) well outside the problem this pins down.
+# Why not `* text=auto eol=lf` for the whole repo: only the files listed here are
+# compared byte-for-byte, and a repo-wide normalization would rewrite files
+# (including test fixtures) well outside the problem this pins down.
 THIRD-PARTY-LICENSES.md text eol=lf
 LICENSE text eol=lf
+
+# The completion snapshots are the parity oracle for the generated zsh/fish
+# scripts: `completion::{zsh,fish}::tests::matches_typescript_snapshot_byte_for_byte`
+# `include_str!`s them and asserts equality with the generator's output, which
+# emits `\n`. Checked out with CRLF on a Windows runner, every line would differ
+# and the test would fail over the checkout rather than over any real drift.
+#
+# These are shell scripts besides: zsh and fish both choke on CRLF line endings,
+# so an LF checkout is what a user should get on any platform anyway.
+rust/crates/vibe-core/src/completion/snapshots/*.snap text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    # `labeled` is not one of the default activity types (opened/synchronize/
+    # reopened), so without it applying `ci-full` to an open PR would not start a
+    # run — the label would only take effect on the next push, which defeats the
+    # point of being able to opt a finished PR into the Windows leg.
+    #
+    # The cost is a duplicate full run whenever ANY label is added to an open PR
+    # (the filter is per-event, not per-label). There is no `concurrency` group on
+    # this workflow, so those runs do not cancel each other; labels are applied
+    # rarely enough here that this is cheaper than the alternative.
+    types: [opened, synchronize, reopened, labeled]
 
 # Least privilege: CI only reads the repository. Jobs that need more must
 # request it explicitly at the job level.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,13 +103,13 @@ jobs:
   # The Windows-only coverage the other jobs structurally cannot provide, in two
   # parts:
   #
-  # 1. The `#[cfg(windows)]`-only vibe-core unit tests (path-prefix validation,
-  #    the Windows profile locations, the fast-remove argv), which are compiled
-  #    AND run nowhere else. On linux/macos they are cfg'd out entirely, so a
-  #    break in them would otherwise reach a release. Only these six run — the
-  #    wider vibe-core suite still assumes Unix paths in its fixtures and fails
-  #    wholesale on Windows (83 tests, see #570); until that lands this job
-  #    cannot run the full crate.
+  # 1. The whole vibe-core unit suite. Its `#[cfg(windows)]`-only tests
+  #    (path-prefix validation, the Windows profile locations, the fast-remove
+  #    argv) are compiled AND run nowhere else — on linux/macos they are cfg'd
+  #    out entirely, so a break in them would otherwise reach a release. The rest
+  #    of the crate runs here too now that its fixtures are platform-portable
+  #    (#570); shared tests with internal `cfg(windows)` assertion branches are
+  #    only actually exercised by this job.
   # 2. The PowerShell wrapper round-trip: rust-linux/rust-macos run the pwsh leg
   #    on Unix pwsh, which cannot exercise Windows path semantics, vibe.exe
   #    resolution, or `& vibe.exe ... @args` splatting where PowerShell users
@@ -120,7 +120,12 @@ jobs:
   # Windows runner, and they carry no cfg(windows) code of their own. Windows
   # PowerShell 5.1 is not exercised either (the wrapper targets pwsh 7).
   rust-windows:
-    if: github.event_name == 'push' || github.base_ref == 'main'
+    # Normally full-run-only (push / release PRs into main), but the `ci-full`
+    # label opts a develop PR in, so a change touching Windows-only behavior can
+    # prove this leg BEFORE merge rather than discovering it on the push to
+    # develop. The workflow is read from the PR's merge commit, so labelling a PR
+    # that edits this file takes effect within that same PR.
+    if: github.event_name == 'push' || github.base_ref == 'main' || contains(github.event.pull_request.labels.*.name, 'ci-full')
     runs-on: windows-latest
     steps:
       - name: Harden Runner
@@ -129,39 +134,10 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-toolchain
-      # Exact names, not a substring filter: `windows_` would also catch the
-      # unix-branch test `unix_and_windows_branches_...`, which (like the rest
-      # of the suite, #570) is not yet Windows-portable. libtest silently runs
-      # nothing when an --exact name goes stale, so the count guard below turns
-      # a renamed test into a hard failure instead of a vacuous pass. The whole
-      # crate still COMPILES for the test binary; only the run set is scoped.
-      - name: vibe-core cfg(windows) unit tests
-        shell: bash
-        run: |
-          set -euo pipefail
-          # --lib: a single test target, so exactly one `test result:` line and
-          # the count below cannot accidentally read a doc-test summary.
-          # Capture then print (no `tee /dev/stderr` — Git Bash on the Windows
-          # runner has no /dev/stderr, and under pipefail the dead tee fails
-          # the step before cargo's exit code is even seen).
-          status=0
-          out=$(cargo test --manifest-path rust/Cargo.toml -p vibe-core --lib -- --exact \
-            commands::doctor::tests::windows_uses_appdata_and_userprofile_documents \
-            commands::doctor::tests::windows_also_probes_onedrive_documents_when_set \
-            commands::doctor::tests::windows_rejects_unc_and_device_namespace_roots \
-            commands::doctor::tests::windows_continues_past_an_invalid_appdata \
-            commands::doctor::tests::the_windows_no_root_message_names_the_windows_variables \
-            fast_remove::tests::background_delete_passes_path_as_own_argv_element_on_windows \
-            2>&1) || status=$?
-          printf '%s\n' "$out"
-          if [ "$status" -ne 0 ]; then
-            exit "$status"
-          fi
-          passed=$(printf '%s\n' "$out" | sed -n 's/^test result: ok\. \([0-9][0-9]*\) passed.*/\1/p' | tail -n1)
-          if [ -z "$passed" ] || [ "$passed" -lt 6 ]; then
-            echo "::error::expected 6 cfg(windows) tests to run, got '${passed:-none}' — a test was renamed or removed"
-            exit 1
-          fi
+      # The whole crate runs: its fixtures are platform-portable as of #570, so
+      # there is nothing left to scope around.
+      - name: vibe-core unit tests
+        run: cargo test --manifest-path rust/Cargo.toml -p vibe-core
       - name: Wrapper round-trip test (Windows-native pwsh)
         env:
           VIBE_REQUIRE_SHELLS: pwsh

--- a/rust/crates/vibe-core/src/commands/clean_tests.rs
+++ b/rust/crates/vibe-core/src/commands/clean_tests.rs
@@ -14,7 +14,7 @@ use crate::settings_io::save_user_settings;
 use crate::stdin::FakeStdin;
 use crate::timestamp::LocalTime;
 use std::cell::RefCell;
-use vibe_test_support::Fixture;
+use vibe_test_support::{fake_root_str, Fixture};
 
 const V: &str = "1.8.1+test";
 
@@ -797,7 +797,11 @@ fn hook_mode_refuses_path_not_in_worktree_set() {
         &two_worktrees("/main", "/wt/real", "feat"),
     );
     let (r, p, fk) = (NoResolver, ScriptPrompt { confirm: true }, Fakes::new());
-    let sin = FakeStdin::text(r#"{"worktree_path": "/evil/outside"}"#);
+    // Absolute on this host (the reader rejects relative paths outright) and
+    // JSON-escaped, so the containment check — not the absoluteness check — is
+    // what refuses it.
+    let outside = serde_json::json!({ "worktree_path": fake_root_str("evil/outside") }).to_string();
+    let sin = FakeStdin::text(&outside);
     let proc = FakeProcess::new("/main");
     let d = deps(&io, &git, &r, &p, &proc, &sin, &fk, "/main");
     let flags = CleanFlags {
@@ -822,7 +826,10 @@ fn hook_mode_cleans_a_contained_path() {
     let io = FakeIo::new().with_env("HOME", fx.path().to_str().unwrap());
     let git = MockGit::new("/main", "/main", &two_worktrees("/main", &wt_path, "feat"));
     let (r, p, fk) = (NoResolver, ScriptPrompt { confirm: true }, Fakes::new());
-    let sin = FakeStdin::text(&format!(r#"{{"worktree_path": "{wt_path}"}}"#));
+    // Built with a JSON serializer, not string interpolation: a Windows temp path
+    // contains `\`, which is an escape introducer inside a JSON string.
+    let json = serde_json::json!({ "worktree_path": &wt_path }).to_string();
+    let sin = FakeStdin::text(&json);
     let proc = FakeProcess::new("/main");
     let d = deps(&io, &git, &r, &p, &proc, &sin, &fk, "/main");
     let flags = CleanFlags {

--- a/rust/crates/vibe-core/src/commands/config.rs
+++ b/rust/crates/vibe-core/src/commands/config.rs
@@ -47,7 +47,7 @@ mod tests {
     use super::*;
     use crate::git::RepoInfo;
     use crate::io::FakeIo;
-    use vibe_test_support::Fixture;
+    use vibe_test_support::{to_slash, Fixture};
 
     struct NoResolver;
     impl RepoResolver for NoResolver {
@@ -68,7 +68,9 @@ mod tests {
 
         let text = io.stderr_text();
         assert!(text.contains("Settings file:"));
-        assert!(text.contains(".config/vibe/settings.json"));
+        // The rendered path uses the host separator (`.config\vibe\...` on
+        // Windows); what this asserts is the location, not the punctuation.
+        assert!(to_slash(&text).contains(".config/vibe/settings.json"));
         // Default settings serialize without `$schema`.
         assert!(text.contains("\"version\": 3"));
         assert!(!text.contains("$schema"));

--- a/rust/crates/vibe-core/src/commands/doctor_tests.rs
+++ b/rust/crates/vibe-core/src/commands/doctor_tests.rs
@@ -9,6 +9,8 @@ use super::*;
 use crate::commands::shell_setup::shell_function;
 use crate::io::FakeIo;
 use std::collections::BTreeMap;
+use std::sync::LazyLock;
+use vibe_test_support::{fake_root, fake_root_str, to_slash};
 
 /// The pre-2.2.0 wrapper texts, recovered from git history (the commit before
 /// `feat: emit shell-dialect-aware eval output via --eval-dialect`). These are
@@ -83,7 +85,7 @@ fn paths(io: &FakeIo, platform: HostPlatform) -> Vec<String> {
     candidate_profiles(io, platform)
         .profiles
         .into_iter()
-        .map(|(_, p)| p.to_string_lossy().replace('\\', "/"))
+        .map(|(_, p)| to_slash(p))
         .collect()
 }
 
@@ -91,17 +93,52 @@ fn skipped(io: &FakeIo, platform: HostPlatform) -> Vec<&'static str> {
     candidate_profiles(io, platform).skipped_roots
 }
 
+/// An absolute fake root for a `HOME`/`XDG_CONFIG_HOME` value, as a `String`.
+///
+/// The unix-branch tests below feed these roots to `candidate_profiles` with
+/// `is_windows: false`, but the *validation* they must survive
+/// (`is_valid_abs_root` + `has_safe_prefix`) is compiled for the host. A literal
+/// `"/home/u"` is relative on Windows and would be rejected before the branch
+/// under test ever ran, so the roots are built per-host instead. See #570.
+fn root(segments: &str) -> String {
+    fake_root_str(segments)
+}
+
+/// The `/`-rendered form of [`root`] joined with `rel`, for path assertions.
+///
+/// `paths()` renders candidates with `/`, so expectations are written the same
+/// way: `expect("home/u", ".config/nushell/config.nu")` is
+/// `/home/u/.config/nushell/config.nu` on unix and
+/// `C:/home/u/.config/nushell/config.nu` on Windows.
+fn expect(segments: &str, rel: &str) -> String {
+    to_slash(fake_root(segments).join(rel.replace('/', std::path::MAIN_SEPARATOR_STR)))
+}
+
+/// The native-separator path a [`FakeProfileFs`] entry is keyed by.
+///
+/// `candidate_profiles` builds candidates with `Path::join`, so the fake FS must
+/// be keyed with host-native separators for lookups to hit.
+fn profile_path(segments: &str, rel: &str) -> String {
+    fake_root(segments)
+        .join(rel.replace('/', std::path::MAIN_SEPARATOR_STR))
+        .to_string_lossy()
+        .into_owned()
+}
+
 // --- candidate_profiles: env matrix ---
 
 #[test]
 fn unix_defaults_to_home_dot_config() {
-    let io = FakeIo::new().with_env("HOME", "/home/u");
+    let io = FakeIo::new().with_env("HOME", &root("home/u"));
     assert_eq!(
         paths(&io, UNIX),
         vec![
-            "/home/u/.config/nushell/config.nu",
-            "/home/u/.config/powershell/Microsoft.PowerShell_profile.ps1",
-            "/home/u/.config/powershell/profile.ps1",
+            expect("home/u", ".config/nushell/config.nu"),
+            expect(
+                "home/u",
+                ".config/powershell/Microsoft.PowerShell_profile.ps1"
+            ),
+            expect("home/u", ".config/powershell/profile.ps1"),
         ]
     );
 }
@@ -113,27 +150,30 @@ fn xdg_redirects_both_shells_to_exactly_one_root() {
     // otherwise — the same rule nu follows, so no `~/.config` candidate is probed
     // while XDG is set.
     let io = FakeIo::new()
-        .with_env("HOME", "/home/u")
-        .with_env("XDG_CONFIG_HOME", "/xdg");
+        .with_env("HOME", &root("home/u"))
+        .with_env("XDG_CONFIG_HOME", &root("xdg"));
     assert_eq!(
         paths(&io, UNIX),
         vec![
-            "/xdg/nushell/config.nu",
-            "/xdg/powershell/Microsoft.PowerShell_profile.ps1",
-            "/xdg/powershell/profile.ps1",
+            expect("xdg", "nushell/config.nu"),
+            expect("xdg", "powershell/Microsoft.PowerShell_profile.ps1"),
+            expect("xdg", "powershell/profile.ps1"),
         ]
     );
 }
 
 #[test]
 fn powershell_falls_back_to_dot_config_when_xdg_is_unset() {
-    let io = FakeIo::new().with_env("HOME", "/home/u");
+    let io = unix_io();
     assert_eq!(
         paths(&io, UNIX),
         vec![
-            "/home/u/.config/nushell/config.nu",
-            "/home/u/.config/powershell/Microsoft.PowerShell_profile.ps1",
-            "/home/u/.config/powershell/profile.ps1",
+            expect("home/u", ".config/nushell/config.nu"),
+            expect(
+                "home/u",
+                ".config/powershell/Microsoft.PowerShell_profile.ps1"
+            ),
+            expect("home/u", ".config/powershell/profile.ps1"),
         ]
     );
 }
@@ -144,10 +184,12 @@ fn a_stale_powershell_leftover_under_home_is_ignored_when_xdg_points_elsewhere()
     // not the directory PowerShell loads, so a stale file there is inert and must
     // not fail the run.
     let io = FakeIo::new()
-        .with_env("HOME", "/home/u")
-        .with_env("XDG_CONFIG_HOME", "/xdg");
-    let fs = FakeProfileFs::new()
-        .with_content("/home/u/.config/powershell/profile.ps1", OLD_PWSH_WRAPPER);
+        .with_env("HOME", &root("home/u"))
+        .with_env("XDG_CONFIG_HOME", &root("xdg"));
+    let fs = FakeProfileFs::new().with_content(
+        &profile_path("home/u", ".config/powershell/profile.ps1"),
+        OLD_PWSH_WRAPPER,
+    );
     let outcome = doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap();
     assert_eq!(outcome, Outcome::none());
     assert!(!io.stderr_text().contains("stale"));
@@ -156,13 +198,11 @@ fn a_stale_powershell_leftover_under_home_is_ignored_when_xdg_points_elsewhere()
 #[test]
 fn a_stale_powershell_profile_under_dot_config_is_found_when_xdg_is_unset() {
     let io = unix_io();
-    let fs = FakeProfileFs::new()
-        .with_content("/home/u/.config/powershell/profile.ps1", OLD_PWSH_WRAPPER);
+    let profile = profile_path("home/u", ".config/powershell/profile.ps1");
+    let fs = FakeProfileFs::new().with_content(&profile, OLD_PWSH_WRAPPER);
     let err = doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap_err();
     assert_eq!(err.exit_code(), 1);
-    assert!(io
-        .stderr_text()
-        .contains("/home/u/.config/powershell/profile.ps1: stale"));
+    assert!(io.stderr_text().contains(&format!("{profile}: stale")));
 }
 
 #[test]
@@ -188,13 +228,16 @@ fn unsafe_env_roots_are_rejected() {
 fn unsafe_xdg_falls_back_to_a_safe_home() {
     let io = FakeIo::new()
         .with_env("XDG_CONFIG_HOME", "../evil")
-        .with_env("HOME", "/home/u");
+        .with_env("HOME", &root("home/u"));
     assert_eq!(
         paths(&io, UNIX),
         vec![
-            "/home/u/.config/nushell/config.nu",
-            "/home/u/.config/powershell/Microsoft.PowerShell_profile.ps1",
-            "/home/u/.config/powershell/profile.ps1",
+            expect("home/u", ".config/nushell/config.nu"),
+            expect(
+                "home/u",
+                ".config/powershell/Microsoft.PowerShell_profile.ps1"
+            ),
+            expect("home/u", ".config/powershell/profile.ps1"),
         ]
     );
 }
@@ -202,10 +245,9 @@ fn unsafe_xdg_falls_back_to_a_safe_home() {
 #[test]
 fn unix_dotdot_substring_in_a_directory_name_is_allowed() {
     // `a..b` is one legitimate segment, not a parent-dir reference.
-    let io = FakeIo::new().with_env("HOME", "/home/a..b");
-    assert!(paths(&io, UNIX)
-        .iter()
-        .any(|p| p == "/home/a..b/.config/nushell/config.nu"));
+    let io = FakeIo::new().with_env("HOME", &root("home/a..b"));
+    let wanted = expect("home/a..b", ".config/nushell/config.nu");
+    assert!(paths(&io, UNIX).iter().any(|p| p == &wanted));
 }
 
 #[cfg(windows)]
@@ -257,33 +299,40 @@ fn unix_and_windows_branches_are_selected_by_the_flag_not_the_host() {
     // The same env map yields different candidates purely from `HostPlatform`, so
     // the platform facts really do arrive as a parameter.
     let io = FakeIo::new()
-        .with_env("HOME", "/home/u")
-        .with_env("APPDATA", "/appdata");
-    assert!(paths(&io, UNIX)
-        .iter()
-        .any(|p| p.contains("/home/u/.config/nushell")));
-    assert!(!paths(&io, WINDOWS)
-        .iter()
-        .any(|p| p.contains("/home/u/.config/nushell")));
+        .with_env("HOME", &root("home/u"))
+        .with_env("APPDATA", &root("appdata"));
+    let unix_marker = expect("home/u", ".config/nushell");
+    assert!(paths(&io, UNIX).iter().any(|p| p.contains(&unix_marker)));
+    assert!(!paths(&io, WINDOWS).iter().any(|p| p.contains(&unix_marker)));
 }
 
 // --- candidate_profiles: the macOS nushell location ---
 
-const MACOS_NU_PATH: &str = "/home/u/Library/Application Support/nushell/config.nu";
+const MACOS_NU_REL: &str = "Library/Application Support/nushell/config.nu";
+
+/// The macOS nu candidate as a fake-FS key (host-native separators).
+fn macos_nu_path() -> String {
+    profile_path("home/u", MACOS_NU_REL)
+}
+
+/// The macOS nu candidate as `paths()` renders it (`/` separators).
+fn macos_nu_rendered() -> String {
+    expect("home/u", MACOS_NU_REL)
+}
 
 #[test]
 fn macos_probes_application_support_when_xdg_is_unset() {
     // With no XDG_CONFIG_HOME, nu on macOS reads the Apple convention path — so
     // that, and not `~/.config`, is where the live config sits.
-    let io = FakeIo::new().with_env("HOME", "/home/u");
+    let io = unix_io();
     let found = paths(&io, MACOS);
-    assert!(found.contains(&MACOS_NU_PATH.to_string()), "got: {found:?}");
+    assert!(found.contains(&macos_nu_rendered()), "got: {found:?}");
 }
 
 #[test]
 fn non_macos_unix_does_not_probe_application_support() {
-    let io = FakeIo::new().with_env("HOME", "/home/u");
-    assert!(!paths(&io, UNIX).contains(&MACOS_NU_PATH.to_string()));
+    let io = unix_io();
+    assert!(!paths(&io, UNIX).contains(&macos_nu_rendered()));
 }
 
 #[test]
@@ -292,15 +341,12 @@ fn macos_skips_application_support_once_xdg_is_set() {
     // Application Support is one nu never loads. Reporting it would exit 1 over a
     // file that has no effect on the user's shell.
     let io = FakeIo::new()
-        .with_env("HOME", "/home/u")
-        .with_env("XDG_CONFIG_HOME", "/xdg");
+        .with_env("HOME", &root("home/u"))
+        .with_env("XDG_CONFIG_HOME", &root("xdg"));
     let found = paths(&io, MACOS);
+    assert!(!found.contains(&macos_nu_rendered()), "got: {found:?}");
     assert!(
-        !found.contains(&MACOS_NU_PATH.to_string()),
-        "got: {found:?}"
-    );
-    assert!(
-        found.contains(&"/xdg/nushell/config.nu".to_string()),
+        found.contains(&expect("xdg", "nushell/config.nu")),
         "got: {found:?}"
     );
 }
@@ -310,11 +356,14 @@ fn a_stale_application_support_leftover_is_ignored_when_xdg_is_current() {
     // The exit-code consequence of the rule above: the wrapper nu actually loads
     // is current, so the run is clean despite the stale file on disk.
     let io = FakeIo::new()
-        .with_env("HOME", "/home/u")
-        .with_env("XDG_CONFIG_HOME", "/xdg");
+        .with_env("HOME", &root("home/u"))
+        .with_env("XDG_CONFIG_HOME", &root("xdg"));
     let fs = FakeProfileFs::new()
-        .with_content(MACOS_NU_PATH, OLD_NU_WRAPPER)
-        .with_content("/xdg/nushell/config.nu", shell_function(ShellName::Nushell));
+        .with_content(&macos_nu_path(), OLD_NU_WRAPPER)
+        .with_content(
+            &profile_path("xdg", "nushell/config.nu"),
+            shell_function(ShellName::Nushell),
+        );
     let outcome = doctor_command(&io, &fs, MACOS, OutputOptions::default()).unwrap();
     assert_eq!(outcome, Outcome::none());
     let text = io.stderr_text();
@@ -324,24 +373,21 @@ fn a_stale_application_support_leftover_is_ignored_when_xdg_is_current() {
 #[test]
 fn a_stale_wrapper_in_application_support_exits_one_on_macos() {
     let io = unix_io();
-    let fs = FakeProfileFs::new().with_content(MACOS_NU_PATH, OLD_NU_WRAPPER);
+    let nu = macos_nu_path();
+    let fs = FakeProfileFs::new().with_content(&nu, OLD_NU_WRAPPER);
     let err = doctor_command(&io, &fs, MACOS, OutputOptions::default()).unwrap_err();
     assert_eq!(err.exit_code(), 1);
     let text = io.stderr_text();
-    assert!(
-        text.contains(&format!("{MACOS_NU_PATH}: stale")),
-        "got: {text}"
-    );
+    assert!(text.contains(&format!("{nu}: stale")), "got: {text}");
 }
 
 #[test]
 fn a_shipped_wrapper_in_application_support_is_clean_on_macos() {
     let io = unix_io();
-    let fs = FakeProfileFs::new().with_content(MACOS_NU_PATH, shell_function(ShellName::Nushell));
+    let nu = macos_nu_path();
+    let fs = FakeProfileFs::new().with_content(&nu, shell_function(ShellName::Nushell));
     doctor_command(&io, &fs, MACOS, OutputOptions::default()).unwrap();
-    assert!(io
-        .stderr_text()
-        .contains(&format!("{MACOS_NU_PATH}: current")));
+    assert!(io.stderr_text().contains(&format!("{nu}: current")));
 }
 
 // --- candidate_profiles: invalid roots are named, never echoed ---
@@ -350,7 +396,7 @@ fn a_shipped_wrapper_in_application_support_is_clean_on_macos() {
 fn a_set_but_invalid_root_is_recorded_by_name() {
     let io = FakeIo::new()
         .with_env("XDG_CONFIG_HOME", "../evil")
-        .with_env("HOME", "/home/u");
+        .with_env("HOME", &root("home/u"));
     assert_eq!(skipped(&io, UNIX), vec!["XDG_CONFIG_HOME"]);
 }
 
@@ -358,7 +404,7 @@ fn a_set_but_invalid_root_is_recorded_by_name() {
 fn an_unset_root_is_not_recorded_as_skipped() {
     // An absent XDG_CONFIG_HOME is the normal state; calling it "skipped" would
     // make a healthy setup read as broken.
-    let io = FakeIo::new().with_env("HOME", "/home/u");
+    let io = unix_io();
     assert!(skipped(&io, UNIX).is_empty());
 }
 
@@ -366,7 +412,7 @@ fn an_unset_root_is_not_recorded_as_skipped() {
 fn an_invalid_root_produces_a_skip_row_and_a_normal_report() {
     let io = FakeIo::new()
         .with_env("XDG_CONFIG_HOME", "relative/dir")
-        .with_env("HOME", "/home/u");
+        .with_env("HOME", &root("home/u"));
     let fs = FakeProfileFs::new();
     let outcome = doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap();
     assert_eq!(outcome, Outcome::none());
@@ -1258,23 +1304,39 @@ fn a_nu_def_that_is_not_vibe_is_ignored() {
 // --- doctor_command ---
 
 fn unix_io() -> FakeIo {
-    FakeIo::new().with_env("HOME", "/home/u")
+    FakeIo::new().with_env("HOME", &root("home/u"))
 }
 
-const NU_PATH: &str = "/home/u/.config/nushell/config.nu";
-const PWSH_PATH: &str = "/home/u/.config/powershell/Microsoft.PowerShell_profile.ps1";
+/// The two profile paths under the fake HOME, keyed the way `candidate_profiles`
+/// builds them (host-native separators) so the fake FS lookups hit and the report
+/// lines they appear in compare equal.
+///
+/// `LazyLock` rather than `const`: the value depends on the host separator, so it
+/// cannot be a literal, yet it stays a single shared definition the way the `&str`
+/// consts these replaced did.
+static NU_PATH: LazyLock<String> =
+    LazyLock::new(|| profile_path("home/u", ".config/nushell/config.nu"));
+static PWSH_PATH: LazyLock<String> = LazyLock::new(|| {
+    profile_path(
+        "home/u",
+        ".config/powershell/Microsoft.PowerShell_profile.ps1",
+    )
+});
 
 #[test]
 fn stale_wrapper_exits_one_and_prints_the_fix() {
     let io = unix_io();
-    let fs = FakeProfileFs::new().with_content(NU_PATH, OLD_NU_WRAPPER);
+    let fs = FakeProfileFs::new().with_content(&NU_PATH, OLD_NU_WRAPPER);
     let err = doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap_err();
     assert_eq!(err.exit_code(), 1);
     // AlreadyReported so the binary adds no second, contentless error line.
     assert!(matches!(err, VibeError::AlreadyReported));
 
     let text = io.stderr_text();
-    assert!(text.contains(&format!("{NU_PATH}: stale")), "got: {text}");
+    assert!(
+        text.contains(&format!("{}: stale", *NU_PATH)),
+        "got: {text}"
+    );
     assert!(
         text.contains("vibe shell-setup --shell nushell"),
         "got: {text}"
@@ -1284,11 +1346,14 @@ fn stale_wrapper_exits_one_and_prints_the_fix() {
 #[test]
 fn current_wrapper_is_clean_and_produces_no_stdout() {
     let io = unix_io();
-    let fs = FakeProfileFs::new().with_content(NU_PATH, shell_function(ShellName::Nushell));
+    let fs = FakeProfileFs::new().with_content(&NU_PATH, shell_function(ShellName::Nushell));
     let outcome = doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap();
     assert_eq!(outcome, Outcome::none());
     let text = io.stderr_text();
-    assert!(text.contains(&format!("{NU_PATH}: current")), "got: {text}");
+    assert!(
+        text.contains(&format!("{}: current", *NU_PATH)),
+        "got: {text}"
+    );
     assert!(!text.contains("Fix:"), "got: {text}");
 }
 
@@ -1306,28 +1371,28 @@ fn no_profiles_at_all_is_clean() {
 #[test]
 fn a_profile_without_a_wrapper_is_clean_but_still_reported() {
     let io = unix_io();
-    let fs = FakeProfileFs::new().with_content(NU_PATH, "$env.EDITOR = 'hx'\n");
+    let fs = FakeProfileFs::new().with_content(&NU_PATH, "$env.EDITOR = 'hx'\n");
     doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap();
     assert!(io
         .stderr_text()
-        .contains(&format!("{NU_PATH}: no vibe wrapper")));
+        .contains(&format!("{}: no vibe wrapper", *NU_PATH)));
 }
 
 #[test]
 fn unreadable_and_non_regular_files_are_reported_without_failing() {
     let io = unix_io();
     let fs = FakeProfileFs::new()
-        .with_read(NU_PATH, ProfileRead::Rejected)
-        .with_read(PWSH_PATH, ProfileRead::Unreadable);
+        .with_read(&NU_PATH, ProfileRead::Rejected)
+        .with_read(&PWSH_PATH, ProfileRead::Unreadable);
     let outcome = doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap();
     assert_eq!(outcome, Outcome::none());
     let text = io.stderr_text();
     assert!(
-        text.contains(&format!("{NU_PATH}: not checked (not a regular file)")),
+        text.contains(&format!("{}: not checked (not a regular file)", *NU_PATH)),
         "got: {text}"
     );
     assert!(
-        text.contains(&format!("{PWSH_PATH}: unreadable")),
+        text.contains(&format!("{}: unreadable", *PWSH_PATH)),
         "got: {text}"
     );
 }
@@ -1336,24 +1401,32 @@ fn unreadable_and_non_regular_files_are_reported_without_failing() {
 fn two_stale_profiles_each_get_their_own_row_and_fix_line() {
     let io = unix_io();
     let fs = FakeProfileFs::new()
-        .with_content(NU_PATH, OLD_NU_WRAPPER)
-        .with_content(PWSH_PATH, OLD_PWSH_WRAPPER);
+        .with_content(&NU_PATH, OLD_NU_WRAPPER)
+        .with_content(&PWSH_PATH, OLD_PWSH_WRAPPER);
     let err = doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap_err();
     assert_eq!(err.exit_code(), 1);
 
     let text = io.stderr_text();
-    assert!(text.contains(&format!("{NU_PATH}: stale")), "got: {text}");
-    assert!(text.contains(&format!("{PWSH_PATH}: stale")), "got: {text}");
+    assert!(
+        text.contains(&format!("{}: stale", *NU_PATH)),
+        "got: {text}"
+    );
+    assert!(
+        text.contains(&format!("{}: stale", *PWSH_PATH)),
+        "got: {text}"
+    );
     // Each Fix line must name the shell belonging to ITS path, not the other's.
     assert!(
         text.contains(&format!(
-            "Fix: run 'vibe shell-setup --shell nushell' and replace the vibe function in {NU_PATH}"
+            "Fix: run 'vibe shell-setup --shell nushell' and replace the vibe function in {}",
+            *NU_PATH
         )),
         "got: {text}"
     );
     assert!(
         text.contains(&format!(
-            "Fix: run 'vibe shell-setup --shell powershell' and replace the vibe function in {PWSH_PATH}"
+            "Fix: run 'vibe shell-setup --shell powershell' and replace the vibe function in {}",
+            *PWSH_PATH
         )),
         "got: {text}"
     );
@@ -1403,13 +1476,14 @@ fn an_indeterminate_wrapper_is_reported_without_failing_the_run() {
     let io = unix_io();
     let filler = "print 'x'\n".repeat(1200);
     let content = format!("def --env vibe [...args] {{ if true {{\n{filler}");
-    let fs = FakeProfileFs::new().with_content(NU_PATH, &content);
+    let fs = FakeProfileFs::new().with_content(&NU_PATH, &content);
     let outcome = doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap();
     assert_eq!(outcome, Outcome::none());
     let text = io.stderr_text();
     assert!(
         text.contains(&format!(
-            "{NU_PATH}: could not determine (wrapper block too long)"
+            "{}: could not determine (wrapper block too long)",
+            *NU_PATH
         )),
         "got: {text}"
     );
@@ -1422,13 +1496,16 @@ fn a_stale_wrapper_elsewhere_still_fails_the_run_alongside_an_indeterminate_one(
     let filler = "print 'x'\n".repeat(1200);
     let indeterminate = format!("def --env vibe [...args] {{ if true {{\n{filler}");
     let fs = FakeProfileFs::new()
-        .with_content(NU_PATH, &indeterminate)
-        .with_content(PWSH_PATH, OLD_PWSH_WRAPPER);
+        .with_content(&NU_PATH, &indeterminate)
+        .with_content(&PWSH_PATH, OLD_PWSH_WRAPPER);
     let err = doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap_err();
     assert_eq!(err.exit_code(), 1);
     let text = io.stderr_text();
     assert!(text.contains("could not determine"), "got: {text}");
-    assert!(text.contains(&format!("{PWSH_PATH}: stale")), "got: {text}");
+    assert!(
+        text.contains(&format!("{}: stale", *PWSH_PATH)),
+        "got: {text}"
+    );
 }
 
 // --- profile decoding ---
@@ -1537,11 +1614,14 @@ fn a_real_profile_file_is_read_and_classified() {
 #[test]
 fn an_oversized_profile_is_classified_and_flagged() {
     let io = unix_io();
-    let fs = FakeProfileFs::new().with_truncated(NU_PATH, OLD_NU_WRAPPER);
+    let fs = FakeProfileFs::new().with_truncated(&NU_PATH, OLD_NU_WRAPPER);
     let err = doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap_err();
     assert_eq!(err.exit_code(), 1);
     let text = io.stderr_text();
-    assert!(text.contains(&format!("{NU_PATH}: stale")), "got: {text}");
+    assert!(
+        text.contains(&format!("{}: stale", *NU_PATH)),
+        "got: {text}"
+    );
     assert!(
         text.contains("file too large; checked first 1 MB"),
         "got: {text}"
@@ -1553,11 +1633,14 @@ fn quiet_still_prints_the_report_and_keeps_the_exit_code() {
     // `vibe doctor -q` exiting 1 in silence would be unexplainable, so the
     // report must survive --quiet.
     let io = unix_io();
-    let fs = FakeProfileFs::new().with_content(NU_PATH, OLD_NU_WRAPPER);
+    let fs = FakeProfileFs::new().with_content(&NU_PATH, OLD_NU_WRAPPER);
     let err = doctor_command(&io, &fs, UNIX, OutputOptions::new(false, true)).unwrap_err();
     assert_eq!(err.exit_code(), 1);
     let text = io.stderr_text();
-    assert!(text.contains(&format!("{NU_PATH}: stale")), "got: {text}");
+    assert!(
+        text.contains(&format!("{}: stale", *NU_PATH)),
+        "got: {text}"
+    );
     assert!(text.contains("Fix: run"), "got: {text}");
 }
 
@@ -1571,11 +1654,11 @@ fn verbose_names_every_path_it_looked_at_including_absent_ones() {
     doctor_command(&io, &fs, UNIX, OutputOptions::new(true, false)).unwrap();
     let text = io.stderr_text();
     assert!(
-        text.contains(&format!("[verbose] checking {NU_PATH}")),
+        text.contains(&format!("[verbose] checking {}", *NU_PATH)),
         "got: {text}"
     );
     assert!(
-        text.contains(&format!("[verbose] checking {PWSH_PATH}")),
+        text.contains(&format!("[verbose] checking {}", *PWSH_PATH)),
         "got: {text}"
     );
 }
@@ -1585,11 +1668,11 @@ fn only_the_stale_line_is_colored() {
     // A passing check painted yellow reads as a problem, so the warning color is
     // reserved for the finding itself.
     let io = FakeIo::new()
-        .with_env("HOME", "/home/u")
+        .with_env("HOME", &root("home/u"))
         .with_env("FORCE_COLOR", "1");
     let fs = FakeProfileFs::new()
-        .with_content(NU_PATH, OLD_NU_WRAPPER)
-        .with_content(PWSH_PATH, shell_function(ShellName::Powershell));
+        .with_content(&NU_PATH, OLD_NU_WRAPPER)
+        .with_content(&PWSH_PATH, shell_function(ShellName::Powershell));
     doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap_err();
 
     let colored: Vec<String> = io
@@ -1613,8 +1696,10 @@ fn only_the_stale_line_is_colored() {
 #[test]
 fn control_characters_in_a_reported_path_are_sanitized() {
     // The path comes from the environment, so a hostile HOME must not be able to
-    // emit raw escape sequences into the operator's terminal.
-    let io = FakeIo::new().with_env("HOME", "/home/u\x1b[2Kfake");
+    // emit raw escape sequences into the operator's terminal. The escape sits in a
+    // path SEGMENT so the root still validates as absolute and actually gets
+    // reported — that is the point of the test.
+    let io = FakeIo::new().with_env("HOME", &root("home/u\x1b[2Kfake"));
     let fs = FakeProfileFs::new();
     doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap();
     assert!(!io.stderr_text().contains('\x1b'));
@@ -1623,7 +1708,7 @@ fn control_characters_in_a_reported_path_are_sanitized() {
 #[test]
 fn a_stale_powershell_wrapper_names_the_powershell_shell_in_the_fix() {
     let io = unix_io();
-    let fs = FakeProfileFs::new().with_content(PWSH_PATH, OLD_PWSH_WRAPPER);
+    let fs = FakeProfileFs::new().with_content(&PWSH_PATH, OLD_PWSH_WRAPPER);
     doctor_command(&io, &fs, UNIX, OutputOptions::default()).unwrap_err();
     assert!(io
         .stderr_text()

--- a/rust/crates/vibe-core/src/commands/doctor_tests.rs
+++ b/rust/crates/vibe-core/src/commands/doctor_tests.rs
@@ -215,7 +215,13 @@ fn unix_with_no_home_at_all_has_no_candidates() {
 fn unsafe_env_roots_are_rejected() {
     // Relative, `..`-bearing and empty roots are all refused, and with no safe
     // fallback the candidate list is empty (never a path built from them).
-    for bad in ["relative/config", "/home/../etc", ""] {
+    //
+    // The `..` case is built from a fake root so it is ABSOLUTE on both hosts:
+    // a bare `/home/../etc` is relative on Windows and would be refused by the
+    // absoluteness check, leaving the ParentDir rejection this case exists to
+    // prove unexercised there.
+    let dotdot = fake_root_str("home/../etc");
+    for bad in ["relative/config", &dotdot, ""] {
         let io = FakeIo::new().with_env("XDG_CONFIG_HOME", bad);
         assert!(
             paths(&io, UNIX).is_empty(),

--- a/rust/crates/vibe-core/src/commands/rename.rs
+++ b/rust/crates/vibe-core/src/commands/rename.rs
@@ -336,6 +336,8 @@ mod tests {
     use crate::settings::VibeSettings;
     use crate::worktree_path::ScriptOutput;
     use std::cell::RefCell;
+    use std::sync::LazyLock;
+    use vibe_test_support::fake_root_str;
 
     const V: &str = "1.8.1+abc";
 
@@ -540,6 +542,17 @@ mod tests {
         (fx, io)
     }
 
+    /// The three worktree paths every case below is built from: the main repo, the
+    /// `feat` worktree, and the `renamed` one the default resolver derives.
+    ///
+    /// Built per-host rather than written as `/home/u/...` literals: rename's
+    /// default path goes through `dirname` + `join`, which use the host separator,
+    /// so a `/`-joined literal would produce a mixed `\`/`/` path on Windows and
+    /// compare unequal to itself. See #570.
+    static MAIN: LazyLock<String> = LazyLock::new(|| fake_root_str("home/u/myrepo"));
+    static FEAT: LazyLock<String> = LazyLock::new(|| fake_root_str("home/u/myrepo-feat"));
+    static RENAMED: LazyLock<String> = LazyLock::new(|| fake_root_str("home/u/myrepo-renamed"));
+
     /// porcelain for [main, feat] where feat is the current (secondary) worktree.
     fn two_worktrees(main: &str, feat_path: &str, feat_branch: &str) -> String {
         format!(
@@ -684,30 +697,19 @@ mod tests {
     fn happy_path_moves_renames_and_cds() {
         let (_fx, io) = io_with_home();
         // main at /home/u/myrepo → default newPath = /home/u/myrepo-renamed.
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-feat", "feat"),
-            "/home/u/myrepo-feat",
-        );
+        let git = MockGit::new(&two_worktrees(&MAIN, &FEAT, "feat"), &FEAT);
         let (r, s) = (NoResolver, NoScript);
-        let p = FakeProcessControl::new("/home/u/myrepo-feat");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-feat");
+        let p = FakeProcessControl::new(&FEAT);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
         let outcome = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap();
-        assert_eq!(outcome, Outcome::cd("/home/u/myrepo-renamed"));
+        assert_eq!(outcome, Outcome::cd(&**RENAMED));
         // Moved, chdir'd into new, then renamed branch — in that order.
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-feat",
-            "/home/u/myrepo-renamed"
-        ]));
+        assert!(git.calls_contain(&["worktree", "move", &FEAT, &RENAMED]));
         assert!(git.calls_contain(&["branch", "-m", "feat", "renamed"]));
-        assert_eq!(
-            p.chdir_calls.borrow().as_slice(),
-            &["/home/u/myrepo-renamed"]
-        );
+        assert_eq!(p.chdir_calls.borrow().as_slice(), [RENAMED.as_str()]);
         let out = io.stderr_text();
         assert!(out.contains("Renamed feat -> renamed"));
-        assert!(out.contains("Directory: /home/u/myrepo-feat -> /home/u/myrepo-renamed"));
+        assert!(out.contains(&format!("Directory: {} -> {}", *FEAT, *RENAMED)));
     }
 
     #[test]
@@ -715,34 +717,21 @@ mod tests {
         // SECURITY/robustness: `git branch -m` fails AFTER the move+chdir → the
         // worktree must be moved BACK and cwd restored, then exit nonzero.
         let (_fx, io) = io_with_home();
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-feat", "feat"),
-            "/home/u/myrepo-feat",
-        )
-        .fail_on(&["branch", "-m"]);
+        let git =
+            MockGit::new(&two_worktrees(&MAIN, &FEAT, "feat"), &FEAT).fail_on(&["branch", "-m"]);
         let (r, s) = (NoResolver, NoScript);
-        let p = FakeProcessControl::new("/home/u/myrepo-feat");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-feat");
+        let p = FakeProcessControl::new(&FEAT);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
         let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         // Forward move happened, then the ROLLBACK move (new → old) happened.
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-feat",
-            "/home/u/myrepo-renamed"
-        ]));
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-renamed",
-            "/home/u/myrepo-feat"
-        ]));
+        assert!(git.calls_contain(&["worktree", "move", &FEAT, &RENAMED]));
+        assert!(git.calls_contain(&["worktree", "move", &RENAMED, &FEAT]));
         // chdir into new, then back to old.
         assert_eq!(
             p.chdir_calls.borrow().as_slice(),
-            &["/home/u/myrepo-renamed", "/home/u/myrepo-feat"]
+            [RENAMED.as_str(), FEAT.as_str()]
         );
         assert!(io
             .stderr_text()
@@ -755,30 +744,17 @@ mod tests {
         // back BEFORE attempting any branch rename, and exit nonzero. The branch
         // must NEVER be renamed in this path.
         let (_fx, io) = io_with_home();
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-feat", "feat"),
-            "/home/u/myrepo-feat",
-        );
+        let git = MockGit::new(&two_worktrees(&MAIN, &FEAT, "feat"), &FEAT);
         let (r, s) = (NoResolver, NoScript);
         // chdir to the NEW path fails.
-        let p = FakeProcessControl::failing_to("/home/u/myrepo-feat", "/home/u/myrepo-renamed");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-feat");
+        let p = FakeProcessControl::failing_to(&FEAT, &RENAMED);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
         let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         // Forward move + rollback move both issued; branch rename NEVER attempted.
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-feat",
-            "/home/u/myrepo-renamed"
-        ]));
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-renamed",
-            "/home/u/myrepo-feat"
-        ]));
+        assert!(git.calls_contain(&["worktree", "move", &FEAT, &RENAMED]));
+        assert!(git.calls_contain(&["worktree", "move", &RENAMED, &FEAT]));
         assert!(
             !git.calls_contain(&["branch", "-m"]),
             "branch must not be renamed after a chdir failure"
@@ -797,51 +773,31 @@ mod tests {
         // `Error: rollback failed: ...` + the exact `Manual recovery:` line and
         // return Err. Uses fail_on_exact so the FORWARD move still succeeds.
         let (_fx, io) = io_with_home();
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-feat", "feat"),
-            "/home/u/myrepo-feat",
-        )
-        .fail_on(&["branch", "-m"])
-        .fail_on_exact(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-renamed",
-            "/home/u/myrepo-feat",
-        ]);
+        let git = MockGit::new(&two_worktrees(&MAIN, &FEAT, "feat"), &FEAT)
+            .fail_on(&["branch", "-m"])
+            .fail_on_exact(&["worktree", "move", &RENAMED, &FEAT]);
         let (r, s) = (NoResolver, NoScript);
-        let p = FakeProcessControl::new("/home/u/myrepo-feat");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-feat");
+        let p = FakeProcessControl::new(&FEAT);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
         let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         // Forward move happened; rollback move (new → old) was ATTEMPTED.
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-feat",
-            "/home/u/myrepo-renamed"
-        ]));
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-renamed",
-            "/home/u/myrepo-feat"
-        ]));
+        assert!(git.calls_contain(&["worktree", "move", &FEAT, &RENAMED]));
+        assert!(git.calls_contain(&["worktree", "move", &RENAMED, &FEAT]));
         let out = io.stderr_text();
         assert!(out.contains("Error: rollback failed:"), "stderr: {out}");
         // Exact TS message (byte-for-byte from rename.ts line 190).
         assert!(
-            out.contains(
-                "Manual recovery: git worktree move '/home/u/myrepo-renamed' '/home/u/myrepo-feat'"
-            ),
+            out.contains(&format!(
+                "Manual recovery: git worktree move '{}' '{}'",
+                *RENAMED, *FEAT
+            )),
             "stderr: {out}"
         );
         // Because rollback failed, we did NOT chdir back to old (the success
         // branch's chdir-back is skipped on a failed rollback).
-        assert_eq!(
-            p.chdir_calls.borrow().as_slice(),
-            &["/home/u/myrepo-renamed"]
-        );
+        assert_eq!(p.chdir_calls.borrow().as_slice(), [RENAMED.as_str()]);
     }
 
     #[test]
@@ -850,35 +806,17 @@ mod tests {
         // the rollback move (new → old) ALSO fails → `Error: rollback failed:` +
         // the exact `Manual recovery:` line, Err, branch NEVER renamed.
         let (_fx, io) = io_with_home();
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-feat", "feat"),
-            "/home/u/myrepo-feat",
-        )
-        .fail_on_exact(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-renamed",
-            "/home/u/myrepo-feat",
-        ]);
+        let git = MockGit::new(&two_worktrees(&MAIN, &FEAT, "feat"), &FEAT)
+            .fail_on_exact(&["worktree", "move", &RENAMED, &FEAT]);
         let (r, s) = (NoResolver, NoScript);
         // chdir into the NEW path fails → triggers the 4a rollback path.
-        let p = FakeProcessControl::failing_to("/home/u/myrepo-feat", "/home/u/myrepo-renamed");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-feat");
+        let p = FakeProcessControl::failing_to(&FEAT, &RENAMED);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
         let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-feat",
-            "/home/u/myrepo-renamed"
-        ]));
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-renamed",
-            "/home/u/myrepo-feat"
-        ]));
+        assert!(git.calls_contain(&["worktree", "move", &FEAT, &RENAMED]));
+        assert!(git.calls_contain(&["worktree", "move", &RENAMED, &FEAT]));
         assert!(
             !git.calls_contain(&["branch", "-m"]),
             "branch must never be renamed on the 4a path"
@@ -887,9 +825,10 @@ mod tests {
         assert!(out.contains("failed to enter moved worktree directory"));
         assert!(out.contains("Error: rollback failed:"), "stderr: {out}");
         assert!(
-            out.contains(
-                "Manual recovery: git worktree move '/home/u/myrepo-renamed' '/home/u/myrepo-feat'"
-            ),
+            out.contains(&format!(
+                "Manual recovery: git worktree move '{}' '{}'",
+                *RENAMED, *FEAT
+            )),
             "stderr: {out}"
         );
     }
@@ -903,15 +842,11 @@ mod tests {
         // any ref mutation: (a) `git branch -m` is NEVER called, (b) the rollback
         // move (new → old) IS called, (c) the command returns Err.
         let (_fx, io) = io_with_home();
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-feat", "feat"),
-            "/home/u/myrepo-feat",
-        );
+        let git = MockGit::new(&two_worktrees(&MAIN, &FEAT, "feat"), &FEAT);
         let (r, s) = (NoResolver, NoScript);
         // chdir to new succeeds, but current_dir() reports a DIFFERENT path.
-        let p =
-            FakeProcessControl::reporting_dir("/home/u/myrepo-feat", "/somewhere/else-entirely");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-feat");
+        let p = FakeProcessControl::reporting_dir(&FEAT, "/somewhere/else-entirely");
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
         let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
@@ -921,12 +856,7 @@ mod tests {
             "detective layer must prevent the branch rename"
         );
         // (b) rollback move (new → old) issued.
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-renamed",
-            "/home/u/myrepo-feat"
-        ]));
+        assert!(git.calls_contain(&["worktree", "move", &RENAMED, &FEAT]));
         // (c) the abort message is the 4b directory-check failure.
         assert!(io
             .stderr_text()
@@ -946,13 +876,10 @@ mod tests {
         // current worktree at /home/u/myrepo-renamed on branch `feat`, renaming
         // feat → renamed → default newPath = /home/u/myrepo-renamed == oldPath.
         let (_fx, io) = io_with_home();
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-renamed", "feat"),
-            "/home/u/myrepo-renamed",
-        );
+        let git = MockGit::new(&two_worktrees(&MAIN, &RENAMED, "feat"), &RENAMED);
         let (r, s) = (NoResolver, NoScript);
-        let p = FakeProcessControl::new("/home/u/myrepo-renamed");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-renamed");
+        let p = FakeProcessControl::new(&RENAMED);
+        let d = deps(&io, &git, &r, &s, &p, &RENAMED);
         let outcome = rename_command(
             &d,
             "renamed",
@@ -961,7 +888,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(outcome, Outcome::cd("/home/u/myrepo-renamed"));
+        assert_eq!(outcome, Outcome::cd(&**RENAMED));
         // No move, no chdir.
         assert!(!git.calls_contain(&["worktree", "move"]));
         assert!(p.chdir_calls.borrow().is_empty());
@@ -970,7 +897,10 @@ mod tests {
 
         let out = io.stderr_text();
         assert!(
-            out.contains("[verbose] Worktree directory unchanged: /home/u/myrepo-renamed"),
+            out.contains(&format!(
+                "[verbose] Worktree directory unchanged: {}",
+                *RENAMED
+            )),
             "stderr: {out}"
         );
         assert!(out.contains("Renamed feat -> renamed"));
@@ -986,13 +916,10 @@ mod tests {
         // R-1 (dry-run variant): when newPath == oldPath, dry-run emits ONLY the
         // branch-rename + change-directory lines, NOT the move line.
         let (_fx, io) = io_with_home();
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-renamed", "feat"),
-            "/home/u/myrepo-renamed",
-        );
+        let git = MockGit::new(&two_worktrees(&MAIN, &RENAMED, "feat"), &RENAMED);
         let (r, s) = (NoResolver, NoScript);
-        let p = FakeProcessControl::new("/home/u/myrepo-renamed");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-renamed");
+        let p = FakeProcessControl::new(&RENAMED);
+        let d = deps(&io, &git, &r, &s, &p, &RENAMED);
         let outcome = rename_command(&d, "renamed", true, OutputOptions::default()).unwrap();
         assert_eq!(outcome, Outcome::none());
 
@@ -1002,7 +929,10 @@ mod tests {
             "move line must be omitted on the unchanged path: {out}"
         );
         assert!(out.contains("[dry-run] Would run: git branch -m feat renamed"));
-        assert!(out.contains("[dry-run] Would change directory to: /home/u/myrepo-renamed"));
+        assert!(out.contains(&format!(
+            "[dry-run] Would change directory to: {}",
+            *RENAMED
+        )));
         // No mutating git calls in dry-run.
         assert!(!git.calls_contain(&["branch", "-m"]));
     }
@@ -1015,29 +945,21 @@ mod tests {
         // chdir back to old FAILS → `Warning: could not return to original
         // directory` + `Manual recovery: cd '<old>'`, and exit nonzero.
         let (_fx, io) = io_with_home();
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-feat", "feat"),
-            "/home/u/myrepo-feat",
-        )
-        .fail_on(&["branch", "-m"]);
+        let git =
+            MockGit::new(&two_worktrees(&MAIN, &FEAT, "feat"), &FEAT).fail_on(&["branch", "-m"]);
         let (r, s) = (NoResolver, NoScript);
         // chdir to NEW succeeds (first chdir), chdir BACK to old fails (second).
-        let p = FakeProcessControl::failing_to("/home/u/myrepo-feat", "/home/u/myrepo-feat");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-feat");
+        let p = FakeProcessControl::failing_to(&FEAT, &FEAT);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
         let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         // Forward + rollback move both happened (rollback SUCCEEDED).
-        assert!(git.calls_contain(&[
-            "worktree",
-            "move",
-            "/home/u/myrepo-renamed",
-            "/home/u/myrepo-feat"
-        ]));
+        assert!(git.calls_contain(&["worktree", "move", &RENAMED, &FEAT]));
         // chdir into new, then attempted chdir back to old.
         assert_eq!(
             p.chdir_calls.borrow().as_slice(),
-            &["/home/u/myrepo-renamed", "/home/u/myrepo-feat"]
+            [RENAMED.as_str(), FEAT.as_str()]
         );
         let out = io.stderr_text();
         assert!(
@@ -1045,7 +967,7 @@ mod tests {
             "stderr: {out}"
         );
         assert!(
-            out.contains("Manual recovery: cd '/home/u/myrepo-feat'"),
+            out.contains(&format!("Manual recovery: cd '{}'", *FEAT)),
             "stderr: {out}"
         );
     }
@@ -1057,14 +979,11 @@ mod tests {
         // The forward `git worktree move` fails → `failed to move worktree
         // directory` + exit nonzero, and `git branch -m` is never called.
         let (_fx, io) = io_with_home();
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-feat", "feat"),
-            "/home/u/myrepo-feat",
-        )
-        .fail_on(&["worktree", "move"]);
+        let git = MockGit::new(&two_worktrees(&MAIN, &FEAT, "feat"), &FEAT)
+            .fail_on(&["worktree", "move"]);
         let (r, s) = (NoResolver, NoScript);
-        let p = FakeProcessControl::new("/home/u/myrepo-feat");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-feat");
+        let p = FakeProcessControl::new(&FEAT);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
         let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
@@ -1089,17 +1008,14 @@ mod tests {
         // location by pointing the MRU's repo paths at the real (existing) move,
         // which still resolves; the key assertion is the command returns Ok.
         let (_fx, io) = io_with_home();
-        let git = MockGit::new(
-            &two_worktrees("/home/u/myrepo", "/home/u/myrepo-feat", "feat"),
-            "/home/u/myrepo-feat",
-        );
+        let git = MockGit::new(&two_worktrees(&MAIN, &FEAT, "feat"), &FEAT);
         let (r, s) = (NoResolver, NoScript);
-        let p = FakeProcessControl::new("/home/u/myrepo-feat");
-        let d = deps(&io, &git, &r, &s, &p, "/home/u/myrepo-feat");
+        let p = FakeProcessControl::new(&FEAT);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
         // The MRU write targets /home/u/myrepo-renamed which does not exist on
         // disk; update_mru_branch is best-effort and its failure is swallowed.
         let outcome = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap();
-        assert_eq!(outcome, Outcome::cd("/home/u/myrepo-renamed"));
+        assert_eq!(outcome, Outcome::cd(&**RENAMED));
         assert!(io.stderr_text().contains("Renamed feat -> renamed"));
     }
 

--- a/rust/crates/vibe-core/src/commands/scratch.rs
+++ b/rust/crates/vibe-core/src/commands/scratch.rs
@@ -104,7 +104,7 @@ mod tests {
     use crate::timestamp::LocalTime;
     use crate::worktree_path::ScriptOutput;
     use std::cell::RefCell;
-    use vibe_test_support::Fixture;
+    use vibe_test_support::{fake_root_str, Fixture};
 
     const V: &str = "1.8.1+test";
 
@@ -251,9 +251,13 @@ mod tests {
     #[test]
     fn delegates_to_start_and_prints_promote_hint() {
         let (_fx, io) = io_with_home();
+        // A per-host repo root: scratch derives the worktree path with
+        // `dirname` + `join`, so a `/`-joined literal would come back mixed on
+        // Windows (and is not absolute there at all). See #570.
+        let repo = fake_root_str("home/u/repo");
         let git = MockGit::new(
-            "/home/u/repo",
-            "worktree /home/u/repo\nbranch refs/heads/main\n\n",
+            &repo,
+            &format!("worktree {repo}\nbranch refs/heads/main\n\n"),
             "",
         );
         let clock = FakeClock::new(0, lt());
@@ -276,7 +280,10 @@ mod tests {
         let outcome =
             scratch_command(&d, &clock, &StartFlags::default(), OutputOptions::default()).unwrap();
         // Created a worktree for the scratch branch and cd'd into it.
-        assert_eq!(outcome, Outcome::cd("/home/u/repo-scratch-20260606-090503"));
+        assert_eq!(
+            outcome,
+            Outcome::cd(fake_root_str("home/u/repo-scratch-20260606-090503"))
+        );
         // The branch name carries the scratch prefix.
         let adds = git.add_calls();
         assert!(adds

--- a/rust/crates/vibe-core/src/commands/start_tests.rs
+++ b/rust/crates/vibe-core/src/commands/start_tests.rs
@@ -11,9 +11,21 @@ use crate::progress::{RecordingTracker, TrackerEvent};
 use crate::stdin::FakeStdin;
 use crate::worktree_path::ScriptOutput;
 use std::cell::RefCell;
-use vibe_test_support::Fixture;
+use std::sync::LazyLock;
+use vibe_test_support::{fake_root_str, to_slash, Fixture};
 
 const V: &str = "1.8.1+test";
+
+/// The repo root and the worktree paths `start` derives from it.
+///
+/// Built per-host rather than written as `/home/u/...` literals: `start` resolves
+/// the worktree path with `dirname` + `join`, which use the host separator, and a
+/// `/`-joined literal is not even absolute on Windows. See #570.
+static REPO: LazyLock<String> = LazyLock::new(|| fake_root_str("home/u/repo"));
+static REPO_FEAT: LazyLock<String> = LazyLock::new(|| fake_root_str("home/u/repo-feat"));
+static REPO_FROM_STDIN: LazyLock<String> =
+    LazyLock::new(|| fake_root_str("home/u/repo-from-stdin"));
+static REPO_CLI_NAME: LazyLock<String> = LazyLock::new(|| fake_root_str("home/u/repo-cli-name"));
 
 /// A git mock that records calls, serves a worktree list / repo-root / branch
 /// existence, and can fail a configured arg prefix.
@@ -412,10 +424,7 @@ fn existing_branch_dry_run_does_not_navigate() {
 fn new_branch_creates_worktree_and_cds() {
     let (_fx, io) = io_with_home();
     // Only main worktree; no branch "feat" anywhere → brand new.
-    let git = MockGit::new(
-        "/home/u/repo",
-        "worktree /home/u/repo\nbranch refs/heads/main\n\n",
-    );
+    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n");
     let (r, s, p, sin, fk) = (
         NoResolver,
         NoScript,
@@ -427,18 +436,15 @@ fn new_branch_creates_worktree_and_cds() {
     let outcome =
         start_command(&d, "feat", &StartFlags::default(), OutputOptions::default()).unwrap();
     // default path = dirname(/home/u/repo)/repo-feat = /home/u/repo-feat.
-    assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
+    assert_eq!(outcome, Outcome::cd(&**REPO_FEAT));
     // The worktree-add argv contains `--` before the path (security #3).
-    assert!(git.calls_contain(&["worktree", "add", "-b", "feat", "--", "/home/u/repo-feat"]));
+    assert!(git.calls_contain(&["worktree", "add", "-b", "feat", "--", &REPO_FEAT]));
 }
 
 #[test]
 fn new_branch_dry_run_emits_no_cd_and_logs() {
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(
-        "/home/u/repo",
-        "worktree /home/u/repo\nbranch refs/heads/main\n\n",
-    );
+    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n");
     let (r, s, p, sin, fk) = (
         NoResolver,
         NoScript,
@@ -453,14 +459,15 @@ fn new_branch_dry_run_emits_no_cd_and_logs() {
     };
     let outcome = start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
     assert_eq!(outcome, Outcome::none());
+    assert!(io.stderr_text().contains(&format!(
+        "[dry-run] Would run: git worktree add -b feat -- '{}'",
+        *REPO_FEAT
+    )));
     assert!(io
         .stderr_text()
-        .contains("[dry-run] Would run: git worktree add -b feat -- '/home/u/repo-feat'"));
-    assert!(io
-        .stderr_text()
-        .contains("Would change directory to: /home/u/repo-feat"));
+        .contains(&format!("Would change directory to: {}", *REPO_FEAT)));
     // No real creation in dry-run.
-    assert!(!git.calls_contain(&["worktree", "add", "-b", "feat", "--", "/home/u/repo-feat"]));
+    assert!(!git.calls_contain(&["worktree", "add", "-b", "feat", "--", &REPO_FEAT]));
 }
 
 // --- base ref guards ---
@@ -534,11 +541,8 @@ fn base_with_empty_value_errors() {
 #[test]
 fn base_creates_with_base_when_revision_exists() {
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(
-        "/home/u/repo",
-        "worktree /home/u/repo\nbranch refs/heads/main\n\n",
-    )
-    .with_revision("main");
+    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n")
+        .with_revision("main");
     let (r, s, p, sin, fk) = (
         NoResolver,
         NoScript,
@@ -553,17 +557,10 @@ fn base_creates_with_base_when_revision_exists() {
         ..Default::default()
     };
     let outcome = start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
-    assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
-    assert!(git.calls_contain(&[
-        "worktree",
-        "add",
-        "-b",
-        "feat",
-        "--track",
-        "--",
-        "/home/u/repo-feat",
-        "main"
-    ]));
+    assert_eq!(outcome, Outcome::cd(&**REPO_FEAT));
+    assert!(
+        git.calls_contain(&["worktree", "add", "-b", "feat", "--track", "--", &REPO_FEAT, "main"])
+    );
 }
 
 // --- same-branch idempotent re-entry ---
@@ -573,7 +570,7 @@ fn same_branch_at_target_is_idempotent_cd() {
     let (_fx, io) = io_with_home();
     // The default path /home/u/repo-feat is ALREADY a worktree on branch feat.
     let git = MockGit::new(
-        "/home/u/repo",
+        &REPO,
         // Note: branch "feat" must NOT appear as used by another path, else the
         // earlier existing-branch guard fires. So this worktree's branch is feat
         // and path is the resolved default path → same-branch conflict.
@@ -595,7 +592,7 @@ fn same_branch_at_target_is_idempotent_cd() {
     let d = deps(&io, &git, &r, &s, &p, &sin, &fk);
     let outcome =
         start_command(&d, "feat", &StartFlags::default(), OutputOptions::default()).unwrap();
-    assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
+    assert_eq!(outcome, Outcome::cd(&**REPO_FEAT));
 }
 
 // --- different-branch conflict: Overwrite / Reuse / Cancel ---
@@ -605,7 +602,7 @@ fn conflicting_git() -> MockGit {
     // "other" (so different-branch conflict), and branch feat is brand new (not
     // used by any worktree → passes validate_branch_for_worktree).
     MockGit::new(
-        "/home/u/repo",
+        &REPO,
         "worktree /home/u/repo\nbranch refs/heads/main\n\nworktree /home/u/repo-feat\nbranch refs/heads/other\n\n",
     )
 }
@@ -624,10 +621,10 @@ fn different_branch_overwrite_removes_and_creates() {
     let d = deps(&io, &git, &r, &s, &p, &sin, &fk);
     let outcome =
         start_command(&d, "feat", &StartFlags::default(), OutputOptions::default()).unwrap();
-    assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
+    assert_eq!(outcome, Outcome::cd(&**REPO_FEAT));
     // Removed the old worktree (force, with `--`) then created the new one.
-    assert!(git.calls_contain(&["worktree", "remove", "--force", "--", "/home/u/repo-feat"]));
-    assert!(git.calls_contain(&["worktree", "add", "-b", "feat", "--", "/home/u/repo-feat"]));
+    assert!(git.calls_contain(&["worktree", "remove", "--force", "--", &REPO_FEAT]));
+    assert!(git.calls_contain(&["worktree", "add", "-b", "feat", "--", &REPO_FEAT]));
 }
 
 #[test]
@@ -658,9 +655,9 @@ fn different_branch_force_overwrites_without_prompt() {
         ..Default::default()
     };
     let outcome = start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
-    assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
-    assert!(git.calls_contain(&["worktree", "remove", "--force", "--", "/home/u/repo-feat"]));
-    assert!(git.calls_contain(&["worktree", "add", "-b", "feat", "--", "/home/u/repo-feat"]));
+    assert_eq!(outcome, Outcome::cd(&**REPO_FEAT));
+    assert!(git.calls_contain(&["worktree", "remove", "--force", "--", &REPO_FEAT]));
+    assert!(git.calls_contain(&["worktree", "add", "-b", "feat", "--", &REPO_FEAT]));
 }
 
 #[test]
@@ -692,7 +689,7 @@ fn different_branch_reuse_flag_reuses_without_prompt() {
         ..Default::default()
     };
     let outcome = start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
-    assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
+    assert_eq!(outcome, Outcome::cd(&**REPO_FEAT));
     // Reuse: no remove, no add — the existing worktree is kept as-is.
     assert!(!git.calls_contain(&["worktree", "remove"]));
     assert!(!git.calls_contain(&["worktree", "add"]));
@@ -712,7 +709,7 @@ fn different_branch_reuse_runs_hooks_and_cds_without_creating() {
     let d = deps(&io, &git, &r, &s, &p, &sin, &fk);
     let outcome =
         start_command(&d, "feat", &StartFlags::default(), OutputOptions::default()).unwrap();
-    assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
+    assert_eq!(outcome, Outcome::cd(&**REPO_FEAT));
     // Reuse: no remove, no add.
     assert!(!git.calls_contain(&["worktree", "remove"]));
     assert!(!git.calls_contain(&["worktree", "add"]));
@@ -1075,18 +1072,21 @@ fn submodule_configs_run_before_parent_pre_start_with_submodule_roots() {
         "libs/foo"
     ]));
 
+    // The paths are real (fixture-derived) and so carry the host separator; the
+    // suffix under test is the submodule's position in the tree, not its
+    // punctuation, so compare on the `/`-rendered form.
     let hooks = fk.hooks.calls.borrow();
     assert_eq!(hooks[0].0, "echo sub-pre");
-    assert!(hooks[0].1.ends_with("repo-feat/libs/foo"));
+    assert!(to_slash(&hooks[0].1).ends_with("repo-feat/libs/foo"));
     assert_eq!(hooks[1].0, "echo sub-post");
-    assert!(hooks[1].1.ends_with("repo-feat/libs/foo"));
+    assert!(to_slash(&hooks[1].1).ends_with("repo-feat/libs/foo"));
     assert_eq!(hooks[2].0, "echo parent");
     assert_eq!(hooks[2].1, repo_root);
 
     let file_copies = fk.exec.file_copies.lock().unwrap();
     assert_eq!(file_copies.len(), 1);
-    assert!(file_copies[0].0.ends_with("repo/libs/foo/.env"));
-    assert!(file_copies[0].1.ends_with("repo-feat/libs/foo/.env"));
+    assert!(to_slash(&file_copies[0].0).ends_with("repo/libs/foo/.env"));
+    assert!(to_slash(&file_copies[0].1).ends_with("repo-feat/libs/foo/.env"));
 }
 
 #[test]
@@ -1221,9 +1221,13 @@ fn submodule_config_invalid_path_is_rejected_before_git_update() {
 fn submodule_config_requires_its_own_trust() {
     let (fx, io, mut resolver, repo_root) = trusted_repo_with_submodule_config();
     let _ = &fx;
+    // Drop the submodule config's trust entry. The map is keyed by real
+    // (host-separator) paths, so the suffix is matched on the `/`-rendered form —
+    // otherwise nothing is removed on Windows and the case under test (an
+    // UNtrusted submodule config) never actually happens.
     resolver
         .repos
-        .retain(|path, _| !path.ends_with("repo-feat/libs/foo/.vibe.toml"));
+        .retain(|path, _| !to_slash(path).ends_with("repo-feat/libs/foo/.vibe.toml"));
     let git = MockGit::new(
         &repo_root,
         &format!("worktree {repo_root}\nbranch refs/heads/main\n\n"),
@@ -1258,10 +1262,7 @@ fn submodule_config_requires_its_own_trust() {
 #[test]
 fn worktree_hook_mode_outputs_path_to_stdout() {
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(
-        "/home/u/repo",
-        "worktree /home/u/repo\nbranch refs/heads/main\n\n",
-    );
+    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n");
     let s = NoScript;
     let p = ScriptPrompt::confirming(true);
     let sin = FakeStdin::text(r#"{"name": "from-stdin"}"#);
@@ -1274,24 +1275,21 @@ fn worktree_hook_mode_outputs_path_to_stdout() {
     let outcome = start_command(&d, "", &flags, OutputOptions::default()).unwrap();
     // Outputs the worktree PATH as stdout (NOT a cd).
     assert_eq!(outcome.cd_path, None);
-    assert_eq!(outcome.stdout.as_deref(), Some("/home/u/repo-from-stdin"));
+    assert_eq!(outcome.stdout.as_deref(), Some(REPO_FROM_STDIN.as_str()));
     assert!(git.calls_contain(&[
         "worktree",
         "add",
         "-b",
         "from-stdin",
         "--",
-        "/home/u/repo-from-stdin"
+        &REPO_FROM_STDIN
     ]));
 }
 
 #[test]
 fn worktree_hook_mode_requires_a_name() {
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(
-        "/home/u/repo",
-        "worktree /home/u/repo\nbranch refs/heads/main\n\n",
-    );
+    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n");
     let s = NoScript;
     let p = ScriptPrompt::confirming(true);
     let sin = FakeStdin::none(); // no stdin name, no CLI name.
@@ -1314,11 +1312,8 @@ fn base_without_track_emits_no_track_flag() {
     // `--no-track` (TS `createWorktree` emits `--no-track` when track is false and
     // a base is given; `--track` when true).
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(
-        "/home/u/repo",
-        "worktree /home/u/repo\nbranch refs/heads/main\n\n",
-    )
-    .with_revision("origin/main");
+    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n")
+        .with_revision("origin/main");
     let (r, s, p, sin, fk) = (
         NoResolver,
         NoScript,
@@ -1333,7 +1328,7 @@ fn base_without_track_emits_no_track_flag() {
         ..Default::default()
     };
     let outcome = start_command(&d, "feat", &flags, OutputOptions::default()).unwrap();
-    assert_eq!(outcome, Outcome::cd("/home/u/repo-feat"));
+    assert_eq!(outcome, Outcome::cd(&**REPO_FEAT));
     assert!(git.calls_contain(&[
         "worktree",
         "add",
@@ -1341,7 +1336,7 @@ fn base_without_track_emits_no_track_flag() {
         "feat",
         "--no-track",
         "--",
-        "/home/u/repo-feat",
+        &REPO_FEAT,
         "origin/main"
     ]));
     // And NOT the --track variant.
@@ -1352,7 +1347,7 @@ fn base_without_track_emits_no_track_flag() {
         "feat",
         "--track",
         "--",
-        "/home/u/repo-feat",
+        &REPO_FEAT,
         "origin/main"
     ]));
 }
@@ -1361,11 +1356,8 @@ fn base_without_track_emits_no_track_flag() {
 fn base_with_track_emits_track_flag() {
     // The complementary half of G-6: track=true → `--track`, never `--no-track`.
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(
-        "/home/u/repo",
-        "worktree /home/u/repo\nbranch refs/heads/main\n\n",
-    )
-    .with_revision("origin/main");
+    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n")
+        .with_revision("origin/main");
     let (r, s, p, sin, fk) = (
         NoResolver,
         NoScript,
@@ -1387,7 +1379,7 @@ fn base_with_track_emits_track_flag() {
         "feat",
         "--track",
         "--",
-        "/home/u/repo-feat",
+        &REPO_FEAT,
         "origin/main"
     ]));
     assert!(!git.calls_contain(&[
@@ -1397,7 +1389,7 @@ fn base_with_track_emits_track_flag() {
         "feat",
         "--no-track",
         "--",
-        "/home/u/repo-feat",
+        &REPO_FEAT,
         "origin/main"
     ]));
 }
@@ -1408,10 +1400,7 @@ fn base_with_track_emits_track_flag() {
 fn worktree_hook_mode_existing_branch_outputs_existing_path_without_creating() {
     let (_fx, io) = io_with_home();
     // Branch "feat" is ALREADY used by another worktree at /wt/feat.
-    let git = MockGit::new(
-        "/home/u/repo",
-        &two_worktrees("/home/u/repo", "/wt/feat", "feat"),
-    );
+    let git = MockGit::new(&REPO, &two_worktrees(&REPO, "/wt/feat", "feat"));
     let s = NoScript;
     let p = ScriptPrompt::confirming(true);
     let sin = FakeStdin::text(r#"{"name": "feat"}"#);
@@ -1480,10 +1469,7 @@ fn worktree_hook_mode_post_setup_failure_is_non_fatal() {
 #[test]
 fn worktree_hook_mode_cli_name_wins_over_stdin() {
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(
-        "/home/u/repo",
-        "worktree /home/u/repo\nbranch refs/heads/main\n\n",
-    );
+    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n");
     let s = NoScript;
     let p = ScriptPrompt::confirming(true);
     let sin = FakeStdin::text(r#"{"name": "stdin-name"}"#);
@@ -1494,5 +1480,5 @@ fn worktree_hook_mode_cli_name_wins_over_stdin() {
         ..Default::default()
     };
     let outcome = start_command(&d, "cli-name", &flags, OutputOptions::default()).unwrap();
-    assert_eq!(outcome.stdout.as_deref(), Some("/home/u/repo-cli-name"));
+    assert_eq!(outcome.stdout.as_deref(), Some(REPO_CLI_NAME.as_str()));
 }

--- a/rust/crates/vibe-core/src/commands/start_tests.rs
+++ b/rust/crates/vibe-core/src/commands/start_tests.rs
@@ -27,6 +27,25 @@ static REPO_FROM_STDIN: LazyLock<String> =
     LazyLock::new(|| fake_root_str("home/u/repo-from-stdin"));
 static REPO_CLI_NAME: LazyLock<String> = LazyLock::new(|| fake_root_str("home/u/repo-cli-name"));
 
+/// `git worktree list --porcelain` output listing only the main worktree.
+///
+/// Built from [`REPO`] rather than written inline: `start` matches the paths in
+/// this listing against the target path it computes with `Path::join`, so a
+/// `/`-joined literal here would never match on Windows — the conflict would go
+/// undetected and the command would silently take the plain-create branch.
+fn main_only() -> String {
+    format!("worktree {}\nbranch refs/heads/main\n\n", *REPO)
+}
+
+/// The listing above plus a second worktree at the resolved default path
+/// ([`REPO_FEAT`]) on `branch`, i.e. the path-conflict fixture.
+fn main_and_feat_path_on(branch: &str) -> String {
+    format!(
+        "worktree {}\nbranch refs/heads/main\n\nworktree {}\nbranch refs/heads/{branch}\n\n",
+        *REPO, *REPO_FEAT
+    )
+}
+
 /// A git mock that records calls, serves a worktree list / repo-root / branch
 /// existence, and can fail a configured arg prefix.
 struct MockGit {
@@ -424,7 +443,7 @@ fn existing_branch_dry_run_does_not_navigate() {
 fn new_branch_creates_worktree_and_cds() {
     let (_fx, io) = io_with_home();
     // Only main worktree; no branch "feat" anywhere → brand new.
-    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n");
+    let git = MockGit::new(&REPO, &main_only());
     let (r, s, p, sin, fk) = (
         NoResolver,
         NoScript,
@@ -444,7 +463,7 @@ fn new_branch_creates_worktree_and_cds() {
 #[test]
 fn new_branch_dry_run_emits_no_cd_and_logs() {
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n");
+    let git = MockGit::new(&REPO, &main_only());
     let (r, s, p, sin, fk) = (
         NoResolver,
         NoScript,
@@ -541,8 +560,7 @@ fn base_with_empty_value_errors() {
 #[test]
 fn base_creates_with_base_when_revision_exists() {
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n")
-        .with_revision("main");
+    let git = MockGit::new(&REPO, &main_only()).with_revision("main");
     let (r, s, p, sin, fk) = (
         NoResolver,
         NoScript,
@@ -574,7 +592,7 @@ fn same_branch_at_target_is_idempotent_cd() {
         // Note: branch "feat" must NOT appear as used by another path, else the
         // earlier existing-branch guard fires. So this worktree's branch is feat
         // and path is the resolved default path → same-branch conflict.
-        "worktree /home/u/repo\nbranch refs/heads/main\n\nworktree /home/u/repo-feat\nbranch refs/heads/feat\n\n",
+        &main_and_feat_path_on("feat"),
     );
     // But validate_branch_for_worktree would find feat used by /home/u/repo-feat
     // → existing-branch path, navigating. To exercise SAME-BRANCH conflict we
@@ -601,10 +619,7 @@ fn conflicting_git() -> MockGit {
     // The resolved default path /home/u/repo-feat holds a DIFFERENT branch
     // "other" (so different-branch conflict), and branch feat is brand new (not
     // used by any worktree → passes validate_branch_for_worktree).
-    MockGit::new(
-        &REPO,
-        "worktree /home/u/repo\nbranch refs/heads/main\n\nworktree /home/u/repo-feat\nbranch refs/heads/other\n\n",
-    )
+    MockGit::new(&REPO, &main_and_feat_path_on("other"))
 }
 
 #[test]
@@ -1262,7 +1277,7 @@ fn submodule_config_requires_its_own_trust() {
 #[test]
 fn worktree_hook_mode_outputs_path_to_stdout() {
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n");
+    let git = MockGit::new(&REPO, &main_only());
     let s = NoScript;
     let p = ScriptPrompt::confirming(true);
     let sin = FakeStdin::text(r#"{"name": "from-stdin"}"#);
@@ -1289,7 +1304,7 @@ fn worktree_hook_mode_outputs_path_to_stdout() {
 #[test]
 fn worktree_hook_mode_requires_a_name() {
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n");
+    let git = MockGit::new(&REPO, &main_only());
     let s = NoScript;
     let p = ScriptPrompt::confirming(true);
     let sin = FakeStdin::none(); // no stdin name, no CLI name.
@@ -1312,8 +1327,7 @@ fn base_without_track_emits_no_track_flag() {
     // `--no-track` (TS `createWorktree` emits `--no-track` when track is false and
     // a base is given; `--track` when true).
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n")
-        .with_revision("origin/main");
+    let git = MockGit::new(&REPO, &main_only()).with_revision("origin/main");
     let (r, s, p, sin, fk) = (
         NoResolver,
         NoScript,
@@ -1356,8 +1370,7 @@ fn base_without_track_emits_no_track_flag() {
 fn base_with_track_emits_track_flag() {
     // The complementary half of G-6: track=true → `--track`, never `--no-track`.
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n")
-        .with_revision("origin/main");
+    let git = MockGit::new(&REPO, &main_only()).with_revision("origin/main");
     let (r, s, p, sin, fk) = (
         NoResolver,
         NoScript,
@@ -1469,7 +1482,7 @@ fn worktree_hook_mode_post_setup_failure_is_non_fatal() {
 #[test]
 fn worktree_hook_mode_cli_name_wins_over_stdin() {
     let (_fx, io) = io_with_home();
-    let git = MockGit::new(&REPO, "worktree /home/u/repo\nbranch refs/heads/main\n\n");
+    let git = MockGit::new(&REPO, &main_only());
     let s = NoScript;
     let p = ScriptPrompt::confirming(true);
     let sin = FakeStdin::text(r#"{"name": "stdin-name"}"#);

--- a/rust/crates/vibe-core/src/config_path.rs
+++ b/rust/crates/vibe-core/src/config_path.rs
@@ -83,11 +83,14 @@ fn set_dir_permissions_0700(_dir: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vibe_test_support::{fake_root, fake_root_str};
 
     #[test]
     fn builds_expected_path() {
-        let dir = config_dir("/home/user").unwrap();
-        assert_eq!(dir, PathBuf::from("/home/user/.config/vibe"));
+        // A per-host root: `/home/user` carries no drive prefix, so on Windows it
+        // is relative and `config_dir` would (correctly) reject it.
+        let dir = config_dir(&fake_root_str("home/user")).unwrap();
+        assert_eq!(dir, fake_root("home/user").join(".config").join("vibe"));
     }
 
     #[test]
@@ -108,8 +111,8 @@ mod tests {
     #[test]
     fn allows_dotdot_substring_in_a_name() {
         // `a..b` is a single, legitimate path segment, not a parent-dir ref.
-        let dir = config_dir("/home/a..b").unwrap();
-        assert_eq!(dir, PathBuf::from("/home/a..b/.config/vibe"));
+        let dir = config_dir(&fake_root_str("home/a..b")).unwrap();
+        assert_eq!(dir, fake_root("home/a..b").join(".config").join("vibe"));
     }
 
     #[cfg(unix)]

--- a/rust/crates/vibe-core/src/config_path.rs
+++ b/rust/crates/vibe-core/src/config_path.rs
@@ -105,7 +105,10 @@ mod tests {
 
     #[test]
     fn rejects_parent_dir_component() {
-        assert!(config_dir("/home/../etc").is_err());
+        // Absolute on both hosts, so it is the ParentDir component — not the
+        // absoluteness check — that does the rejecting. A bare `/home/../etc` is
+        // relative on Windows and would never reach the guard under test.
+        assert!(config_dir(&fake_root_str("home/../etc")).is_err());
     }
 
     #[test]

--- a/rust/crates/vibe-core/src/copy_runner.rs
+++ b/rust/crates/vibe-core/src/copy_runner.rs
@@ -208,7 +208,7 @@ mod tests {
     use crate::copy::types::{CopyError, CopyStrategyKind};
     use crate::io::FakeIo;
     use crate::progress::NullTracker;
-    use vibe_test_support::Fixture;
+    use vibe_test_support::{fake_root, Fixture};
 
     fn pats(items: &[&str]) -> Vec<String> {
         items.iter().map(|s| s.to_string()).collect()
@@ -271,19 +271,22 @@ mod tests {
         let io = FakeIo::new();
         let exec = FakeCopyExecutor::new(CopyStrategyKind::Standard);
         let tracker = NullTracker;
+        let worktree = fake_root("wt");
         copy_files(
             &io,
             &exec,
             &tracker,
             &pats(&[".env", "config.toml"]),
             fx.path().to_str().unwrap(),
-            "/wt",
+            worktree.to_str().unwrap(),
             false,
         );
         let copies = exec.file_copies.lock().unwrap();
         assert_eq!(copies.len(), 2);
         assert!(copies[0].0.ends_with(".env"));
-        assert!(copies[0].1.ends_with("/wt/.env") || copies[0].1.ends_with("\\wt\\.env"));
+        // Built the same way the product builds it, so the assertion states the
+        // destination rather than a separator convention.
+        assert_eq!(copies[0].1, worktree.join(".env").to_string_lossy());
     }
 
     #[test]

--- a/rust/crates/vibe-core/src/glob.rs
+++ b/rust/crates/vibe-core/src/glob.rs
@@ -240,7 +240,7 @@ pub fn expand_directory_patterns(
 mod tests {
     use super::*;
     use crate::io::FakeIo;
-    use vibe_test_support::Fixture;
+    use vibe_test_support::{fake_root_str, to_slash, Fixture};
 
     fn pats(items: &[&str]) -> Vec<String> {
         items.iter().map(|s| s.to_string()).collect()
@@ -302,8 +302,14 @@ mod tests {
         fx.mkdir(".cache/b");
         fx.write(".cache/file.txt", "x");
         let io = FakeIo::new();
-        let mut dirs =
-            expand_directory_patterns(&io, &pats(&[".cache/*"]), fx.path().to_str().unwrap());
+        let mut dirs: Vec<String> =
+            expand_directory_patterns(&io, &pats(&[".cache/*"]), fx.path().to_str().unwrap())
+                .iter()
+                // Repo-relative results carry the host separator (`.cache\a` on
+                // Windows); the identity under test is which entries matched, not
+                // how they are punctuated.
+                .map(to_slash)
+                .collect();
         dirs.sort();
         assert_eq!(dirs, vec![".cache/a".to_string(), ".cache/b".to_string()]);
     }
@@ -393,7 +399,11 @@ mod tests {
     fn absolute_pattern_is_skipped_with_warning() {
         let fx = Fixture::new();
         let io = FakeIo::new();
-        let files = expand_copy_patterns(&io, &pats(&["/etc/passwd"]), fx.path().to_str().unwrap());
+        // Absoluteness is host-defined: `/etc/passwd` is a RELATIVE path on
+        // Windows (no drive prefix), so the pattern must carry the host's own
+        // notion of "absolute" for the rejection under test to be exercised.
+        let absolute = fake_root_str("etc/passwd");
+        let files = expand_copy_patterns(&io, &pats(&[&absolute]), fx.path().to_str().unwrap());
         assert!(files.is_empty());
         assert!(io.stderr_text().contains("Skipping invalid pattern"));
     }
@@ -420,8 +430,11 @@ mod tests {
     fn absolute_glob_pattern_is_skipped() {
         let fx = Fixture::new();
         let io = FakeIo::new();
-        // An absolute glob must be rejected too (defense vs `/etc/*`).
-        let files = expand_copy_patterns(&io, &pats(&["/etc/*"]), fx.path().to_str().unwrap());
+        // An absolute glob must be rejected too (defense vs `/etc/*`), using the
+        // host's own notion of absolute — see the exact-path case above.
+        let absolute_glob = fake_root_str("etc/*");
+        let files =
+            expand_copy_patterns(&io, &pats(&[&absolute_glob]), fx.path().to_str().unwrap());
         assert!(files.is_empty());
         assert!(io.stderr_text().contains("Skipping invalid pattern"));
     }

--- a/rust/crates/vibe-core/src/stdin.rs
+++ b/rust/crates/vibe-core/src/stdin.rs
@@ -282,8 +282,12 @@ mod tests {
     #[test]
     fn path_failing_validate_path_is_rejected() {
         let io = FakeIo::new();
-        // Absolute but contains a command-substitution pattern.
-        let r = FakeStdin::text(r#"{"worktree_path": "/tmp/$(whoami)"}"#);
+        // Absolute on BOTH hosts and carrying a command-substitution pattern, so
+        // it is `validate_path` that rejects it. A bare `/tmp/$(whoami)` is
+        // relative on Windows and would be refused one check earlier, leaving the
+        // substitution guard this case exists to prove unexercised there.
+        let json = serde_json::json!({ "worktree_path": fake_root_str("tmp/$(whoami)") });
+        let r = FakeStdin::text(&json.to_string());
         assert!(read_worktree_hook_path(&io, &r).is_none());
     }
 

--- a/rust/crates/vibe-core/src/stdin.rs
+++ b/rust/crates/vibe-core/src/stdin.rs
@@ -182,6 +182,7 @@ mod fake {
 mod tests {
     use super::*;
     use crate::io::FakeIo;
+    use vibe_test_support::fake_root_str;
 
     #[test]
     fn parses_a_json_object() {
@@ -263,11 +264,12 @@ mod tests {
     #[test]
     fn reads_valid_absolute_path() {
         let io = FakeIo::new();
-        let r = FakeStdin::text(r#"{"worktree_path": "/home/u/wt"}"#);
-        assert_eq!(
-            read_worktree_hook_path(&io, &r),
-            Some("/home/u/wt".to_string())
-        );
+        // JSON-escaped: on Windows the fake root is `C:\home\u\wt`, whose
+        // backslashes are not legal raw inside a JSON string.
+        let path = fake_root_str("home/u/wt");
+        let json = serde_json::json!({ "worktree_path": path }).to_string();
+        let r = FakeStdin::text(&json);
+        assert_eq!(read_worktree_hook_path(&io, &r), Some(path));
     }
 
     #[test]

--- a/rust/crates/vibe-core/src/worktree_path.rs
+++ b/rust/crates/vibe-core/src/worktree_path.rs
@@ -214,7 +214,7 @@ mod tests {
     use crate::io::FakeIo;
     use crate::settings::SettingsWorktree;
     use std::cell::RefCell;
-    use vibe_test_support::{fake_root, fake_root_str, Fixture};
+    use vibe_test_support::{fake_root, fake_root_str, to_slash, Fixture};
 
     /// Records the cmd + the (key, value) env overlays a script was asked to run.
     type SeenInvocation = (String, Vec<(String, String)>);
@@ -456,7 +456,12 @@ mod tests {
         let settings = settings_with_script(Some("~/s.sh"));
         resolve_worktree_path(&io, &runner, None, &settings, &ctx(&fake_root_str("repo"))).unwrap();
         let (cmd, _) = runner.seen.borrow().clone().unwrap();
-        assert_eq!(cmd, script.to_string_lossy());
+        // `~` expansion is a plain `format!("{home}{rest}")` (kept for TS parity,
+        // see `execute_path_script`), so the tilde's own `/` survives into the
+        // expanded path: `C:\...\tmp/s.sh` on Windows. It names the same file the
+        // fixture wrote — Windows accepts `/` as a separator when opening — so
+        // the identity under test is the resolved file, not its punctuation.
+        assert_eq!(to_slash(&cmd), to_slash(&script));
     }
 
     #[test]

--- a/rust/crates/vibe-core/src/worktree_path.rs
+++ b/rust/crates/vibe-core/src/worktree_path.rs
@@ -214,7 +214,7 @@ mod tests {
     use crate::io::FakeIo;
     use crate::settings::SettingsWorktree;
     use std::cell::RefCell;
-    use vibe_test_support::Fixture;
+    use vibe_test_support::{fake_root, fake_root_str, Fixture};
 
     /// Records the cmd + the (key, value) env overlays a script was asked to run.
     type SeenInvocation = (String, Vec<(String, String)>);
@@ -283,9 +283,13 @@ mod tests {
         let io = FakeIo::new();
         let runner = FakeScriptRunner::ok("");
         let settings = settings_with_script(None);
+        let repo = fake_root("home/u/myrepo");
         let path =
-            resolve_worktree_path(&io, &runner, None, &settings, &ctx("/home/u/myrepo")).unwrap();
-        assert_eq!(path, "/home/u/myrepo-feat-x");
+            resolve_worktree_path(&io, &runner, None, &settings, &ctx(repo.to_str().unwrap()))
+                .unwrap();
+        // The default path is the repo dir with a `-<sanitized-branch>` suffix, so
+        // it is built from the same root rather than a `/`-joined literal.
+        assert_eq!(path, format!("{}-feat-x", repo.display()));
         // The script was never invoked.
         assert!(runner.seen.borrow().is_none());
     }
@@ -296,7 +300,10 @@ mod tests {
         // An absolute, existing script file.
         let script = fx.write("from-config.sh", "#!/bin/sh\n");
         let io = FakeIo::new();
-        let runner = FakeScriptRunner::ok("/abs/output");
+        // The script's OUTPUT must satisfy the product's absoluteness check, which
+        // is host-defined — hence a fake root rather than a `/abs/...` literal.
+        let output = fake_root_str("abs/output");
+        let runner = FakeScriptRunner::ok(&output);
         let config = VibeConfig {
             worktree: Some(WorktreeConfig {
                 path_script: Some(script.to_string_lossy().into_owned()),
@@ -304,10 +311,11 @@ mod tests {
             ..Default::default()
         };
         // settings ALSO has a script, but config wins.
-        let settings = settings_with_script(Some("/never/used.sh"));
-        let path =
-            resolve_worktree_path(&io, &runner, Some(&config), &settings, &ctx("/repo")).unwrap();
-        assert_eq!(path, "/abs/output");
+        let settings = settings_with_script(Some(&fake_root_str("never/used.sh")));
+        let repo_root = fake_root_str("repo");
+        let path = resolve_worktree_path(&io, &runner, Some(&config), &settings, &ctx(&repo_root))
+            .unwrap();
+        assert_eq!(path, output);
         // It ran the CONFIG script, with the four VIBE_* overlays.
         let (cmd, env) = runner.seen.borrow().clone().unwrap();
         assert_eq!(cmd, script.to_string_lossy());
@@ -322,7 +330,7 @@ mod tests {
             .any(|(k, v)| k == "VIBE_SANITIZED_BRANCH" && v == "feat-x"));
         assert!(env
             .iter()
-            .any(|(k, v)| k == "VIBE_REPO_ROOT" && v == "/repo"));
+            .any(|(k, v)| k == "VIBE_REPO_ROOT" && v == &repo_root));
     }
 
     #[test]
@@ -330,10 +338,12 @@ mod tests {
         let fx = Fixture::new();
         let script = fx.write("s.sh", "#!/bin/sh\n");
         let io = FakeIo::new();
-        let runner = FakeScriptRunner::ok("/from/settings");
+        let output = fake_root_str("from/settings");
+        let runner = FakeScriptRunner::ok(&output);
         let settings = settings_with_script(Some(script.to_str().unwrap()));
-        let path = resolve_worktree_path(&io, &runner, None, &settings, &ctx("/repo")).unwrap();
-        assert_eq!(path, "/from/settings");
+        let repo_root = fake_root_str("repo");
+        let path = resolve_worktree_path(&io, &runner, None, &settings, &ctx(&repo_root)).unwrap();
+        assert_eq!(path, output);
 
         // R-6: the SETTINGS-script path also gets all four VIBE_* overlays, with
         // the raw branch (`feat/x`) and the sanitized one (`feat-x`) DISTINCT.
@@ -345,7 +355,7 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing env {k}"))
         };
         assert_eq!(get("VIBE_REPO_NAME"), "myrepo");
-        assert_eq!(get("VIBE_REPO_ROOT"), "/repo");
+        assert_eq!(get("VIBE_REPO_ROOT"), repo_root);
         // The raw vs sanitized distinction is load-bearing: `/` → `-`.
         assert_eq!(get("VIBE_BRANCH_NAME"), "feat/x");
         assert_eq!(get("VIBE_SANITIZED_BRANCH"), "feat-x");
@@ -362,7 +372,7 @@ mod tests {
         let repo = fx.mkdir("repo");
         let _ = fx.write("repo/script.sh", "#!/bin/sh\n");
         let io = FakeIo::new();
-        let runner = FakeScriptRunner::ok("/out");
+        let runner = FakeScriptRunner::ok(&fake_root_str("out"));
         let settings = settings_with_script(Some("script.sh")); // relative
         resolve_worktree_path(&io, &runner, None, &settings, &ctx(repo.to_str().unwrap())).unwrap();
         let (cmd, _) = runner.seen.borrow().clone().unwrap();
@@ -442,9 +452,9 @@ mod tests {
         let home = fx.path().to_str().unwrap();
         let script = fx.write("s.sh", "#!/bin/sh\n");
         let io = FakeIo::new().with_env("HOME", home);
-        let runner = FakeScriptRunner::ok("/out");
+        let runner = FakeScriptRunner::ok(&fake_root_str("out"));
         let settings = settings_with_script(Some("~/s.sh"));
-        resolve_worktree_path(&io, &runner, None, &settings, &ctx("/repo")).unwrap();
+        resolve_worktree_path(&io, &runner, None, &settings, &ctx(&fake_root_str("repo"))).unwrap();
         let (cmd, _) = runner.seen.borrow().clone().unwrap();
         assert_eq!(cmd, script.to_string_lossy());
     }

--- a/rust/crates/vibe-core/src/worktree_path.rs
+++ b/rust/crates/vibe-core/src/worktree_path.rs
@@ -479,10 +479,17 @@ mod tests {
     #[test]
     fn tilde_with_dotdot_home_errors() {
         // HOME containing `..` is rejected by the substring check (TS parity).
-        let io = FakeIo::new().with_env("HOME", "/home/../etc");
-        let runner = FakeScriptRunner::ok("/out");
+        //
+        // Absolute on both hosts, so it is the `..` that rejects it: the guard is
+        // `is_absolute() && !contains("..")`, and a bare `/home/../etc` fails the
+        // absoluteness half on Windows — reaching the same error for the wrong
+        // reason and never proving the `..` check runs.
+        let io = FakeIo::new().with_env("HOME", &fake_root_str("home/../etc"));
+        let runner = FakeScriptRunner::ok(&fake_root_str("out"));
         let settings = settings_with_script(Some("~/s.sh"));
-        let err = resolve_worktree_path(&io, &runner, None, &settings, &ctx("/repo")).unwrap_err();
+        let err =
+            resolve_worktree_path(&io, &runner, None, &settings, &ctx(&fake_root_str("repo")))
+                .unwrap_err();
         assert!(err.to_string().contains("Cannot expand ~ in path_script"));
     }
 }

--- a/rust/crates/vibe-test-support/src/lib.rs
+++ b/rust/crates/vibe-test-support/src/lib.rs
@@ -5,9 +5,73 @@
 //! wraps `tempfile::TempDir` with a small builder that writes inline file trees
 //! and cleans up on drop, so tests get a shared fixture instead of repeating
 //! error-prone manual temp-dir setup.
+//!
+//! It also owns the platform-neutral *fake path* helpers ([`fake_root`],
+//! [`fake_home`]). vibe ships on Windows as well as unix, and the unit suite is
+//! run on every one of them, so a fixture literal like `"/home/u"` is not a
+//! neutral placeholder: on Windows it is a *relative* path (no drive prefix),
+//! which the product's own `is_valid_abs_root` correctly rejects. Building fake
+//! roots through these helpers keeps such fixtures absolute on every host
+//! without scattering `cfg(windows)` through the tests themselves. See #570.
 
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+
+/// An absolute, non-existent path rooted at a per-platform prefix.
+///
+/// `fake_root("home/u")` is `/home/u` on unix and `C:\home\u` on Windows.
+/// `segments` is always written with `/` separators; they are translated to the
+/// host's separator here, so a caller never has to think about it.
+///
+/// The path intentionally does NOT exist: these helpers are for tests that feed
+/// paths through pure logic (validation, joining, rendering). Tests that touch
+/// the filesystem want [`Fixture`] instead.
+///
+/// Why a `C:` drive prefix rather than a UNC or verbatim path on Windows: the
+/// product deliberately accepts only `Prefix::Disk` roots for environment-derived
+/// directories (`vibe doctor`'s `has_safe_prefix` refuses UNC/device namespaces),
+/// so a drive-prefixed fake is the only kind that exercises the success path.
+#[must_use]
+pub fn fake_root(segments: &str) -> PathBuf {
+    let relative: PathBuf = segments.split('/').filter(|s| !s.is_empty()).collect();
+
+    #[cfg(windows)]
+    {
+        Path::new(r"C:\").join(relative)
+    }
+    #[cfg(not(windows))]
+    {
+        Path::new("/").join(relative)
+    }
+}
+
+/// [`fake_root`] as a `String`, for the many seams that take `&str` paths.
+#[must_use]
+pub fn fake_root_str(segments: &str) -> String {
+    fake_root(segments).to_string_lossy().into_owned()
+}
+
+/// The conventional fake HOME: `/home/u` on unix, `C:\home\u` on Windows.
+#[must_use]
+pub fn fake_home() -> PathBuf {
+    fake_root("home/u")
+}
+
+/// [`fake_home`] as a `String`.
+#[must_use]
+pub fn fake_home_str() -> String {
+    fake_home().to_string_lossy().into_owned()
+}
+
+/// Render a path with `/` separators, whatever the host uses.
+///
+/// For assertions that compare against a readable `/`-joined literal: normalizing
+/// the *actual* value keeps the expected side of the assertion legible instead of
+/// forcing every expectation through a `join` chain.
+#[must_use]
+pub fn to_slash(path: impl AsRef<Path>) -> String {
+    path.as_ref().to_string_lossy().replace('\\', "/")
+}
 
 /// A temporary directory tree that is removed when dropped.
 pub struct Fixture {
@@ -29,9 +93,24 @@ impl Fixture {
     }
 
     /// Resolve a relative path against the fixture root.
+    ///
+    /// A `/` in `rel` is treated as a path separator on every host. Why not a
+    /// plain `Path::join`: Windows accepts `/` as a separator when *opening* a
+    /// file, but preserves it verbatim in the `PathBuf`, so `join("repo/.vibe.toml")`
+    /// would yield `C:\tmp\repo/.vibe.toml`. Tests then compare that against a
+    /// product value built by the product's own `Path::join` (`...\repo\.vibe.toml`)
+    /// and fail on separator style alone, even though both name the same file.
+    /// Re-joining component-wise makes the fixture path canonical for the host.
     #[must_use]
     pub fn join(&self, rel: impl AsRef<Path>) -> PathBuf {
-        self.dir.path().join(rel)
+        let mut path = self.dir.path().to_path_buf();
+        for segment in rel.as_ref().to_string_lossy().split('/') {
+            if segment.is_empty() {
+                continue;
+            }
+            path.push(segment);
+        }
+        path
     }
 
     /// Write a file at `rel` (creating parent directories), returning its path.
@@ -105,5 +184,41 @@ mod tests {
         let fx = Fixture::new();
         let dir = fx.mkdir("nested/dir");
         assert!(dir.is_dir());
+    }
+
+    #[test]
+    fn join_uses_the_host_separator_for_every_segment() {
+        let fx = Fixture::new();
+        let joined = fx.join("repo/.vibe.toml");
+        // Equivalent to a component-wise join, i.e. no stray `/` survives on a
+        // host whose separator is `\`.
+        assert_eq!(joined, fx.path().join("repo").join(".vibe.toml"));
+    }
+
+    #[test]
+    fn fake_roots_are_absolute_on_every_host() {
+        assert!(fake_root("home/u").is_absolute());
+        assert!(fake_home().is_absolute());
+        // No `..` component, so the product's root validation accepts them.
+        assert!(!fake_home()
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir)));
+    }
+
+    #[test]
+    fn to_slash_renders_every_segment_with_a_forward_slash() {
+        // Whatever the host separator, the rendered form is `<prefix>a/b/c`.
+        let rendered = to_slash(fake_root("a/b/c"));
+        assert!(rendered.ends_with("a/b/c"), "got: {rendered}");
+        assert!(!rendered.contains('\\'), "got: {rendered}");
+    }
+
+    #[test]
+    fn fake_root_str_matches_fake_root() {
+        assert_eq!(
+            fake_root_str("home/u"),
+            fake_root("home/u").to_string_lossy()
+        );
+        assert_eq!(fake_home_str(), fake_home().to_string_lossy());
     }
 }


### PR DESCRIPTION
Closes #570.

The first full `cargo test -p vibe-core` on windows-latest (post-#569) failed 83 of 590 tests — all Unix-path assumptions in test fixtures, no product bugs. This makes the suite platform-portable and restores the full run in CI.

## Fixes

- **`vibe-test-support`**: new `fake_root` / `fake_home` / `to_slash` helpers — `/home/u` on Unix, `C:\home\u` on Windows (drive prefix chosen deliberately: doctor's `has_safe_prefix` accepts only `Prefix::Disk`). Fixture literals across 15 modules replaced.
- **`Fixture::join`**: now pushes `/`-separated segments component-wise. Windows accepts `/` in `open()` but preserves it verbatim in the string, so fixture paths (`...\tmp\repo/.vibe.toml`) never string-matched product paths (`...\tmp\repo\.vibe.toml`). This one change fixed all 11 verify/untrust failures with zero edits to those test files.
- **JSON fixtures**: raw `\` in interpolated JSON string literals is invalid — switched to `serde_json::json!`.
- **Completion snapshots**: the byte-for-byte zsh/fish snapshot tests failed due to `core.autocrlf=true` CRLF-mangling the checked-out `.snap` files, not paths. Pinned to LF in `.gitattributes` (no renormalization needed — verified the blobs are already LF; zsh/fish cannot source CRLF files anyway).
- **Nothing was cfg-gated**: the doctor `unix_*` branch tests are pure path logic and now genuinely execute on Windows too.

## CI

- `rust-windows` returns to plain `cargo test -p vibe-core` (the `--exact` six-test scoping from #571/#572 is gone).
- The job's `if:` now also fires on develop PRs labeled **`ci-full`** — the workflow comes from the PR merge commit, so this very PR proves the Windows leg before merging (label applied).

## Verification

`cargo fmt` / `clippy -D warnings` / `cargo test --workspace` (593 vibe-core tests) / `pnpm run check:all` all green on macOS; the Windows proof is this PR's own `rust-windows` run via the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFQdQUb1tdTv7G6YvmWu93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows compatibility across path handling, worktree operations, configuration, and command workflows.
  - Ensured completion snapshots use consistent line endings for reliable comparisons.

- **Tests**
  - Expanded Windows CI coverage to run the complete core unit-test suite.
  - Updated test fixtures and assertions to work consistently across Unix and Windows environments.
  - Added coverage for platform-specific paths, separators, shell compatibility, and absolute-path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->