### PR TITLE
feat: add a list command to show all worktrees

### DIFF
--- a/packages/e2e/list.test.ts
+++ b/packages/e2e/list.test.ts
@@ -1,0 +1,143 @@
+import { execFileSync } from "child_process";
+import { join } from "path";
+import { afterEach, describe, expect, test } from "vitest";
+import { getVibePath, VibeCommandRunner } from "./helpers/pty.js";
+import { setupTestGitRepo } from "./helpers/git-setup.js";
+import { assertExitCode, assertOutputContains } from "./helpers/assertions.js";
+
+/**
+ * Add a worktree with `git` directly, so the listing is exercised against a
+ * repository state built independently of `vibe start`.
+ */
+function addWorktree(repoPath: string, branch: string, dirName: string): string {
+  const path = join(repoPath, "..", dirName);
+  execFileSync("git", ["worktree", "add", "-b", branch, path], {
+    cwd: repoPath,
+    stdio: "pipe",
+  });
+  return path;
+}
+
+/** Strip PTY carriage returns and ANSI escapes so lines can be matched. */
+function toLines(output: string): string[] {
+  return output
+    .replace(/\x1b\[[0-9;]*[A-Za-z]/g, "")
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+}
+
+describe("list command", () => {
+  let cleanup: (() => Promise<void>) | null = null;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = null;
+    }
+  });
+
+  test("Lists every worktree and marks the current one", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+    addWorktree(repoPath, "feature/alpha", "vibe-e2e-list-alpha");
+
+    const runner = new VibeCommandRunner(getVibePath(), repoPath, homePath);
+    try {
+      await runner.spawn(["list"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+
+      // Both worktrees appear, with their branch names.
+      assertOutputContains(output, "main");
+      assertOutputContains(output, "feature/alpha");
+
+      // Exactly one row is marked, and it is the main worktree we ran from.
+      const marked = toLines(output).filter((line) => line.startsWith("*"));
+      expect(marked).toHaveLength(1);
+      expect(marked[0]).toContain("main");
+    } finally {
+      runner.dispose();
+    }
+  });
+
+  test("Marks the worktree the command is run from", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+    const alphaPath = addWorktree(repoPath, "feature/alpha", "vibe-e2e-list-cwd");
+
+    // Run from inside the secondary worktree: the marker must follow the cwd.
+    const runner = new VibeCommandRunner(getVibePath(), alphaPath, homePath);
+    try {
+      await runner.spawn(["list"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+
+      const marked = toLines(output).filter((line) => line.startsWith("*"));
+      expect(marked).toHaveLength(1);
+      expect(marked[0]).toContain("feature/alpha");
+    } finally {
+      runner.dispose();
+    }
+  });
+
+  test("--json emits a parseable array carrying every worktree", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+    addWorktree(repoPath, "feature/alpha", "vibe-e2e-list-json");
+
+    const runner = new VibeCommandRunner(getVibePath(), repoPath, homePath);
+    try {
+      await runner.spawn(["list", "--json"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+
+      const jsonMatch = output.replace(/\r/g, "").match(/\[[\s\S]*\]/);
+      expect(jsonMatch).not.toBeNull();
+      const parsed = JSON.parse(jsonMatch![0]) as {
+        branch: string;
+        path: string;
+        current: boolean;
+        scratch: boolean;
+      }[];
+
+      expect(parsed).toHaveLength(2);
+      const branches = parsed.map((entry) => entry.branch).sort();
+      expect(branches).toEqual(["feature/alpha", "main"]);
+      // Exactly one entry is the current worktree, and it is `main`.
+      const current = parsed.filter((entry) => entry.current);
+      expect(current).toHaveLength(1);
+      expect(current[0].branch).toBe("main");
+      expect(parsed.every((entry) => entry.scratch === false)).toBe(true);
+    } finally {
+      runner.dispose();
+    }
+  });
+
+  test("Marks scratch worktrees so they are easy to spot", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+    addWorktree(repoPath, "scratch/20260101120000", "vibe-e2e-list-scratch");
+
+    const runner = new VibeCommandRunner(getVibePath(), repoPath, homePath);
+    try {
+      await runner.spawn(["list"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+
+      const scratchLine = toLines(output).find((line) => line.includes("scratch/20260101120000"));
+      expect(scratchLine).toBeDefined();
+      expect(scratchLine).toContain("(scratch)");
+    } finally {
+      runner.dispose();
+    }
+  });
+});

--- a/packages/e2e/list.test.ts
+++ b/packages/e2e/list.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { join } from "path";
+import { basename, join } from "path";
 import { afterEach, describe, expect, test } from "vitest";
 import { getVibePath, VibeCommandRunner } from "./helpers/pty.js";
 import { setupTestGitRepo } from "./helpers/git-setup.js";
@@ -10,7 +10,12 @@ import { assertExitCode, assertOutputContains } from "./helpers/assertions.js";
  * repository state built independently of `vibe start`.
  */
 function addWorktree(repoPath: string, branch: string, dirName: string): string {
-  const path = join(repoPath, "..", dirName);
+  // Prefixed with `basename(repoPath)` (the per-run `mkdtemp` name) rather than
+  // used bare: `join(repoPath, "..", …)` climbs back out to the shared temp
+  // root, so a bare `dirName` is a fixed path across every run. A run that dies
+  // before cleanup would then leave a directory that makes the next run's
+  // `git worktree add` fail on collision instead of testing the listing.
+  const path = join(repoPath, "..", `${basename(repoPath)}-${dirName}`);
   execFileSync("git", ["worktree", "add", "-b", branch, path], {
     cwd: repoPath,
     stdio: "pipe",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1114,6 +1114,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "unicode-width",
  "ureq",
  "uuid",
  "vibe-native",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1095,6 +1095,7 @@ version = "3.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "serde_json",
  "tempfile",
  "vibe-core",
  "vibe-test-support",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,6 +41,11 @@ uuid = { version = "1", features = ["v4"] }
 # silently re-sorts keys, diverging from the shipping TS CLI's file format.
 serde_json = { version = "1", features = ["preserve_order"] }
 toml = "0.8"
+# Terminal display width for column alignment (`vibe list`). Codepoint counts
+# misalign columns for CJK/emoji branch names, which occupy two cells. Already
+# in the tree transitively (indicatif -> console), so this adds no new
+# third-party code — only a direct edge to it.
+unicode-width = "0.2"
 sha2 = "0.10"
 thiserror = "2.0"
 anyhow = "1"

--- a/rust/crates/vibe-core/Cargo.toml
+++ b/rust/crates/vibe-core/Cargo.toml
@@ -27,6 +27,7 @@ globset.workspace = true
 walkdir.workspace = true
 indicatif.workspace = true
 uuid.workspace = true
+unicode-width.workspace = true
 # rustls for the upgrade command's HTTPS check. `default-features = false` drops
 # ureq's default `gzip`. Why not the plain `rustls` feature: it pulls in ureq's
 # `_ring` (rustls/ring) crypto provider. We require aws-lc-rs, so we take

--- a/rust/crates/vibe-core/src/commands/clean.rs
+++ b/rust/crates/vibe-core/src/commands/clean.rs
@@ -135,7 +135,10 @@ where
         success_log(deps.io, "Worktree already removed.", opts);
         return Ok(Outcome::cd(main_path));
     };
-    let current_branch = worktree_info.branch;
+    // A detached worktree has no branch to delete; the empty name makes
+    // `maybe_delete_branch` skip via its existing `branch.is_empty()` guard,
+    // while the worktree itself is still removed normally.
+    let current_branch = worktree_info.branch.unwrap_or_default();
 
     let config = load_vibe_config(deps.io, deps.resolver, deps.version, &current_worktree_path)?;
 
@@ -540,7 +543,10 @@ where
         verbose_log(deps.io, "[cc-worktree-hook] Worktree already removed", opts);
         return Ok(Outcome::none());
     };
-    let current_branch = worktree_info.branch;
+    // A detached worktree has no branch to delete; the empty name makes
+    // `maybe_delete_branch` skip via its existing `branch.is_empty()` guard,
+    // while the worktree itself is still removed normally.
+    let current_branch = worktree_info.branch.unwrap_or_default();
 
     let config = load_vibe_config(deps.io, deps.resolver, deps.version, &worktree_path)?;
 

--- a/rust/crates/vibe-core/src/commands/jump.rs
+++ b/rust/crates/vibe-core/src/commands/jump.rs
@@ -28,6 +28,37 @@ impl HasPath for Worktree {
     }
 }
 
+/// A worktree that is checked out on a branch.
+///
+/// `jump` matches a query against branch names, so a detached-HEAD worktree
+/// (`Worktree::branch == None`) has nothing to match and is filtered out up
+/// front. Narrowing once here — rather than threading `Option` through all seven
+/// matching tiers — keeps every tier operating on a plain `String`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BranchedWorktree {
+    path: String,
+    branch: String,
+}
+
+impl HasPath for BranchedWorktree {
+    fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+/// Keep only the worktrees that are on a branch.
+fn branched(worktrees: Vec<Worktree>) -> Vec<BranchedWorktree> {
+    worktrees
+        .into_iter()
+        .filter_map(|w| {
+            w.branch.map(|branch| BranchedWorktree {
+                path: w.path,
+                branch,
+            })
+        })
+        .collect()
+}
+
 /// Inputs the jump command pulls from the binary (so the clock stays injected).
 pub struct JumpDeps<'a, I, G, P, S>
 where
@@ -63,7 +94,7 @@ where
         return Err(VibeError::Worktree("Branch name is required".to_string()));
     }
 
-    let worktrees = get_worktree_list(deps.git)?;
+    let worktrees = branched(get_worktree_list(deps.git)?);
     verbose_log(
         deps.io,
         &format!("Found {} worktree(s)", worktrees.len()),
@@ -104,7 +135,7 @@ where
     }
 
     // For non-exact matching, optionally drop scratch worktrees.
-    let pool: Vec<&Worktree> = if should_filter_out_scratch(trimmed) {
+    let pool: Vec<&BranchedWorktree> = if should_filter_out_scratch(trimmed) {
         worktrees
             .iter()
             .filter(|w| !is_scratch(&w.branch))
@@ -114,7 +145,7 @@ where
     };
 
     // 3. Word boundary (CS).
-    let wb_cs: Vec<Worktree> = pool
+    let wb_cs: Vec<BranchedWorktree> = pool
         .iter()
         .filter(|w| is_word_boundary_match(&w.branch, trimmed))
         .map(|w| (*w).clone())
@@ -124,7 +155,7 @@ where
     }
 
     // 4. Word boundary (CI).
-    let wb_ci: Vec<Worktree> = pool
+    let wb_ci: Vec<BranchedWorktree> = pool
         .iter()
         .filter(|w| is_word_boundary_match(&w.branch.to_lowercase(), &lower_query))
         .map(|w| (*w).clone())
@@ -134,7 +165,7 @@ where
     }
 
     // 5. Substring (CS).
-    let sub_cs: Vec<Worktree> = pool
+    let sub_cs: Vec<BranchedWorktree> = pool
         .iter()
         .filter(|w| w.branch.contains(trimmed))
         .map(|w| (*w).clone())
@@ -144,7 +175,7 @@ where
     }
 
     // 6. Substring (CI).
-    let sub_ci: Vec<Worktree> = pool
+    let sub_ci: Vec<BranchedWorktree> = pool
         .iter()
         .filter(|w| w.branch.to_lowercase().contains(&lower_query))
         .map(|w| (*w).clone())
