### PR TITLE
chore: refresh prebuilt-binary hashes for v3.0.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,19 +24,19 @@
       platforms = {
         x86_64-linux = {
           artifact = "vibe-linux-x64";
-          hash = "sha256-zR9OUIcJWfXOHnnBArbPmLNciUO9kYmhbabApYXhSnc=";
+          hash = "sha256-qhw1weNFxVndVd3+HKwO2XIzs6WzVZrllHqWBjNZmno=";
         };
         aarch64-linux = {
           artifact = "vibe-linux-arm64";
-          hash = "sha256-hD0QBZaXPRB+rMyzvYtADFK1qcmn6R8k1MXvGrnXtdo=";
+          hash = "sha256-O8Zr+dajru06NQjLNvz7O9awvXykb2s+TlybbQZCg3w=";
         };
         x86_64-darwin = {
           artifact = "vibe-darwin-x64";
-          hash = "sha256-1qIB2aARjAg6AIkW66pCsxa+AAfjj3Iw3lUXmR5voX0=";
+          hash = "sha256-PAonOeiAIcSEqS6c++egXmEAsch5jAOlQWdEbPIgBpw=";
         };
         aarch64-darwin = {
           artifact = "vibe-darwin-arm64";
-          hash = "sha256-A5CNtmIejiCsbLZd5zPeNilt2mmIErOj/Qyr5ypVghg=";
+          hash = "sha256-WUJG0bS2Yn0SzbS8Oo639YEOZsWjL1+yT3y12WoalyA=";
         };
       };
 


### PR DESCRIPTION
Post-release follow-up for v3.0.0: update the four `platforms.*.hash` fixed-output hashes in `flake.nix` to the published v3.0.0 release binaries (these live outside `flake.lock` and must be bumped by hand on each release; the version itself derives from `package.json`). Hashes computed with `nix store prefetch-file` against the release assets and verified locally with `nix build .#binary` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFQdQUb1tdTv7G6YvmWu93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release verification checksums for Linux and macOS on both x86_64 and aarch64 platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->