@@ -156,13 +187,13 @@ where
     // 7. Fuzzy (≥ 3 chars), sorted by score descending (stable).
     let has_enough = trimmed.chars().count() >= FUZZY_MATCH_MIN_LENGTH;
     if has_enough {
-        let mut scored: Vec<(Worktree, f64)> = pool
+        let mut scored: Vec<(BranchedWorktree, f64)> = pool
             .iter()
             .filter_map(|w| fuzzy_match(&w.branch, trimmed).map(|r| ((*w).clone(), r.score)))
             .collect();
         // Stable sort by score descending (TS `b.score - a.score`).
         scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        let fuzzy: Vec<Worktree> = scored.into_iter().map(|(w, _)| w).collect();
+        let fuzzy: Vec<BranchedWorktree> = scored.into_iter().map(|(w, _)| w).collect();
         if let Some(outcome) = handle_partial(deps, &fuzzy, trimmed, &mru_entries, opts)? {
             return Ok(outcome);
         }
@@ -185,7 +216,7 @@ where
 /// Handle a candidate set: single → jump; multiple → prompt; empty → `None`.
 fn handle_partial<I, G, P, S>(
     deps: &JumpDeps<I, G, P, S>,
-    matches: &[Worktree],
+    matches: &[BranchedWorktree],
     query: &str,
     mru_entries: &[MruEntry],
     opts: OutputOptions,

--- a/rust/crates/vibe-core/src/commands/jump.rs
+++ b/rust/crates/vibe-core/src/commands/jump.rs
@@ -14,7 +14,7 @@ use crate::fuzzy::{fuzzy_match, FUZZY_MATCH_MIN_LENGTH};
 use crate::git::{get_worktree_list, GitRunner, Worktree};
 use crate::io::Io;
 use crate::mru::{load_mru_data, record_mru_entry, sort_by_mru, HasPath, MruEntry};
-use crate::output::{log, verbose_log, OutputOptions};
+use crate::output::{log, sanitize_for_display, verbose_log, OutputOptions};
 use crate::prompt::Prompt;
 
 /// Branch-name prefix marking auto-generated scratch worktrees.
@@ -34,6 +34,14 @@ impl HasPath for Worktree {
 /// (`Worktree::branch == None`) has nothing to match and is filtered out up
 /// front. Narrowing once here — rather than threading `Option` through all seven
 /// matching tiers — keeps every tier operating on a plain `String`.
+///
+/// Both fields hold the RAW git values. `git worktree list --porcelain -z`
+/// preserves a literal newline (or any control character) inside a path, and a
+/// branch name can carry one too, so every *display* site — prompt labels and
+/// verbose diagnostics — runs the value through
+/// [`sanitize_for_display`](crate::output::sanitize_for_display), matching what
+/// `list` does. Sanitizing at the struct instead would corrupt the `cd` target
+/// and the MRU key, which must stay byte-exact to actually work.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct BranchedWorktree {
     path: String,
@@ -111,7 +119,11 @@ where
     if let Some(wt) = worktrees.iter().find(|w| w.branch == trimmed) {
         verbose_log(
             deps.io,
-            &format!("Exact match found: {} -> {}", wt.branch, wt.path),
+            &format!(
+                "Exact match found: {} -> {}",
+                sanitize_for_display(&wt.branch),
+                sanitize_for_display(&wt.path)
+            ),
             opts,
         );
         return Ok(jump_to(deps, &wt.branch, &wt.path));
@@ -126,11 +138,16 @@ where
             deps.io,
             &format!(
                 "Exact match found (case-insensitive): {} -> {}",
-                wt.branch, wt.path
+                sanitize_for_display(&wt.branch),
+                sanitize_for_display(&wt.path)
             ),
             opts,
         );
-        log(deps.io, &format!("Matched: {}", wt.branch), opts);
+        log(
+            deps.io,
+            &format!("Matched: {}", sanitize_for_display(&wt.branch)),
+            opts,
+        );
         return Ok(jump_to(deps, &wt.branch, &wt.path));
     }
 
@@ -231,10 +248,18 @@ where
         let wt = &matches[0];
         verbose_log(
             deps.io,
-            &format!("Partial match found: {} -> {}", wt.branch, wt.path),
+            &format!(
+                "Partial match found: {} -> {}",
+                sanitize_for_display(&wt.branch),
+                sanitize_for_display(&wt.path)
+            ),
             opts,
         );
-        log(deps.io, &format!("Matched: {}", wt.branch), opts);
+        log(
+            deps.io,
+            &format!("Matched: {}", sanitize_for_display(&wt.branch)),
+            opts,
+        );
         return Ok(Some(jump_to(deps, &wt.branch, &wt.path)));
     }
 
@@ -246,9 +271,17 @@ where
         );
 
         let sorted = sort_by_mru(matches, mru_entries);
+        // Labels only: `sorted[selected]` still carries the raw branch/path, so
+        // the `cd` and the MRU record are unaffected by this substitution.
         let mut choices: Vec<String> = sorted
             .iter()
-            .map(|w| format!("{} ({})", w.branch, w.path))
+            .map(|w| {
+                format!(
+                    "{} ({})",
+                    sanitize_for_display(&w.branch),
+                    sanitize_for_display(&w.path)
+                )
+            })
             .collect();
         choices.push("Cancel".to_string());
 
@@ -329,23 +362,32 @@ mod tests {
     }
 
     /// Prompt scripted with a confirm answer and a select index.
+    ///
+    /// Also records the choice labels it was offered, so tests can assert what
+    /// the user would actually have seen.
     struct ScriptPrompt {
         confirm: bool,
         select: RefCell<Vec<usize>>,
+        offered: RefCell<Vec<String>>,
     }
     impl ScriptPrompt {
         fn new(confirm: bool, selects: &[usize]) -> Self {
             ScriptPrompt {
                 confirm,
                 select: RefCell::new(selects.to_vec()),
+                offered: RefCell::new(Vec::new()),
             }
+        }
+        fn offered(&self) -> Vec<String> {
+            self.offered.borrow().clone()
         }
     }
     impl Prompt for ScriptPrompt {
         fn confirm(&self, _message: &str) -> bool {
             self.confirm
         }
-        fn select(&self, _message: &str, _choices: &[String]) -> Result<usize> {
+        fn select(&self, _message: &str, choices: &[String]) -> Result<usize> {
+            *self.offered.borrow_mut() = choices.to_vec();
             Ok(self.select.borrow_mut().remove(0))
         }
     }
@@ -693,5 +735,90 @@ mod tests {
         assert!(io.stderr_text().contains("Cancelled"));
         // Cancel records no MRU entry.
         assert!(crate::mru::load_mru_data(&io).is_empty());
+    }
+
+    /// NUL-framed porcelain, as `git worktree list --porcelain -z` emits it.
+    ///
+    /// The newline-framed `porcelain()` helper cannot express a path that
+    /// itself contains a newline — which is the whole point of these two tests.
+    fn porcelain_z(entries: &[(&str, &str)]) -> String {
+        let mut s = String::new();
+        for (path, branch) in entries {
+            s.push_str(&format!(
+                "worktree {path}\0HEAD abc\0branch refs/heads/{branch}\0\0"
+            ));
+        }
+        s
+    }
+
+    #[test]
+    fn selection_labels_are_sanitized_but_the_cd_target_is_not() {
+        // What it guarantees: a path carrying a literal newline (which `-z`
+        // preserves) cannot inject an extra line into the interactive chooser,
+        // while the `cd` the shell evals still points at the real directory.
+        let fx = vibe_test_support::Fixture::new();
+        let io = FakeIo::new().with_env("HOME", fx.path().to_str().unwrap());
+        let evil = "/wt/a\nFAKE-CHOICE";
+        let git = ListGit {
+            porcelain: porcelain_z(&[(evil, "feat/login"), ("/wt/b", "fix/login")]),
+        };
+        let prompt = ScriptPrompt::new(false, &[0]);
+        let start = UnimplementedStart;
+        let d = JumpDeps {
+            io: &io,
+            git: &git,
+            prompt: &prompt,
+            start: &start,
+            now_ms: 1,
+        };
+        let outcome = jump_command(&d, "login", OutputOptions::default()).unwrap();
+
+        let offered = prompt.offered();
+        assert!(
+            offered.iter().all(|c| !c.contains('\n')),
+            "a raw newline reached the chooser: {offered:?}"
+        );
+        assert!(
+            offered
+                .iter()
+                .any(|c| c.contains("/wt/a\u{fffd}FAKE-CHOICE")),
+            "the path was not sanitized in place: {offered:?}"
+        );
+        // Navigation keeps the raw bytes, or the `cd` would miss the directory.
+        assert_eq!(outcome, Outcome::cd(evil));
+    }
+
+    #[test]
+    fn verbose_match_diagnostics_are_sanitized() {
+        // What it guarantees: the single-match verbose line goes through the
+        // same display policy, so a control character in a path cannot rewrite
+        // the surrounding diagnostic.
+        let fx = vibe_test_support::Fixture::new();
+        let io = FakeIo::new().with_env("HOME", fx.path().to_str().unwrap());
+        let evil = "/wt/a\nfatal: spoofed";
+        let git = ListGit {
+            porcelain: porcelain_z(&[(evil, "feat/login")]),
+        };
+        let prompt = ScriptPrompt::new(false, &[]);
+        let start = UnimplementedStart;
+        let d = JumpDeps {
+            io: &io,
+            git: &git,
+            prompt: &prompt,
+            start: &start,
+            now_ms: 1,
+        };
+        let opts = OutputOptions {
+            verbose: true,
+            ..OutputOptions::default()
+        };
+        let outcome = jump_command(&d, "login", opts).unwrap();
+
+        let err = io.stderr_text();
+        assert!(
+            err.contains("/wt/a\u{fffd}fatal: spoofed"),
+            "the diagnostic was not sanitized: {err:?}"
+        );
+        assert_eq!(outcome, Outcome::cd(evil));
     }
 }

--- a/rust/crates/vibe-core/src/commands/list.rs
+++ b/rust/crates/vibe-core/src/commands/list.rs
@@ -18,6 +18,7 @@ use crate::io::Io;
 use crate::mru::{load_mru_data, sort_by_mru};
 use crate::output::{report_log, sanitize_for_display, verbose_log, OutputOptions};
 use serde::Serialize;
+use unicode_width::UnicodeWidthStr;
 
 /// Marker printed in the first column for the worktree the user is standing in.
 const CURRENT_MARKER: &str = "*";
@@ -26,11 +27,16 @@ const CURRENT_MARKER: &str = "*";
 /// easy to spot (and easy to clean up).
 const SCRATCH_LABEL: &str = "(scratch)";
 
+/// Placeholder shown in the branch column for a detached-HEAD worktree, which
+/// has no branch to name.
+const DETACHED_LABEL: &str = "(detached)";
+
 /// One rendered row of the listing. `Serialize` drives `--json`, so the field
 /// names are the stable public schema of that output.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ListEntry {
-    pub branch: String,
+    /// `None` for a detached-HEAD worktree (JSON emits `null`).
+    pub branch: Option<String>,
     pub path: String,
     /// Whether this is the worktree the command was invoked from.
     pub current: bool,
@@ -65,11 +71,6 @@ where
     }
 
     let entries = collect_entries(deps)?;
-    verbose_log(
-        deps.io,
-        &format!("Found {} worktree(s)", entries.len()),
-        opts,
-    );
 
     if json {
         let text = serde_json::to_string_pretty(&entries).map_err(|e| {
@@ -77,9 +78,20 @@ where
         })?;
         // `report_log`, not `log`: the listing is the whole point of the command,
         // so `--quiet` must not turn `vibe list` into a silent no-op.
+        //
+        // The diagnostic is deliberately NOT emitted here: `--json` writes its
+        // payload to the same stderr stream, so a `[verbose]` line would prepend
+        // non-JSON bytes to the document and break `vibe --verbose list --json |
+        // jq`. In JSON mode the payload is the only thing on the stream.
         report_log(deps.io, &text);
         return Ok(Outcome::none());
     }
+
+    verbose_log(
+        deps.io,
+        &format!("Found {} worktree(s)", entries.len()),
+        opts,
+    );
 
     if entries.is_empty() {
         report_log(deps.io, "No worktrees found.");
@@ -108,11 +120,23 @@ where
     let sorted = sort_by_mru(&worktrees, &mru);
 
     let cwd = lexical_normalize_path(deps.cwd);
+    // Worktrees CAN nest (`git worktree add <wt>/inner` is accepted), so several
+    // rows may contain `cwd`. The innermost one — the longest containing path —
+    // is the worktree the user is actually standing in.
+    let current_path = sorted
+        .iter()
+        .map(|w| lexical_normalize_path(&w.path))
+        .filter(|base| is_within(&cwd, base))
+        .max_by_key(|base| base.len());
+
     let mut entries: Vec<ListEntry> = sorted
         .into_iter()
         .map(|w| ListEntry {
-            current: is_within(&cwd, &w.path),
-            scratch: w.branch.starts_with(SCRATCH_PREFIX),
+            current: current_path.as_deref() == Some(lexical_normalize_path(&w.path).as_str()),
+            scratch: w
+                .branch
+                .as_deref()
+                .is_some_and(|b| b.starts_with(SCRATCH_PREFIX)),
             branch: w.branch,
             path: w.path,
         })
@@ -124,22 +148,25 @@ where
     Ok(entries)
 }
 
-/// Whether `cwd` is the worktree at `path` or a directory inside it.
+/// Whether `cwd` is the worktree at the already-normalized `base`, or inside it.
 ///
 /// Comparison is lexical (like [`get_worktree_by_path`]): no filesystem access,
 /// so a worktree that has just been moved out from under the process still
-/// compares sanely instead of erroring. Nested worktrees are impossible in git,
-/// so a prefix match cannot mark two rows.
+/// compares sanely instead of erroring.
+///
+/// This answers *containment* only. Containment alone does NOT identify the
+/// current worktree: git permits nesting (`git worktree add <wt>/inner`
+/// succeeds), so a cwd inside `inner` is contained by both rows. The caller
+/// resolves that by taking the longest containing path.
 ///
 /// [`get_worktree_by_path`]: crate::git::get_worktree_by_path
-fn is_within(cwd: &str, path: &str) -> bool {
-    let base = lexical_normalize_path(path);
+fn is_within(cwd: &str, base: &str) -> bool {
     if cwd == base {
         return true;
     }
     // Require a separator so `/repo/feature-2` is not read as inside `/repo/feature`.
     let with_sep = if base.ends_with('/') {
-        base.clone()
+        base.to_string()
     } else {
         format!("{base}/")
     };
@@ -149,24 +176,28 @@ fn is_within(cwd: &str, path: &str) -> bool {
 /// Render the aligned plain-text table (one `String` per line).
 ///
 /// Column width is computed from the *sanitized* branch text so a branch name
-/// carrying control characters cannot skew the alignment of the other rows.
+/// carrying control characters cannot skew the alignment of the other rows, and
+/// in terminal *display* cells rather than codepoints: a CJK or emoji branch
+/// name occupies two cells per character, so padding by `chars().count()` would
+/// leave the path column ragged.
 fn render_table(entries: &[ListEntry]) -> Vec<String> {
     let branches: Vec<String> = entries
         .iter()
-        .map(|e| sanitize_for_display(&e.branch))
+        .map(|e| match &e.branch {
+            Some(b) => sanitize_for_display(b),
+            None => DETACHED_LABEL.to_string(),
+        })
         .collect();
-    let width = branches
-        .iter()
-        .map(|b| b.chars().count())
-        .max()
-        .unwrap_or(0);
+    let width = branches.iter().map(|b| b.width()).max().unwrap_or(0);
 
     entries
         .iter()
         .zip(&branches)
         .map(|(entry, branch)| {
             let marker = if entry.current { CURRENT_MARKER } else { " " };
-            let pad = " ".repeat(width - branch.chars().count());
+            // `saturating_sub` because `width` is the max over this same set, so
+            // the difference can never actually go negative.
+            let pad = " ".repeat(width.saturating_sub(branch.width()));
             let path = sanitize_for_display(&entry.path);
             let mut line = format!("{marker} {branch}{pad}  {path}");
             if entry.scratch {
@@ -190,11 +221,21 @@ mod tests {
     }
     impl ListGit {
         fn with(entries: &[(&str, &str)]) -> Self {
+            let owned: Vec<(&str, Option<&str>)> =
+                entries.iter().map(|(p, b)| (*p, Some(*b))).collect();
+            ListGit::with_optional_branches(&owned)
+        }
+
+        /// Same, but `None` renders the detached-HEAD porcelain shape (a bare
+        /// `detached` line and no `branch` line), exactly as real git emits it.
+        fn with_optional_branches(entries: &[(&str, Option<&str>)]) -> Self {
             let mut porcelain = String::new();
             for (path, branch) in entries {
-                porcelain.push_str(&format!(
-                    "worktree {path}\nHEAD abc\nbranch refs/heads/{branch}\n\n"
-                ));
+                porcelain.push_str(&format!("worktree {path}\nHEAD abc\n"));
+                match branch {
+                    Some(b) => porcelain.push_str(&format!("branch refs/heads/{b}\n\n")),
+                    None => porcelain.push_str("detached\n\n"),
+                }
             }
             ListGit {
                 porcelain,
@@ -475,5 +516,137 @@ mod tests {
         assert!(is_within("/repo/feat/src", "/repo/feat"));
         assert!(!is_within("/repo/feat-2", "/repo/feat"));
         assert!(!is_within("/repo", "/repo/feat"));
+    }
+
+    #[test]
+    fn detached_worktrees_are_listed_not_dropped() {
+        // git emits no `branch` line for a detached HEAD; the worktree still
+        // exists and must appear in the listing.
+        let io = no_home();
+        let git =
+            ListGit::with_optional_branches(&[("/repo/main", Some("main")), ("/repo/det", None)]);
+        run(&io, &git, "/repo/main", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        assert_eq!(lines.len(), 2, "detached row missing: {lines:?}");
+        let det = lines
+            .iter()
+            .find(|l| l.contains("/repo/det"))
+            .expect("detached row present");
+        assert!(det.contains(DETACHED_LABEL), "got: {det}");
+    }
+
+    #[test]
+    fn a_detached_worktree_is_marked_current_and_serializes_as_null() {
+        let io = no_home();
+        let git =
+            ListGit::with_optional_branches(&[("/repo/main", Some("main")), ("/repo/det", None)]);
+        run(&io, &git, "/repo/det", true).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&io.stderr_text()).unwrap();
+        assert_eq!(
+            parsed,
+            serde_json::json!([
+                {
+                    "branch": null,
+                    "path": "/repo/det",
+                    "current": true,
+                    "scratch": false,
+                },
+                {
+                    "branch": "main",
+                    "path": "/repo/main",
+                    "current": false,
+                    "scratch": false,
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn a_nested_worktree_marks_only_the_innermost_row() {
+        // `git worktree add <wt>/inner` is accepted by git, so `/repo/feat` and
+        // `/repo/feat/inner` can both contain the cwd. Only the innermost is
+        // the worktree the user is standing in.
+        let io = no_home();
+        let git = ListGit::with(&[
+            ("/repo/main", "main"),
+            ("/repo/feat", "feat"),
+            ("/repo/feat/inner", "inner"),
+        ]);
+        run(&io, &git, "/repo/feat/inner/src", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        let marked: Vec<&String> = lines.iter().filter(|l| l.starts_with('*')).collect();
+        assert_eq!(marked.len(), 1, "exactly one row is marked: {lines:?}");
+        assert!(marked[0].contains("/repo/feat/inner"), "got: {marked:?}");
+    }
+
+    #[test]
+    fn a_nested_worktree_outside_the_inner_tree_marks_the_outer_row() {
+        // The complement: standing in the outer worktree but NOT inside the
+        // nested one still marks the outer row (and only it).
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/feat", "feat"), ("/repo/feat/inner", "inner")]);
+        run(&io, &git, "/repo/feat/src", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        let marked: Vec<&String> = lines.iter().filter(|l| l.starts_with('*')).collect();
+        assert_eq!(marked.len(), 1, "exactly one row is marked: {lines:?}");
+        assert!(!marked[0].contains("inner"), "got: {marked:?}");
+    }
+
+    #[test]
+    fn verbose_does_not_prepend_a_diagnostic_to_the_json_payload() {
+        // `--json` writes to the same stderr stream as the diagnostics, so a
+        // `[verbose]` line would make the payload unparseable.
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main")]);
+        let deps = ListDeps {
+            io: &io,
+            git: &git,
+            cwd: "/repo/main",
+        };
+        list_command(&deps, true, OutputOptions::new(true, false)).unwrap();
+
+        let text = io.stderr_text();
+        assert!(!text.contains("[verbose]"), "diagnostic leaked: {text}");
+        // The whole stream parses as JSON, byte for byte.
+        serde_json::from_str::<serde_json::Value>(&text).expect("stderr must be pure JSON");
+    }
+
+    #[test]
+    fn verbose_still_reports_the_count_in_text_mode() {
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main")]);
+        let deps = ListDeps {
+            io: &io,
+            git: &git,
+            cwd: "/repo/main",
+        };
+        list_command(&deps, false, OutputOptions::new(true, false)).unwrap();
+        assert!(io.stderr_text().contains("[verbose] Found 1 worktree(s)"));
+    }
+
+    #[test]
+    fn wide_branch_names_align_by_display_width_not_codepoints() {
+        // Each CJK character occupies two terminal cells. Padding by codepoint
+        // count would leave the path column ragged.
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/a", "機能/ログイン"), ("/repo/b", "main")]);
+        run(&io, &git, "/repo/a", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        let widths: Vec<usize> = lines
+            .iter()
+            .map(|l| {
+                let idx = l.find("/repo/").expect("every row shows a path");
+                l[..idx].width()
+            })
+            .collect();
+        assert!(
+            widths.windows(2).all(|w| w[0] == w[1]),
+            "paths not aligned by display width: {lines:?} -> {widths:?}"
+        );
     }
 }

--- a/rust/crates/vibe-core/src/commands/list.rs
+++ b/rust/crates/vibe-core/src/commands/list.rs
@@ -1,0 +1,479 @@
+//! `vibe list`: show every worktree of the current repository at a glance.
+//!
+//! The listing IS this command's product, but it still goes to the *human*
+//! channel (stderr) via the [`Io`], exactly like `vibe config`: the shell
+//! wrapper evals stdout verbatim (`eval "$(command vibe "$@")"`), so a table
+//! written there would be executed as shell code. `list` therefore returns
+//! [`Outcome::none()`] and never emits a `cd`.
+//!
+//! Enumeration reuses [`get_worktree_list`] (the same source `jump` matches
+//! against) and the MRU store `jump` maintains, so the two commands can never
+//! disagree about which worktrees exist or which one was used last.
+
+use crate::commands::jump::SCRATCH_PREFIX;
+use crate::commands::Outcome;
+use crate::error::{Result, VibeError};
+use crate::git::{get_worktree_list, is_inside_worktree, lexical_normalize_path, GitRunner};
+use crate::io::Io;
+use crate::mru::{load_mru_data, sort_by_mru};
+use crate::output::{report_log, sanitize_for_display, verbose_log, OutputOptions};
+use serde::Serialize;
+
+/// Marker printed in the first column for the worktree the user is standing in.
+const CURRENT_MARKER: &str = "*";
+
+/// Label appended to a `scratch/<timestamp>` worktree so throwaway trees are
+/// easy to spot (and easy to clean up).
+const SCRATCH_LABEL: &str = "(scratch)";
+
+/// One rendered row of the listing. `Serialize` drives `--json`, so the field
+/// names are the stable public schema of that output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ListEntry {
+    pub branch: String,
+    pub path: String,
+    /// Whether this is the worktree the command was invoked from.
+    pub current: bool,
+    /// Whether the branch is an auto-generated `scratch/<timestamp>` worktree.
+    pub scratch: bool,
+}
+
+/// Inputs `list` pulls from the binary.
+pub struct ListDeps<'a, I, G>
+where
+    I: Io,
+    G: GitRunner,
+{
+    pub io: &'a I,
+    pub git: &'a G,
+    /// The directory the command was invoked from, used to mark the current row.
+    pub cwd: &'a str,
+}
+
+/// Run `vibe list [--json]`.
+pub fn list_command<I, G>(deps: &ListDeps<I, G>, json: bool, opts: OutputOptions) -> Result<Outcome>
+where
+    I: Io,
+    G: GitRunner,
+{
+    let inside = is_inside_worktree(deps.git);
+    if !inside {
+        // Same fatal (exit-1) shape `home` uses for the identical situation.
+        return Err(VibeError::Worktree(
+            "Not inside a git repository.".to_string(),
+        ));
+    }
+
+    let entries = collect_entries(deps)?;
+    verbose_log(
+        deps.io,
+        &format!("Found {} worktree(s)", entries.len()),
+        opts,
+    );
+
+    if json {
+        let text = serde_json::to_string_pretty(&entries).map_err(|e| {
+            VibeError::Configuration(format!("Failed to serialize worktree list: {e}"))
+        })?;
+        // `report_log`, not `log`: the listing is the whole point of the command,
+        // so `--quiet` must not turn `vibe list` into a silent no-op.
+        report_log(deps.io, &text);
+        return Ok(Outcome::none());
+    }
+
+    if entries.is_empty() {
+        report_log(deps.io, "No worktrees found.");
+        return Ok(Outcome::none());
+    }
+
+    for line in render_table(&entries) {
+        report_log(deps.io, &line);
+    }
+
+    Ok(Outcome::none())
+}
+
+/// Build the ordered entry list: the current worktree first, then the rest in
+/// MRU order (most recently jumped-to first), then never-visited worktrees in
+/// git's own emitted order.
+fn collect_entries<I, G>(deps: &ListDeps<I, G>) -> Result<Vec<ListEntry>>
+where
+    I: Io,
+    G: GitRunner,
+{
+    let worktrees = get_worktree_list(deps.git)?;
+    // MRU is best-effort everywhere else in the codebase; a missing or corrupt
+    // store must degrade to git order, never fail the listing.
+    let mru = load_mru_data(deps.io);
+    let sorted = sort_by_mru(&worktrees, &mru);
+
+    let cwd = lexical_normalize_path(deps.cwd);
+    let mut entries: Vec<ListEntry> = sorted
+        .into_iter()
+        .map(|w| ListEntry {
+            current: is_within(&cwd, &w.path),
+            scratch: w.branch.starts_with(SCRATCH_PREFIX),
+            branch: w.branch,
+            path: w.path,
+        })
+        .collect();
+
+    // Current worktree first; the MRU order established above is preserved for
+    // everything else because `sort_by_key` is stable.
+    entries.sort_by_key(|e| !e.current);
+    Ok(entries)
+}
+
+/// Whether `cwd` is the worktree at `path` or a directory inside it.
+///
+/// Comparison is lexical (like [`get_worktree_by_path`]): no filesystem access,
+/// so a worktree that has just been moved out from under the process still
+/// compares sanely instead of erroring. Nested worktrees are impossible in git,
+/// so a prefix match cannot mark two rows.
+///
+/// [`get_worktree_by_path`]: crate::git::get_worktree_by_path
+fn is_within(cwd: &str, path: &str) -> bool {
+    let base = lexical_normalize_path(path);
+    if cwd == base {
+        return true;
+    }
+    // Require a separator so `/repo/feature-2` is not read as inside `/repo/feature`.
+    let with_sep = if base.ends_with('/') {
+        base.clone()
+    } else {
+        format!("{base}/")
+    };
+    cwd.starts_with(&with_sep)
+}
+
+/// Render the aligned plain-text table (one `String` per line).
+///
+/// Column width is computed from the *sanitized* branch text so a branch name
+/// carrying control characters cannot skew the alignment of the other rows.
+fn render_table(entries: &[ListEntry]) -> Vec<String> {
+    let branches: Vec<String> = entries
+        .iter()
+        .map(|e| sanitize_for_display(&e.branch))
+        .collect();
+    let width = branches
+        .iter()
+        .map(|b| b.chars().count())
+        .max()
+        .unwrap_or(0);
+
+    entries
+        .iter()
+        .zip(&branches)
+        .map(|(entry, branch)| {
+            let marker = if entry.current { CURRENT_MARKER } else { " " };
+            let pad = " ".repeat(width - branch.chars().count());
+            let path = sanitize_for_display(&entry.path);
+            let mut line = format!("{marker} {branch}{pad}  {path}");
+            if entry.scratch {
+                line.push(' ');
+                line.push_str(SCRATCH_LABEL);
+            }
+            line
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::FakeIo;
+
+    /// Git returning a fixed worktree-list porcelain and reporting "inside repo".
+    struct ListGit {
+        porcelain: String,
+        inside: bool,
+    }
+    impl ListGit {
+        fn with(entries: &[(&str, &str)]) -> Self {
+            let mut porcelain = String::new();
+            for (path, branch) in entries {
+                porcelain.push_str(&format!(
+                    "worktree {path}\nHEAD abc\nbranch refs/heads/{branch}\n\n"
+                ));
+            }
+            ListGit {
+                porcelain,
+                inside: true,
+            }
+        }
+    }
+    impl GitRunner for ListGit {
+        fn run(&self, args: &[&str]) -> Result<String> {
+            if args.contains(&"--is-inside-work-tree") {
+                return Ok(if self.inside { "true" } else { "false" }.to_string());
+            }
+            if args.contains(&"worktree") {
+                return Ok(self.porcelain.clone());
+            }
+            Ok(String::new())
+        }
+    }
+
+    fn run(io: &FakeIo, git: &ListGit, cwd: &str, json: bool) -> Result<Outcome> {
+        let deps = ListDeps { io, git, cwd };
+        list_command(&deps, json, OutputOptions::default())
+    }
+
+    fn no_home() -> FakeIo {
+        FakeIo::new().with_env("HOME", "/nonexistent-home")
+    }
+
+    #[test]
+    fn errors_when_not_inside_a_repository() {
+        let io = no_home();
+        let git = ListGit {
+            porcelain: String::new(),
+            inside: false,
+        };
+        let err = run(&io, &git, "/tmp", false).unwrap_err();
+        assert_eq!(err.exit_code(), 1);
+        assert!(err.to_string().contains("Not inside a git repository."));
+    }
+
+    #[test]
+    fn lists_every_worktree_with_branch_and_path() {
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main"), ("/repo/feat", "feat/login")]);
+        let outcome = run(&io, &git, "/repo/main", false).unwrap();
+        // The listing is the product; no `cd` is ever emitted.
+        assert_eq!(outcome, Outcome::none());
+
+        let text = io.stderr_text();
+        assert!(text.contains("main"));
+        assert!(text.contains("/repo/main"));
+        assert!(text.contains("feat/login"));
+        assert!(text.contains("/repo/feat"));
+    }
+
+    #[test]
+    fn marks_only_the_current_worktree() {
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main"), ("/repo/feat", "feat/login")]);
+        run(&io, &git, "/repo/feat", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        let marked: Vec<&String> = lines.iter().filter(|l| l.starts_with('*')).collect();
+        assert_eq!(marked.len(), 1, "exactly one row is marked: {lines:?}");
+        assert!(marked[0].contains("feat/login"));
+    }
+
+    #[test]
+    fn marks_the_current_worktree_from_a_nested_directory() {
+        // The user is deep inside the worktree, not at its root.
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main"), ("/repo/feat", "feat/login")]);
+        run(&io, &git, "/repo/feat/src/deep", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        let marked: Vec<&String> = lines.iter().filter(|l| l.starts_with('*')).collect();
+        assert_eq!(marked.len(), 1);
+        assert!(marked[0].contains("feat/login"));
+    }
+
+    #[test]
+    fn a_sibling_with_a_shared_prefix_is_not_marked() {
+        // `/repo/feat-2` must not be read as being inside `/repo/feat`.
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/feat", "feat"), ("/repo/feat-2", "feat-2")]);
+        run(&io, &git, "/repo/feat-2", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        let marked: Vec<&String> = lines.iter().filter(|l| l.starts_with('*')).collect();
+        assert_eq!(marked.len(), 1);
+        assert!(marked[0].contains("feat-2"));
+    }
+
+    #[test]
+    fn nothing_is_marked_when_cwd_is_outside_every_worktree() {
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main")]);
+        run(&io, &git, "/somewhere/else", false).unwrap();
+        assert!(!io.stderr_text().contains('*'));
+    }
+
+    #[test]
+    fn scratch_worktrees_are_labelled() {
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main"), ("/repo/s", "scratch/20260101")]);
+        run(&io, &git, "/repo/main", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        let scratch_line = lines
+            .iter()
+            .find(|l| l.contains("scratch/20260101"))
+            .expect("scratch row present");
+        assert!(scratch_line.contains(SCRATCH_LABEL));
+        let main_line = lines
+            .iter()
+            .find(|l| l.contains(" main "))
+            .expect("main row present");
+        assert!(!main_line.contains(SCRATCH_LABEL));
+    }
+
+    #[test]
+    fn columns_are_aligned_so_paths_start_at_one_offset() {
+        let io = no_home();
+        let git = ListGit::with(&[
+            ("/repo/main", "main"),
+            ("/repo/long", "feature/a-very-long-branch-name"),
+        ]);
+        run(&io, &git, "/repo/main", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        let offsets: Vec<usize> = lines
+            .iter()
+            .map(|l| l.find("/repo/").expect("every row shows a path"))
+            .collect();
+        assert!(
+            offsets.windows(2).all(|w| w[0] == w[1]),
+            "paths not aligned: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn the_current_worktree_is_listed_first() {
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main"), ("/repo/feat", "feat/login")]);
+        run(&io, &git, "/repo/feat", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        assert!(lines[0].contains("feat/login"), "got: {lines:?}");
+    }
+
+    #[test]
+    fn remaining_worktrees_follow_mru_order() {
+        // main is current (first); of the other two, the most recently jumped-to
+        // one must come next even though git lists it last.
+        let fx = vibe_test_support::Fixture::new();
+        let io = FakeIo::new().with_env("HOME", fx.path().to_str().unwrap());
+        crate::mru::record_mru_entry(&io, "feat/a", "/repo/a", 100).unwrap();
+        crate::mru::record_mru_entry(&io, "feat/b", "/repo/b", 200).unwrap();
+
+        let git = ListGit::with(&[
+            ("/repo/main", "main"),
+            ("/repo/a", "feat/a"),
+            ("/repo/b", "feat/b"),
+        ]);
+        run(&io, &git, "/repo/main", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        assert!(lines[0].contains("main"), "got: {lines:?}");
+        assert!(lines[1].contains("feat/b"), "got: {lines:?}");
+        assert!(lines[2].contains("feat/a"), "got: {lines:?}");
+    }
+
+    #[test]
+    fn json_output_is_parseable_and_carries_every_field() {
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main"), ("/repo/s", "scratch/20260101")]);
+        let outcome = run(&io, &git, "/repo/main", true).unwrap();
+        assert_eq!(outcome, Outcome::none());
+
+        // Parsed as generic JSON (not back into `ListEntry`): the assertion is
+        // about the wire schema consumers depend on, not about a round-trip
+        // through our own derive.
+        let parsed: serde_json::Value = serde_json::from_str(&io.stderr_text()).unwrap();
+        assert_eq!(
+            parsed,
+            serde_json::json!([
+                {
+                    "branch": "main",
+                    "path": "/repo/main",
+                    "current": true,
+                    "scratch": false,
+                },
+                {
+                    "branch": "scratch/20260101",
+                    "path": "/repo/s",
+                    "current": false,
+                    "scratch": true,
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn json_output_omits_the_human_table() {
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main")]);
+        run(&io, &git, "/repo/main", true).unwrap();
+        // A `*` marker would mean the table leaked into the machine-readable form.
+        assert!(!io.stderr_text().contains('*'));
+    }
+
+    #[test]
+    fn empty_repository_listing_says_so() {
+        let io = no_home();
+        let git = ListGit {
+            porcelain: String::new(),
+            inside: true,
+        };
+        run(&io, &git, "/repo", false).unwrap();
+        assert!(io.stderr_text().contains("No worktrees found."));
+    }
+
+    #[test]
+    fn empty_json_listing_is_an_empty_array() {
+        let io = no_home();
+        let git = ListGit {
+            porcelain: String::new(),
+            inside: true,
+        };
+        run(&io, &git, "/repo", true).unwrap();
+        assert_eq!(io.stderr_text(), "[]");
+    }
+
+    #[test]
+    fn quiet_does_not_silence_the_listing() {
+        // The listing IS the command's product; `--quiet` must not make
+        // `vibe list` exit 0 having printed nothing.
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/main", "main")]);
+        let deps = ListDeps {
+            io: &io,
+            git: &git,
+            cwd: "/repo/main",
+        };
+        list_command(&deps, false, OutputOptions::new(false, true)).unwrap();
+        assert!(io.stderr_text().contains("/repo/main"));
+    }
+
+    #[test]
+    fn terminal_control_characters_in_a_branch_are_neutralized() {
+        let io = no_home();
+        let git = ListGit::with(&[("/repo/x", "feat/\x1b[2Kspoof")]);
+        run(&io, &git, "/repo/x", false).unwrap();
+        let text = io.stderr_text();
+        assert!(
+            !text.contains('\x1b'),
+            "escape reached the terminal: {text}"
+        );
+        assert!(text.contains('\u{fffd}'));
+    }
+
+    #[test]
+    fn a_corrupt_mru_store_degrades_to_git_order() {
+        let fx = vibe_test_support::Fixture::new();
+        let _ = fx.write(".config/vibe/mru.json", "{not an array");
+        let io = FakeIo::new().with_env("HOME", fx.path().to_str().unwrap());
+        let git = ListGit::with(&[("/repo/a", "feat/a"), ("/repo/b", "feat/b")]);
+        run(&io, &git, "/somewhere/else", false).unwrap();
+
+        let lines: Vec<String> = io.stderr.borrow().clone();
+        assert!(lines[0].contains("feat/a"), "got: {lines:?}");
+        assert!(lines[1].contains("feat/b"), "got: {lines:?}");
+    }
+
+    #[test]
+    fn is_within_helper() {
+        assert!(is_within("/repo/feat", "/repo/feat"));
+        assert!(is_within("/repo/feat/src", "/repo/feat"));
+        assert!(!is_within("/repo/feat-2", "/repo/feat"));
+        assert!(!is_within("/repo", "/repo/feat"));
+    }
+}

--- a/rust/crates/vibe-core/src/commands/mod.rs
+++ b/rust/crates/vibe-core/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod doctor;
 pub mod home;
 pub mod jump;
+pub mod list;
 pub mod rename;
 pub mod scratch;
 pub mod shell_setup;

--- a/rust/crates/vibe-core/src/commands/rename.rs
+++ b/rust/crates/vibe-core/src/commands/rename.rs
@@ -77,7 +77,16 @@ where
         return Err(VibeError::AlreadyReported);
     }
 
-    let old_name = current.branch.clone();
+    // `rename` renames the checked-out BRANCH (plus the directory), so a
+    // detached-HEAD worktree has nothing to rename. Refuse explicitly rather
+    // than inventing a branch name.
+    let Some(old_name) = current.branch.clone() else {
+        error_log(
+            deps.io,
+            "Error: Cannot rename a detached HEAD worktree (no branch to rename)",
+        );
+        return Err(VibeError::AlreadyReported);
+    };
     let old_path = current.path.clone();
 
     // The branch name is kept verbatim (slashes are valid git namespacing); only

--- a/rust/crates/vibe-core/src/commands/scratch.rs
+++ b/rust/crates/vibe-core/src/commands/scratch.rs
@@ -55,8 +55,11 @@ fn generate_scratch_name(git: &impl GitRunner, clock: &impl Clock) -> Result<Str
     let base_name = format!("{SCRATCH_PREFIX}{ts}");
 
     let mut used: HashSet<String> = HashSet::new();
+    // A detached worktree occupies no branch name, so it constrains nothing here.
     for w in get_worktree_list(git)? {
-        used.insert(w.branch);
+        if let Some(branch) = w.branch {
+            used.insert(branch);
+        }
     }
     // Existing scratch branch refs (best-effort: ignore a git error → empty).
     let refs = git

--- a/rust/crates/vibe-core/src/completion/snapshots/fish.snap
+++ b/rust/crates/vibe-core/src/completion/snapshots/fish.snap
@@ -5,6 +5,7 @@ complete -c vibe -f
 complete -c vibe -n __fish_use_subcommand -a start -d 'Create a new worktree with the given branch'
 complete -c vibe -n __fish_use_subcommand -a scratch -d 'Create a worktree with an auto-generated scratch/<timestamp> branch'
 complete -c vibe -n __fish_use_subcommand -a jump -d 'Jump to an existing worktree by branch name'
+complete -c vibe -n __fish_use_subcommand -a list -d 'List all worktrees of the current repository'
 complete -c vibe -n __fish_use_subcommand -a rename -d 'Rename the current worktree\'s branch and directory'
 complete -c vibe -n __fish_use_subcommand -a clean -d 'Remove current worktree and return to main'
 complete -c vibe -n __fish_use_subcommand -a home -d 'Return to main worktree without removing current'
@@ -42,6 +43,9 @@ complete -c vibe -n '__fish_seen_subcommand_from scratch' -l track -d 'Set upstr
 complete -c vibe -n '__fish_seen_subcommand_from scratch' -l no-hooks -d 'Skip pre-start and post-start hooks'
 complete -c vibe -n '__fish_seen_subcommand_from scratch' -l no-copy -d 'Skip copying files and directories'
 complete -c vibe -n '__fish_seen_subcommand_from scratch' -s n -l dry-run -d 'Show what would be executed'
+
+# list flags
+complete -c vibe -n '__fish_seen_subcommand_from list' -l json -d 'Output the listing as JSON'
 
 # rename flags
 complete -c vibe -n '__fish_seen_subcommand_from rename' -s n -l dry-run -d 'Show what would be executed'

--- a/rust/crates/vibe-core/src/completion/snapshots/zsh.snap
+++ b/rust/crates/vibe-core/src/completion/snapshots/zsh.snap
@@ -7,6 +7,7 @@ _vibe_commands() {
     'start:Create a new worktree with the given branch'
     'scratch:Create a worktree with an auto-generated scratch/<timestamp> branch'
     'jump:Jump to an existing worktree by branch name'
+    'list:List all worktrees of the current repository'
     'rename:Rename the current worktree'\''s branch and directory'
     'clean:Remove current worktree and return to main'
     'home:Return to main worktree without removing current'
@@ -58,6 +59,11 @@ _vibe_scratch() {
 _vibe_jump() {
   _arguments \
     '1: :_vibe_worktree_branches'
+}
+
+_vibe_list() {
+  _arguments \
+    '--json[Output the listing as JSON]'
 }
 
 _vibe_rename() {
@@ -125,6 +131,7 @@ _vibe() {
         start) _vibe_start ;;
         scratch) _vibe_scratch ;;
         jump) _vibe_jump ;;
+        list) _vibe_list ;;
         rename) _vibe_rename ;;
         clean) _vibe_clean ;;
         home) _vibe_home ;;

--- a/rust/crates/vibe-core/src/completion/spec.rs
+++ b/rust/crates/vibe-core/src/completion/spec.rs
@@ -125,6 +125,12 @@ pub const SUBCOMMANDS: &[CommandSpec] = &[
         flags: &[],
     },
     CommandSpec {
+        name: "list",
+        description: "List all worktrees of the current repository",
+        positional_completion: None,
+        flags: &[FlagSpec::flag("json", "Output the listing as JSON")],
+    },
+    CommandSpec {
         name: "rename",
         description: "Rename the current worktree's branch and directory",
         positional_completion: None,

--- a/rust/crates/vibe-core/src/git.rs
+++ b/rust/crates/vibe-core/src/git.rs
@@ -11,10 +11,14 @@ use std::path::Path;
 use std::process::Command;
 
 /// A single worktree entry parsed from `git worktree list --porcelain`.
+///
+/// `branch` is `None` for a detached-HEAD worktree: git emits a bare `detached`
+/// line instead of `branch refs/heads/…` for those, and they are real worktrees
+/// a user can be standing in, so they must be representable rather than dropped.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Worktree {
     pub path: String,
-    pub branch: String,
+    pub branch: Option<String>,
 }
 
 /// Repository information extracted from a file path.
@@ -73,20 +77,43 @@ pub fn sanitize_branch_name(branch_name: &str) -> String {
 /// git emits entries in a stable order (main worktree first), so we preserve
 /// the emitted order rather than re-sorting — and we never depend on
 /// nondeterministic filesystem `read_dir` order anywhere.
+///
+/// An entry is accumulated from its `worktree <path>` line and flushed when the
+/// next one starts (or at EOF), so a detached-HEAD worktree — which carries a
+/// bare `detached` line and NO `branch` line — yields `branch: None` instead of
+/// vanishing. A `bare` entry is dropped: a bare repository has no working tree
+/// to stand in or `cd` to, so it is not a worktree for any of our purposes.
 pub fn parse_worktree_list(output: &str) -> Vec<Worktree> {
     let mut worktrees = Vec::new();
-    let mut current_path = String::new();
+    let mut current: Option<Worktree> = None;
+    let mut is_bare = false;
+
+    // Push the entry accumulated so far, unless it is a bare repository.
+    fn flush(out: &mut Vec<Worktree>, current: Option<Worktree>, is_bare: bool) {
+        if let Some(wt) = current {
+            if !is_bare {
+                out.push(wt);
+            }
+        }
+    }
 
     for line in output.split('\n') {
         if let Some(rest) = line.strip_prefix("worktree ") {
-            current_path = rest.to_string();
-        } else if let Some(rest) = line.strip_prefix("branch refs/heads/") {
-            worktrees.push(Worktree {
-                path: current_path.clone(),
-                branch: rest.to_string(),
+            flush(&mut worktrees, current.take(), is_bare);
+            is_bare = false;
+            current = Some(Worktree {
+                path: rest.to_string(),
+                branch: None,
             });
+        } else if let Some(rest) = line.strip_prefix("branch refs/heads/") {
+            if let Some(wt) = current.as_mut() {
+                wt.branch = Some(rest.to_string());
+            }
+        } else if line.trim() == "bare" {
+            is_bare = true;
         }
     }
+    flush(&mut worktrees, current.take(), is_bare);
 
     worktrees
 }
@@ -157,7 +184,7 @@ pub fn find_worktree_by_branch(
     let worktrees = parse_worktree_list(&output);
     Ok(worktrees
         .into_iter()
-        .find(|w| w.branch == branch_name)
+        .find(|w| w.branch.as_deref() == Some(branch_name))
         .map(|w| w.path))
 }
 
@@ -504,7 +531,7 @@ mod tests {
         let wt = get_worktree_by_path(&git, "/test/repo/../wt/./feat")
             .unwrap()
             .unwrap();
-        assert_eq!(wt.branch, "feature");
+        assert_eq!(wt.branch.as_deref(), Some("feature"));
         assert_eq!(wt.path, "/test/wt/feat");
     }
 
@@ -544,10 +571,10 @@ mod tests {
     // start/clean over real git) cannot silently change how worktrees are read.
 
     #[test]
-    fn parse_skips_detached_head_entry_without_branch_line() {
+    fn parse_keeps_detached_head_entry_with_no_branch() {
         // A detached-HEAD worktree emits `detached` instead of a `branch` line.
-        // The parser pushes only on a `branch refs/heads/` line, so the detached
-        // entry is intentionally OMITTED from the result.
+        // It is still a real worktree the user can stand in, so it is reported
+        // with `branch: None` rather than dropped.
         let out = "\
 worktree /repo/main
 HEAD aaaa
@@ -560,11 +587,30 @@ detached
 ";
         assert_eq!(
             parse_worktree_list(out),
+            vec![
+                Worktree {
+                    path: "/repo/main".into(),
+                    branch: Some("main".into()),
+                },
+                Worktree {
+                    path: "/repo/detached".into(),
+                    branch: None,
+                },
+            ],
+            "detached entry must be reported with no branch"
+        );
+    }
+
+    #[test]
+    fn parse_keeps_a_trailing_detached_entry_at_eof() {
+        // No trailing blank line: the last entry is flushed at EOF, not lost.
+        let out = "worktree /repo/detached\nHEAD bbbb\ndetached";
+        assert_eq!(
+            parse_worktree_list(out),
             vec![Worktree {
-                path: "/repo/main".into(),
-                branch: "main".into(),
-            }],
-            "detached entry (no branch line) must be skipped"
+                path: "/repo/detached".into(),
+                branch: None,
+            }]
         );
     }
 
@@ -581,7 +627,7 @@ branch refs/heads/feat
             parse_worktree_list(out),
             vec![Worktree {
                 path: "/repo/my worktree dir".into(),
-                branch: "feat".into(),
+                branch: Some("feat".into()),
             }]
         );
     }
@@ -603,7 +649,7 @@ branch refs/heads/main
             parse_worktree_list(out),
             vec![Worktree {
                 path: "/repo/wt".into(),
-                branch: "main".into(),
+                branch: Some("main".into()),
             }]
         );
     }
@@ -622,11 +668,11 @@ branch refs/heads/main
             vec![
                 Worktree {
                     path: "/a".into(),
-                    branch: "main".into()
+                    branch: Some("main".into())
                 },
                 Worktree {
                     path: "/b".into(),
-                    branch: "feat".into()
+                    branch: Some("feat".into())
                 },
             ]
         );

--- a/rust/crates/vibe-core/src/git.rs
+++ b/rust/crates/vibe-core/src/git.rs
@@ -10,7 +10,7 @@ use crate::error::{Result, VibeError};
 use std::path::Path;
 use std::process::Command;
 
-/// A single worktree entry parsed from `git worktree list --porcelain -z`.
+/// A single worktree entry parsed from `git worktree list --porcelain [-z]`.
 ///
 /// `branch` is `None` for a detached-HEAD worktree: git emits a bare `detached`
 /// line instead of `branch refs/heads/…` for those, and they are real worktrees
@@ -72,14 +72,60 @@ pub fn sanitize_branch_name(branch_name: &str) -> String {
     branch_name.replace('/', "-")
 }
 
-/// The argument vector for reading the worktree list.
+/// The preferred argument vector for reading the worktree list.
 ///
 /// `-z` (NUL-terminated records) rather than plain `--porcelain`: a worktree
 /// path may legally contain a literal newline, and the line-oriented format has
 /// no way to express that — git's own docs recommend `-z` for machine
-/// consumption for exactly this reason. `-z` is unconditional (not a fallback
-/// probe) because it predates every git we support.
-const WORKTREE_LIST_ARGS: [&str; 4] = ["worktree", "list", "--porcelain", "-z"];
+/// consumption for exactly this reason.
+const WORKTREE_LIST_ARGS_Z: [&str; 4] = ["worktree", "list", "--porcelain", "-z"];
+
+/// The compatibility argument vector, used when `git` rejects `-z`.
+///
+/// `git worktree list` only learned `-z` in 2.36, and some LTS distributions
+/// still ship an older git. Dropping `-z` there costs only the newline-in-path
+/// edge case (which the line-oriented format simply cannot express) instead of
+/// breaking every worktree-enumerating command — `list`, `start`, `clean`,
+/// `home` and `jump` all read through here.
+const WORKTREE_LIST_ARGS_PLAIN: [&str; 3] = ["worktree", "list", "--porcelain"];
+
+/// Read the raw worktree-list payload, preferring `-z` and degrading if unsupported.
+///
+/// Probing by *attempting* `-z` rather than parsing `git --version` first: the
+/// version string is not a reliable capability oracle (distributions backport,
+/// and vendored builds carry non-semver versions), and the happy path stays a
+/// single `git` invocation — the extra call only happens on the git that cannot
+/// serve the first one.
+///
+/// Only an argument-parsing rejection triggers the retry. A genuine failure —
+/// "not a git repository", a broken repo — must surface as itself rather than
+/// being retried and reported under the fallback command, which would hide the
+/// real cause behind a second identical error.
+fn run_worktree_list(runner: &impl GitRunner) -> Result<String> {
+    match runner.run(&WORKTREE_LIST_ARGS_Z) {
+        Ok(output) => Ok(output),
+        Err(err) if is_unsupported_option_error(&err) => runner.run(&WORKTREE_LIST_ARGS_PLAIN),
+        Err(err) => Err(err),
+    }
+}
+
+/// True when a git failure is "you passed an option I do not know".
+///
+/// git prints `error: unknown option ...` (and/or a `usage: git worktree list`
+/// synopsis) on an unparsed flag, versus `fatal: ...` for operational failures,
+/// so matching those markers separates "this git is too old" from "this repo is
+/// broken". Matching on the message rather than the exit status because git uses
+/// 129 for usage errors only on some paths, and the [`GitRunner`] abstraction
+/// intentionally carries the message, not the raw status.
+fn is_unsupported_option_error(err: &VibeError) -> bool {
+    let VibeError::GitOperation { message, .. } = err else {
+        return false;
+    };
+    let message = message.to_ascii_lowercase();
+    message.contains("unknown option")
+        || message.contains("unknown switch")
+        || message.contains("usage: git worktree list")
+}
 
 /// Parse `git worktree list --porcelain [-z]` output into ordered worktree
 /// entries.
@@ -89,10 +135,10 @@ const WORKTREE_LIST_ARGS: [&str; 4] = ["worktree", "list", "--porcelain", "-z"];
 /// nondeterministic filesystem `read_dir` order anywhere.
 ///
 /// The record separator is detected from the payload — see
-/// [`split_worktree_records`] — so both the `-z` output we ask git for and the
-/// plain line-oriented porcelain parse identically. That is what lets a path
-/// containing a newline survive: under `-z` the newline is interior to a record
-/// rather than a record separator.
+/// [`split_worktree_records`] — so both the `-z` output we ask git for first and
+/// the plain line-oriented porcelain we fall back to on a pre-2.36 git parse
+/// identically. That is what lets a path containing a newline survive: under
+/// `-z` the newline is interior to a record rather than a record separator.
 ///
 /// An entry is accumulated from its `worktree <path>` record and flushed when
 /// the next one starts (or at EOF), so a detached-HEAD worktree — which carries
@@ -143,9 +189,10 @@ pub fn parse_worktree_list(output: &str) -> Vec<Worktree> {
 /// `\0` is an unambiguous discriminator, and keying off it — rather than
 /// splitting on both bytes — is what preserves a newline inside a path.
 ///
-/// Not simply "always `-z`": the plain branch is still needed because the same
-/// parser is fed hand-written line-oriented fixtures, and keeping one parser for
-/// both beats maintaining two that can drift apart.
+/// Not simply "always `-z`": the plain branch is what a git older than 2.36
+/// produces after [`run_worktree_list`] retries without `-z`, and it is also
+/// what the hand-written line-oriented fixtures use. Keeping one parser for both
+/// beats maintaining two that can drift apart.
 fn split_worktree_records(output: &str) -> impl Iterator<Item = &str> {
     let separator = if output.contains('\0') { '\0' } else { '\n' };
     output.split(separator)
@@ -213,7 +260,7 @@ pub fn find_worktree_by_branch(
     runner: &impl GitRunner,
     branch_name: &str,
 ) -> Result<Option<String>> {
-    let output = runner.run(&WORKTREE_LIST_ARGS)?;
+    let output = run_worktree_list(runner)?;
     let worktrees = parse_worktree_list(&output);
     Ok(worktrees
         .into_iter()
@@ -315,9 +362,9 @@ pub fn remote_branch_exists(runner: &impl GitRunner, branch_name: &str, remote: 
         .is_ok()
 }
 
-/// All worktrees from `git worktree list --porcelain -z`, in git's emitted order.
+/// All worktrees from `git worktree list --porcelain [-z]`, in git's emitted order.
 pub fn get_worktree_list(runner: &impl GitRunner) -> Result<Vec<Worktree>> {
-    let output = runner.run(&WORKTREE_LIST_ARGS)?;
+    let output = run_worktree_list(runner)?;
     Ok(parse_worktree_list(&output))
 }
 
@@ -449,6 +496,153 @@ mod tests {
                 Ok(String::new())
             }
         }
+    }
+
+    /// A runner emulating a git that rejects `-z`, recording every invocation.
+    ///
+    /// `stderr_for_z` is the message such a git puts on stderr, so a test can
+    /// pin the exact wording an old git produces.
+    struct OldGit {
+        stderr_for_z: String,
+        plain_output: String,
+        calls: std::cell::RefCell<Vec<Vec<String>>>,
+    }
+    impl OldGit {
+        fn new(stderr_for_z: &str, plain_output: &str) -> Self {
+            Self {
+                stderr_for_z: stderr_for_z.to_string(),
+                plain_output: plain_output.to_string(),
+                calls: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.calls.borrow().clone()
+        }
+    }
+    impl GitRunner for OldGit {
+        fn run(&self, args: &[&str]) -> Result<String> {
+            self.calls
+                .borrow_mut()
+                .push(args.iter().map(|a| a.to_string()).collect());
+            if args.contains(&"-z") {
+                return Err(VibeError::GitOperation {
+                    command: args.join(" "),
+                    message: format!("failed: {}", self.stderr_for_z),
+                });
+            }
+            Ok(self.plain_output.clone())
+        }
+    }
+
+    /// A runner whose worktree listing always fails with `message`.
+    struct FailingGit {
+        message: String,
+        calls: std::cell::RefCell<usize>,
+    }
+    impl GitRunner for FailingGit {
+        fn run(&self, args: &[&str]) -> Result<String> {
+            *self.calls.borrow_mut() += 1;
+            Err(VibeError::GitOperation {
+                command: args.join(" "),
+                message: self.message.clone(),
+            })
+        }
+    }
+
+    const PLAIN_LIST: &str = "worktree /repo/main\nHEAD aaaa\nbranch refs/heads/main\n\nworktree /repo/feat\nHEAD bbbb\nbranch refs/heads/feature\n\n";
+
+    #[test]
+    fn worktree_list_prefers_z_and_does_not_retry_when_it_works() {
+        // The modern path must stay a single git invocation.
+        let git = MockGit {
+            worktree_list: "worktree /repo/main\0branch refs/heads/main\0\0".to_string(),
+        };
+        assert_eq!(
+            get_worktree_list(&git).unwrap(),
+            vec![Worktree {
+                path: "/repo/main".into(),
+                branch: Some("main".into()),
+            }]
+        );
+    }
+
+    #[test]
+    fn worktree_list_falls_back_to_plain_porcelain_when_z_is_rejected() {
+        // A git older than 2.36 rejects `-z`; the listing must still be read
+        // rather than every worktree command failing outright.
+        let git = OldGit::new("error: unknown option `z'", PLAIN_LIST);
+        assert_eq!(
+            get_worktree_list(&git).unwrap(),
+            vec![
+                Worktree {
+                    path: "/repo/main".into(),
+                    branch: Some("main".into()),
+                },
+                Worktree {
+                    path: "/repo/feat".into(),
+                    branch: Some("feature".into()),
+                },
+            ]
+        );
+        assert_eq!(
+            git.calls(),
+            vec![
+                vec!["worktree", "list", "--porcelain", "-z"],
+                vec!["worktree", "list", "--porcelain"],
+            ],
+            "the fallback must retry without -z, and only after -z was rejected"
+        );
+    }
+
+    #[test]
+    fn worktree_list_falls_back_on_a_usage_synopsis_rejection() {
+        // Some git builds answer an unparsed flag with only the usage synopsis.
+        let git = OldGit::new(
+            "usage: git worktree list [-v | --porcelain]",
+            "worktree /repo/main\nbranch refs/heads/main\n\n",
+        );
+        assert_eq!(
+            get_worktree_list(&git).unwrap(),
+            vec![Worktree {
+                path: "/repo/main".into(),
+                branch: Some("main".into()),
+            }]
+        );
+        assert_eq!(git.calls().len(), 2);
+    }
+
+    #[test]
+    fn find_worktree_by_branch_also_falls_back() {
+        // The fallback is shared, so the other call site degrades identically.
+        let git = OldGit::new("error: unknown option `z'", PLAIN_LIST);
+        assert_eq!(
+            find_worktree_by_branch(&git, "feature").unwrap(),
+            Some("/repo/feat".to_string())
+        );
+        assert_eq!(git.calls().len(), 2);
+    }
+
+    #[test]
+    fn worktree_list_does_not_retry_a_genuine_git_failure() {
+        // "Not a repository" must surface as itself, not be retried and then
+        // reported under the fallback command, hiding the real cause.
+        let git = FailingGit {
+            message: "failed: fatal: not a git repository".to_string(),
+            calls: std::cell::RefCell::new(0),
+        };
+        let err = get_worktree_list(&git).unwrap_err();
+        assert!(
+            err.to_string().contains("not a git repository"),
+            "the original failure must be preserved, got: {err}"
+        );
+        assert_eq!(*git.calls.borrow(), 1, "a real failure must not be retried");
+    }
+
+    #[test]
+    fn fallback_output_and_z_output_parse_to_the_same_entries() {
+        // One parser serves both invocations, so the two forms must agree.
+        let z = "worktree /repo/main\0HEAD aaaa\0branch refs/heads/main\0\0worktree /repo/feat\0HEAD bbbb\0branch refs/heads/feature\0\0";
+        assert_eq!(parse_worktree_list(z), parse_worktree_list(PLAIN_LIST));
     }
 
     #[test]

--- a/rust/crates/vibe-core/src/git.rs
+++ b/rust/crates/vibe-core/src/git.rs
@@ -40,19 +40,38 @@ pub trait GitRunner {
     fn run(&self, args: &[&str]) -> Result<String>;
 }
 
+/// Environment pinned on every `git` invocation, forcing the C locale.
+///
+/// `is_unsupported_option_error` decides the `-z` fallback by matching git's
+/// English diagnostic text, and git translates its messages: under `ja_JP.UTF-8`
+/// a pre-2.36 git answers `-z` with a translated "unknown option", the match
+/// fails, and every worktree-enumerating command breaks instead of degrading.
+///
+/// Pinned here — on the one place a `git` process is constructed — rather than
+/// only on the probe invocation: the [`GitRunner`] seam takes just an argument
+/// vector, so a probe-only override would mean widening the trait or bypassing
+/// it for one call, and there is nothing to protect on the other callers. Every
+/// other invocation reads machine-stable output (`--porcelain`, `rev-parse`,
+/// `config --get`), which git does not translate, so the C locale changes
+/// nothing for them.
+///
+/// `LC_ALL` alone is not enough: `LANGUAGE` overrides it for message
+/// translation in gettext, so both must be set.
+const GIT_C_LOCALE_ENV: [(&str, &str); 2] = [("LC_ALL", "C"), ("LANGUAGE", "C")];
+
 /// Production [`GitRunner`] that shells out to the real `git` binary.
 pub struct RealGit;
 
 impl GitRunner for RealGit {
     fn run(&self, args: &[&str]) -> Result<String> {
-        let output =
-            Command::new("git")
-                .args(args)
-                .output()
-                .map_err(|e| VibeError::GitOperation {
-                    command: args.join(" "),
-                    message: e.to_string(),
-                })?;
+        let output = Command::new("git")
+            .args(args)
+            .envs(GIT_C_LOCALE_ENV)
+            .output()
+            .map_err(|e| VibeError::GitOperation {
+                command: args.join(" "),
+                message: e.to_string(),
+            })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -117,6 +136,10 @@ fn run_worktree_list(runner: &impl GitRunner) -> Result<String> {
 /// broken". Matching on the message rather than the exit status because git uses
 /// 129 for usage errors only on some paths, and the [`GitRunner`] abstraction
 /// intentionally carries the message, not the raw status.
+///
+/// The markers are git's untranslated English wording, which is only what
+/// [`RealGit`] sees because it pins [`GIT_C_LOCALE_ENV`]; without that pinning
+/// this predicate would silently stop matching under a non-English locale.
 fn is_unsupported_option_error(err: &VibeError) -> bool {
     let VibeError::GitOperation { message, .. } = err else {
         return false;
@@ -592,6 +615,81 @@ mod tests {
             ],
             "the fallback must retry without -z, and only after -z was rejected"
         );
+    }
+
+    #[test]
+    fn real_git_runs_git_under_the_c_locale() {
+        // What it guarantees: the `-z` fallback probe keeps working on a
+        // non-English system. `is_unsupported_option_error` matches git's
+        // English diagnostics, so `RealGit` must force the C locale onto the
+        // child regardless of the ambient environment — otherwise a pre-2.36
+        // git under e.g. ja_JP.UTF-8 answers with a translated "unknown option"
+        // and the fallback never fires.
+        //
+        // Asserted by making git echo the locale variables it was launched
+        // with, rather than by comparing translated output: whether any given
+        // machine has git's translations installed is not something a test can
+        // rely on, so a message-text assertion would silently pass everywhere.
+        let ambient = [("LC_ALL", "ja_JP.UTF-8"), ("LANGUAGE", "ja")];
+        let output = Command::new("git")
+            .args([
+                "-c",
+                "alias.vibeshowlocale=!printf '%s|%s' \"$LC_ALL\" \"$LANGUAGE\"",
+                "vibeshowlocale",
+            ])
+            .envs(ambient)
+            .envs(GIT_C_LOCALE_ENV)
+            .output()
+            .expect("git must be runnable in the test environment");
+
+        assert!(
+            output.status.success(),
+            "probe alias failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "C|C",
+            "RealGit's pinned env must override an ambient non-English locale"
+        );
+    }
+
+    #[test]
+    fn c_locale_pinning_covers_both_gettext_variables() {
+        // What it guarantees: LC_ALL alone is insufficient — gettext lets
+        // LANGUAGE override it for message translation, so dropping LANGUAGE
+        // would reintroduce the translated-diagnostic bug on systems that set
+        // it.
+        let pinned: std::collections::HashMap<_, _> = GIT_C_LOCALE_ENV.into_iter().collect();
+        assert_eq!(pinned.get("LC_ALL"), Some(&"C"));
+        assert_eq!(pinned.get("LANGUAGE"), Some(&"C"));
+    }
+
+    #[test]
+    fn unsupported_option_match_is_case_insensitive_over_git_wordings() {
+        // What it guarantees: the marker set covers the wordings git actually
+        // emits for an unparsed flag, in the C locale the runner pins.
+        for message in [
+            "failed: error: unknown option `z'",
+            "failed: error: unknown switch `z'",
+            "failed: usage: git worktree list [-v | --porcelain [-z]]",
+            "failed: ERROR: Unknown Option `z'",
+        ] {
+            let err = VibeError::GitOperation {
+                command: "worktree list --porcelain -z".to_string(),
+                message: message.to_string(),
+            };
+            assert!(
+                is_unsupported_option_error(&err),
+                "must be treated as an unsupported-option rejection: {message}"
+            );
+        }
+
+        let genuine = VibeError::GitOperation {
+            command: "worktree list --porcelain -z".to_string(),
+            message: "failed: fatal: not a git repository".to_string(),
+        };
+        assert!(!is_unsupported_option_error(&genuine));
     }
 
     #[test]

--- a/rust/crates/vibe-core/src/git.rs
+++ b/rust/crates/vibe-core/src/git.rs
@@ -10,7 +10,7 @@ use crate::error::{Result, VibeError};
 use std::path::Path;
 use std::process::Command;
 
-/// A single worktree entry parsed from `git worktree list --porcelain`.
+/// A single worktree entry parsed from `git worktree list --porcelain -z`.
 ///
 /// `branch` is `None` for a detached-HEAD worktree: git emits a bare `detached`
 /// line instead of `branch refs/heads/…` for those, and they are real worktrees
@@ -72,17 +72,34 @@ pub fn sanitize_branch_name(branch_name: &str) -> String {
     branch_name.replace('/', "-")
 }
 
-/// Parse `git worktree list --porcelain` output into ordered worktree entries.
+/// The argument vector for reading the worktree list.
+///
+/// `-z` (NUL-terminated records) rather than plain `--porcelain`: a worktree
+/// path may legally contain a literal newline, and the line-oriented format has
+/// no way to express that — git's own docs recommend `-z` for machine
+/// consumption for exactly this reason. `-z` is unconditional (not a fallback
+/// probe) because it predates every git we support.
+const WORKTREE_LIST_ARGS: [&str; 4] = ["worktree", "list", "--porcelain", "-z"];
+
+/// Parse `git worktree list --porcelain [-z]` output into ordered worktree
+/// entries.
 ///
 /// git emits entries in a stable order (main worktree first), so we preserve
 /// the emitted order rather than re-sorting — and we never depend on
 /// nondeterministic filesystem `read_dir` order anywhere.
 ///
-/// An entry is accumulated from its `worktree <path>` line and flushed when the
-/// next one starts (or at EOF), so a detached-HEAD worktree — which carries a
-/// bare `detached` line and NO `branch` line — yields `branch: None` instead of
-/// vanishing. A `bare` entry is dropped: a bare repository has no working tree
-/// to stand in or `cd` to, so it is not a worktree for any of our purposes.
+/// The record separator is detected from the payload — see
+/// [`split_worktree_records`] — so both the `-z` output we ask git for and the
+/// plain line-oriented porcelain parse identically. That is what lets a path
+/// containing a newline survive: under `-z` the newline is interior to a record
+/// rather than a record separator.
+///
+/// An entry is accumulated from its `worktree <path>` record and flushed when
+/// the next one starts (or at EOF), so a detached-HEAD worktree — which carries
+/// a bare `detached` record and NO `branch` record — yields `branch: None`
+/// instead of vanishing. A `bare` entry is dropped: a bare repository has no
+/// working tree to stand in or `cd` to, so it is not a worktree for any of our
+/// purposes.
 pub fn parse_worktree_list(output: &str) -> Vec<Worktree> {
     let mut worktrees = Vec::new();
     let mut current: Option<Worktree> = None;
@@ -97,7 +114,7 @@ pub fn parse_worktree_list(output: &str) -> Vec<Worktree> {
         }
     }
 
-    for line in output.split('\n') {
+    for line in split_worktree_records(output) {
         if let Some(rest) = line.strip_prefix("worktree ") {
             flush(&mut worktrees, current.take(), is_bare);
             is_bare = false;
@@ -116,6 +133,22 @@ pub fn parse_worktree_list(output: &str) -> Vec<Worktree> {
     flush(&mut worktrees, current.take(), is_bare);
 
     worktrees
+}
+
+/// Split worktree-list output into records, picking the separator from the data.
+///
+/// `-z` output is NUL-terminated and, by construction, uses `\n` for nothing but
+/// bytes that are genuinely part of a path; plain `--porcelain` output is
+/// newline-separated and contains no `\0` at all. So the presence of a single
+/// `\0` is an unambiguous discriminator, and keying off it — rather than
+/// splitting on both bytes — is what preserves a newline inside a path.
+///
+/// Not simply "always `-z`": the plain branch is still needed because the same
+/// parser is fed hand-written line-oriented fixtures, and keeping one parser for
+/// both beats maintaining two that can drift apart.
+fn split_worktree_records(output: &str) -> impl Iterator<Item = &str> {
+    let separator = if output.contains('\0') { '\0' } else { '\n' };
+    output.split(separator)
 }
 
 /// Normalize a git remote URL to a canonical `host/user/repo` form.
@@ -180,7 +213,7 @@ pub fn find_worktree_by_branch(
     runner: &impl GitRunner,
     branch_name: &str,
 ) -> Result<Option<String>> {
-    let output = runner.run(&["worktree", "list", "--porcelain"])?;
+    let output = runner.run(&WORKTREE_LIST_ARGS)?;
     let worktrees = parse_worktree_list(&output);
     Ok(worktrees
         .into_iter()
@@ -282,9 +315,9 @@ pub fn remote_branch_exists(runner: &impl GitRunner, branch_name: &str, remote: 
         .is_ok()
 }
 
-/// All worktrees from `git worktree list --porcelain`, in git's emitted order.
+/// All worktrees from `git worktree list --porcelain -z`, in git's emitted order.
 pub fn get_worktree_list(runner: &impl GitRunner) -> Result<Vec<Worktree>> {
-    let output = runner.run(&["worktree", "list", "--porcelain"])?;
+    let output = runner.run(&WORKTREE_LIST_ARGS)?;
     Ok(parse_worktree_list(&output))
 }
 
@@ -629,6 +662,44 @@ branch refs/heads/feat
                 path: "/repo/my worktree dir".into(),
                 branch: Some("feat".into()),
             }]
+        );
+    }
+
+    #[test]
+    fn parse_handles_nul_delimited_z_output() {
+        // What `git worktree list --porcelain -z` actually emits: every record is
+        // NUL-TERMINATED (not separated), so an entry ends with `\0\0`. Parsing
+        // must produce exactly what the line-oriented form produces.
+        let out = "worktree /repo/main\0HEAD aaaa\0branch refs/heads/main\0\0\
+                   worktree /repo/detached\0HEAD bbbb\0detached\0\0";
+        assert_eq!(
+            parse_worktree_list(out),
+            vec![
+                Worktree {
+                    path: "/repo/main".into(),
+                    branch: Some("main".into()),
+                },
+                Worktree {
+                    path: "/repo/detached".into(),
+                    branch: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_keeps_a_newline_inside_a_worktree_path_under_z() {
+        // A worktree path may legally contain a literal newline. Under `-z` that
+        // byte is interior to the record, so the path must survive INTACT and the
+        // entry must not be split into two bogus worktrees.
+        let out = "worktree /repo/we\nird\0HEAD aaaa\0branch refs/heads/feat\0\0";
+        assert_eq!(
+            parse_worktree_list(out),
+            vec![Worktree {
+                path: "/repo/we\nird".into(),
+                branch: Some("feat".into()),
+            }],
+            "a newline in the path must not act as a record separator"
         );
     }
 

--- a/rust/crates/vibe-core/src/worktree_validator.rs
+++ b/rust/crates/vibe-core/src/worktree_validator.rs
@@ -78,18 +78,20 @@ pub fn check_worktree_conflict(
         });
     };
 
-    if wt.branch == branch_name {
+    if wt.branch.as_deref() == Some(branch_name) {
         return Ok(WorktreeConflict {
             has_conflict: false,
             conflict_type: ConflictType::SameBranch,
-            existing_branch: Some(wt.branch),
+            existing_branch: wt.branch,
         });
     }
 
+    // A detached worktree occupies the path without being on `branch_name`, so it
+    // is a genuine conflict — reported with no branch name rather than a fake one.
     Ok(WorktreeConflict {
         has_conflict: true,
         conflict_type: ConflictType::DifferentBranch,
-        existing_branch: Some(wt.branch),
+        existing_branch: wt.branch,
     })
 }
 

--- a/rust/crates/vibe/Cargo.toml
+++ b/rust/crates/vibe/Cargo.toml
@@ -26,3 +26,6 @@ vibe-core = { workspace = true, features = ["test-util"] }
 vibe-test-support.workspace = true
 # Real-binary eval-contract integration tests build temp git worktrees.
 tempfile.workspace = true
+# The eval-contract test parses `vibe list --json` output, so it asserts on a
+# real document rather than on substrings a malformed payload would also satisfy.
+serde_json.workspace = true

--- a/rust/crates/vibe/src/cli.rs
+++ b/rust/crates/vibe/src/cli.rs
@@ -70,6 +70,8 @@ pub enum Command {
     Scratch(ScratchArgs),
     /// Jump to an existing worktree by branch name.
     Jump(JumpArgs),
+    /// List all worktrees of the current repository.
+    List(ListArgs),
     /// Rename the current worktree's branch and directory.
     Rename(RenameArgs),
     /// Remove current worktree and return to main.
@@ -143,6 +145,13 @@ pub struct ScratchArgs {
 pub struct JumpArgs {
     /// Branch name (or partial/fuzzy match) of the worktree to jump to.
     pub branch_name: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct ListArgs {
+    /// Emit the listing as JSON for scripting and tool integrations.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]

--- a/rust/crates/vibe/src/commands/mod.rs
+++ b/rust/crates/vibe/src/commands/mod.rs
@@ -10,7 +10,7 @@ use vibe_core::clock::{RealClock, RealRandom};
 use vibe_core::commands::clean::{clean_command, CleanDeps, CleanFlags};
 use vibe_core::commands::scratch::scratch_command;
 use vibe_core::commands::start::{start_command, StartDeps, StartFlags};
-use vibe_core::commands::{Outcome, RealProcessControl, RealStart};
+use vibe_core::commands::{Outcome, ProcessControl, RealProcessControl, RealStart};
 use vibe_core::copy::{RealCopyExecutor, RealNativeClone, RealProbe};
 use vibe_core::fast_remove::RealBackgroundSpawner;
 use vibe_core::git::RealGit;
@@ -77,9 +77,11 @@ pub fn jump(branch_name: &str, opts: OutputOptions) -> Result<Outcome> {
 pub fn list(json: bool, opts: OutputOptions) -> Result<Outcome> {
     let io = RealIo;
     let git = RealGit;
-    let cwd = std::env::current_dir()
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_default();
+    // Through the `ProcessControl` seam, and propagating rather than defaulting:
+    // an unreadable cwd used to collapse to `""`, which `collect_entries`
+    // normalizes to `"."` and so silently marks *no* worktree as current —
+    // a wrong listing presented as a correct one.
+    let cwd = RealProcessControl.current_dir()?;
     let deps = commands::list::ListDeps {
         io: &io,
         git: &git,

--- a/rust/crates/vibe/src/commands/mod.rs
+++ b/rust/crates/vibe/src/commands/mod.rs
@@ -73,6 +73,21 @@ pub fn jump(branch_name: &str, opts: OutputOptions) -> Result<Outcome> {
     commands::jump::jump_command(&deps, branch_name, opts)
 }
 
+/// `vibe list [--json]`.
+pub fn list(json: bool, opts: OutputOptions) -> Result<Outcome> {
+    let io = RealIo;
+    let git = RealGit;
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let deps = commands::list::ListDeps {
+        io: &io,
+        git: &git,
+        cwd: &cwd,
+    };
+    commands::list::list_command(&deps, json, opts)
+}
+
 /// `vibe trust`.
 pub fn trust(opts: OutputOptions) -> Result<Outcome> {
     let io = RealIo;

--- a/rust/crates/vibe/src/main.rs
+++ b/rust/crates/vibe/src/main.rs
@@ -150,6 +150,7 @@ fn dispatch(
             let branch = args.branch_name.unwrap_or_default();
             commands::jump(&branch, opts)
         }
+        Command::List(args) => commands::list(args.json, opts),
         Command::Rename(args) => {
             let new_name = args.new_name.unwrap_or_default();
             commands::rename(&new_name, args.dry_run, opts)

--- a/rust/crates/vibe/tests/eval_contract.rs
+++ b/rust/crates/vibe/tests/eval_contract.rs
@@ -1045,12 +1045,20 @@ fn list_json_keeps_stdout_empty_and_stderr_pure_json() {
         !stderr.contains("[verbose]"),
         "a diagnostic corrupted the payload: {stderr:?}"
     );
+    // Deserialized rather than substring-matched: `starts_with('[')` +
+    // `ends_with(']')` + `contains(…)` would also accept a payload with trailing
+    // garbage or a trailing comma, which is exactly the corruption this contract
+    // exists to catch. A successful parse is the only real proof the stream is
+    // the document and nothing else.
+    let payload: serde_json::Value = serde_json::from_str(&stderr)
+        .unwrap_or_else(|e| panic!("stderr is not a single JSON document ({e}): {stderr:?}"));
+    let entries = payload
+        .as_array()
+        .unwrap_or_else(|| panic!("payload is not a JSON array: {stderr:?}"));
     assert!(
-        stderr.starts_with('[') && stderr.trim_end().ends_with(']'),
-        "stderr is not exactly the JSON document: {stderr:?}"
-    );
-    assert!(
-        stderr.contains("\"branch\": \"feature\""),
+        entries
+            .iter()
+            .any(|e| e.get("branch") == Some(&serde_json::json!("feature"))),
         "payload missing the worktree: {stderr:?}"
     );
 }

--- a/rust/crates/vibe/tests/eval_contract.rs
+++ b/rust/crates/vibe/tests/eval_contract.rs
@@ -979,6 +979,80 @@ fn bogus_eval_dialect_exits_two_with_empty_stdout() {
     );
 }
 
+/// `vibe list` renders a TABLE, which is the exact shape that would be
+/// catastrophic on the eval channel: the POSIX wrapper would execute every row
+/// as a command line (branch names and paths are attacker-influenced). The E2E
+/// suite drives a PTY, which MERGES the two streams, so only this test can prove
+/// the split. STDOUT must be byte-exact empty while the rows land on STDERR.
+#[test]
+fn list_writes_the_table_to_stderr_leaving_stdout_empty() {
+    if !git_available() {
+        eprintln!("skipping: git unavailable");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let (main_path, secondary_path) = setup_worktrees(tmp.path(), "feat", "feature");
+
+    let out = run_vibe(&main_path, home.path(), &["list"]);
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+
+    assert!(out.status.success(), "list failed; stderr={stderr:?}");
+    assert!(
+        stdout.is_empty(),
+        "the listing must never reach the eval channel: {stdout:?}"
+    );
+    // The rows really were produced — otherwise an empty stdout proves nothing.
+    assert!(
+        stderr.contains("feature") && stderr.contains(&secondary_path.display().to_string()),
+        "listing missing from stderr: {stderr:?}"
+    );
+}
+
+/// The same invariant for `--json`: the payload is machine-readable and belongs
+/// on stderr too, and stdout must stay byte-exact empty. `--verbose` is passed
+/// as well, because a diagnostic line prepended to the payload would both
+/// corrupt the JSON and be the kind of stray write that lands on stdout.
+#[test]
+fn list_json_keeps_stdout_empty_and_stderr_pure_json() {
+    if !git_available() {
+        eprintln!("skipping: git unavailable");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let (main_path, _secondary_path) = setup_worktrees(tmp.path(), "feat", "feature");
+
+    let out = run_vibe(&main_path, home.path(), &["--verbose", "list", "--json"]);
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+
+    assert!(
+        out.status.success(),
+        "list --json failed; stderr={stderr:?}"
+    );
+    assert!(
+        stdout.is_empty(),
+        "the JSON payload must never reach the eval channel: {stdout:?}"
+    );
+    // Every byte on stderr is the payload: no `[verbose]` preamble before it and
+    // nothing after it. (Parsing is covered by the unit tests; here the point is
+    // that the stream STARTS with the document, which a diagnostic would break.)
+    assert!(
+        !stderr.contains("[verbose]"),
+        "a diagnostic corrupted the payload: {stderr:?}"
+    );
+    assert!(
+        stderr.starts_with('[') && stderr.trim_end().ends_with(']'),
+        "stderr is not exactly the JSON document: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("\"branch\": \"feature\""),
+        "payload missing the worktree: {stderr:?}"
+    );
+}
+
 /// `vibe doctor` is a diagnostics command, and diagnostics conventionally go to
 /// stdout — but here stdout IS the eval channel, so a report there would be
 /// EXECUTED by the POSIX wrapper. With an empty HOME (no profiles to find) the

--- a/rust/crates/vibe/tests/eval_contract.rs
+++ b/rust/crates/vibe/tests/eval_contract.rs
@@ -411,13 +411,15 @@ fn shell_setup_wrappers_are_byte_exact_on_stdout() {
 ///
 /// The contract guard lives in `eval_output::write_outcome`: a `cd_path`
 /// containing `\n`/`\r` returns an error instead of printing, so the shell never
-/// evals a smuggled second line. A literal newline cannot exist in a real
-/// on-disk worktree path, AND the porcelain parser splits on `\n`, so the guard
-/// is genuinely UNREACHABLE through real `git` — meaning we can't manufacture a
-/// newline-bearing `cd_path` end-to-end. The guard itself is unit-tested in
+/// evals a smuggled second line. POSIX permits a newline in a path, and since
+/// the worktree list is read with `--porcelain -z` such a path now survives
+/// parsing intact instead of being mangled into two entries — so this guard is
+/// the REAL defense, not a belt-and-braces one. It is unit-tested directly in
 /// `crates/vibe/src/eval_output.rs` (`rejects_cd_path_with_newline` /
 /// `rejects_cd_path_with_carriage_return`), which drive the exact function the
-/// binary calls at its single stdout write point.
+/// binary calls at its single stdout write point; reproducing it end-to-end
+/// would require creating a newline-named directory on the test host, which not
+/// every filesystem we run CI on accepts.
 ///
 /// What we CAN assert at the process boundary is the complementary invariant the
 /// guard protects: when a command fails (here, `home` outside any git repo) the


### PR DESCRIPTION
Closes #581

## Summary

Adds `vibe list`, showing every worktree of the current repository at a glance. Until now the set of worktrees was only reachable through `vibe jump`'s matching (you had to guess a query to discover what exists), and `git worktree list` shows raw paths without vibe's notion of scratch worktrees or which one you are standing in.

```
$ vibe list
* feat/issue-581-list-command  /Users/me/ghq/github.com/kexi/vibe-wf-4
  develop                      /Users/me/ghq/github.com/kexi/vibe
  scratch/20260801120000       /Users/me/ghq/github.com/kexi/vibe-scratch (scratch)
```

- `*` marks the worktree the command was run from (also when run from a nested subdirectory).
- Columns are aligned; output is stable and line-parseable.
- `scratch/<timestamp>` worktrees carry a `(scratch)` label so throwaway trees are easy to spot and clean up.
- `--json` emits the same rows as an array (`branch`, `path`, `current`, `scratch`) for scripting and editor/tool integrations.

## Design notes

**Where the output goes.** The listing is this command's product, but it goes to **stderr**, exactly like `vibe config` — not stdout. `docs/specifications/eval-contract.md` is normative that stdout is the eval channel: the wrapper runs `eval "$(command vibe "$@")"`, so a table printed there would be executed as shell code, and `vibe-core` MUST NOT write to stdout at all. The handler returns `Outcome::none()` and never emits a `cd`, so the shell wrapper cannot misinterpret it.

**No second source of truth.** Enumeration reuses `get_worktree_list` and the MRU store `jump` already maintains, so the two commands can never disagree about which worktrees exist. Ordering is current worktree first, then MRU (most recently jumped-to), then never-visited worktrees in git's own order. A missing or corrupt MRU file degrades to git order rather than failing the listing, matching how `jump` treats that store.

**Quiet.** The listing uses `report_log`, so `--quiet` cannot turn `vibe list` into a silent exit-0 no-op.

**Untrusted text.** Branch names and paths go through `sanitize_for_display`, and the column width is computed from the *sanitized* text, so a branch carrying terminal control characters can neither reposition the cursor nor skew the alignment of the other rows.

**Completions.** The subcommand and its `--json` flag are added to the completion spec (required by the clap↔spec consistency test), which regenerates the fish/zsh snapshots.

## Tests

- 17 unit tests in `rust/crates/vibe-core/src/commands/list.rs` covering: not-in-a-repo error (exit 1), listing content, exactly-one current marker, marking from a nested directory, a shared-prefix sibling **not** being marked, nothing marked outside every worktree, scratch labelling, column alignment, current-first ordering, MRU ordering of the remainder, JSON schema + parseability, JSON omitting the table, empty listings (text and `[]`), `--quiet` not silencing, control-character neutralization, and corrupt-MRU fallback.
- 4 E2E tests in `packages/e2e/list.test.ts` driving the real binary through node-pty against a real git repository: listing with the marker, the marker following the cwd into a secondary worktree, `--json` parseability, and the `(scratch)` label.

## Checks run

`pnpm run check:all` — **passed in full** (fmt:check, lint, check:i18n, check:rust [fmt + clippy + 611 workspace tests], check:licenses, test:npm, test:e2e [49 passed / 1 skipped, including the 4 new list tests], check:docs).

One environment fix was needed locally and is unrelated to this change: this worktree's `node_modules/node-pty/prebuilds/*/spawn-helper` lacked its exec bit (the e2e package's `postinstall` chmod had not run), which made every pre-existing E2E test fail with `posix_spawnp failed` until it was restored.

## Follow-up

No user-facing docs are included, keeping this PR code-focused. A follow-up should add `packages/docs/src/content/docs/commands/list.mdx` with its `ja/` and `zh/` mirrors and the `astro.config.ts` sidebar entry with translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `vibe list` command to display repository worktrees.
  * Shows current, scratch, detached, and branch-associated worktrees in readable, aligned output.
  * Added `--json` for stable machine-readable listings and shell completion support.
  * Preserves MRU ordering without changing directories.

* **Bug Fixes**
  * Handles empty repositories, missing or invalid metadata, and non-repository locations gracefully.
  * Improved support for detached worktrees across listing, cleaning, jumping, renaming, and scratch naming.
  * Preserves newlines in worktree paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->