### PR TITLE
feat: protect the default branch from clean and rename

### DIFF
--- a/packages/e2e/default-branch.test.ts
+++ b/packages/e2e/default-branch.test.ts
@@ -1,0 +1,197 @@
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import { basename, dirname } from "path";
+import { afterEach, describe, expect, test } from "vitest";
+import { getVibePath, VibeCommandRunner } from "./helpers/pty.js";
+import { setupTestGitRepo } from "./helpers/git-setup.js";
+import {
+  assertExitCode,
+  assertNonZeroExitCode,
+  assertOutputContains,
+} from "./helpers/assertions.js";
+
+/**
+ * Guards `vibe clean --delete-branch` and `vibe rename` against operating on the
+ * repository's default branch (issue #578).
+ *
+ * `setupTestGitRepo` builds a repo with no remote, so the default branch is
+ * resolved from `init.defaultBranch`; each test declares it explicitly rather
+ * than relying on whatever the host's global git config happens to say.
+ */
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, stdio: "pipe", encoding: "utf-8" });
+}
+
+function branchExists(repoPath: string, branchName: string): boolean {
+  try {
+    git(["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`], repoPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Add a worktree checked out on a NEW branch and return its path.
+ */
+function addWorktree(repoPath: string, branch: string, suffix: string): string {
+  const worktreePath = `${dirname(repoPath)}/${basename(repoPath)}-${suffix}`;
+  git(["worktree", "add", "-b", branch, worktreePath], repoPath);
+  return worktreePath;
+}
+
+describe("default branch protection", () => {
+  let cleanup: (() => Promise<void>) | null = null;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = null;
+    }
+  });
+
+  test("clean --delete-branch removes the worktree but keeps the default branch", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+
+    // A second worktree checked out on the default branch itself.
+    git(["config", "init.defaultBranch", "protected-trunk"], repoPath);
+    const worktreePath = addWorktree(repoPath, "protected-trunk", "trunk");
+
+    const runner = new VibeCommandRunner(getVibePath(), worktreePath, homePath);
+    try {
+      await runner.spawn(["clean", "--delete-branch"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+      // The worktree is still removed — only the branch deletion is skipped.
+      assertOutputContains(output, "has been removed");
+      assertOutputContains(output, "Skipped deleting branch protected-trunk");
+      assertOutputContains(output, "--allow-default-branch");
+      expect(existsSync(worktreePath)).toBe(false);
+      expect(branchExists(repoPath, "protected-trunk")).toBe(true);
+    } finally {
+      runner.dispose();
+    }
+  });
+
+  test("clean --delete-branch --allow-default-branch deletes the default branch", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+
+    git(["config", "init.defaultBranch", "protected-trunk"], repoPath);
+    const worktreePath = addWorktree(repoPath, "protected-trunk", "trunk-allowed");
+
+    const runner = new VibeCommandRunner(getVibePath(), worktreePath, homePath);
+    try {
+      await runner.spawn(["clean", "--delete-branch", "--allow-default-branch"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+      assertOutputContains(output, "Branch protected-trunk has been deleted");
+      expect(branchExists(repoPath, "protected-trunk")).toBe(false);
+    } finally {
+      runner.dispose();
+    }
+  });
+
+  test("clean --delete-branch still deletes a non-default branch", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+
+    git(["config", "init.defaultBranch", "protected-trunk"], repoPath);
+    const worktreePath = addWorktree(repoPath, "feat/ordinary", "ordinary");
+
+    const runner = new VibeCommandRunner(getVibePath(), worktreePath, homePath);
+    try {
+      await runner.spawn(["clean", "--delete-branch"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+      expect(branchExists(repoPath, "feat/ordinary")).toBe(false);
+    } finally {
+      runner.dispose();
+    }
+  });
+
+  test("rename refuses to rename the default branch", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+
+    git(["config", "init.defaultBranch", "protected-trunk"], repoPath);
+    const worktreePath = addWorktree(repoPath, "protected-trunk", "rename-guard");
+
+    const runner = new VibeCommandRunner(getVibePath(), worktreePath, homePath);
+    try {
+      await runner.spawn(["rename", "renamed-trunk"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertNonZeroExitCode(runner.getExitCode());
+      assertOutputContains(output, "is this repository's default branch");
+      assertOutputContains(output, "--allow-default-branch");
+      // Nothing was mutated.
+      expect(branchExists(repoPath, "protected-trunk")).toBe(true);
+      expect(branchExists(repoPath, "renamed-trunk")).toBe(false);
+      expect(existsSync(worktreePath)).toBe(true);
+    } finally {
+      runner.dispose();
+    }
+  });
+
+  test("rename --allow-default-branch renames the default branch", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+
+    git(["config", "init.defaultBranch", "protected-trunk"], repoPath);
+    const worktreePath = addWorktree(repoPath, "protected-trunk", "rename-allowed");
+
+    const runner = new VibeCommandRunner(getVibePath(), worktreePath, homePath);
+    try {
+      await runner.spawn(["rename", "renamed-trunk", "--allow-default-branch"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertExitCode(runner.getExitCode(), 0, output);
+      assertOutputContains(output, "Renamed protected-trunk -> renamed-trunk");
+      expect(branchExists(repoPath, "renamed-trunk")).toBe(true);
+      expect(branchExists(repoPath, "protected-trunk")).toBe(false);
+    } finally {
+      runner.dispose();
+    }
+  });
+
+  test("the default branch is read from origin/HEAD in preference to init.defaultBranch", async () => {
+    const { repoPath, homePath, cleanup: repoCleanup } = await setupTestGitRepo();
+    cleanup = repoCleanup;
+
+    // origin/HEAD says `main`; init.defaultBranch says something else. The
+    // remote's answer must win, so renaming `main` is refused.
+    git(["config", "init.defaultBranch", "not-the-default"], repoPath);
+    git(["update-ref", "refs/remotes/origin/main", "HEAD"], repoPath);
+    git(["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], repoPath);
+
+    // `main` is checked out in the primary worktree, so park it in a secondary
+    // one: check out an unrelated branch in the primary first.
+    git(["checkout", "-b", "parking"], repoPath);
+    const worktreePath = `${dirname(repoPath)}/${basename(repoPath)}-origin-head`;
+    git(["worktree", "add", worktreePath, "main"], repoPath);
+
+    const runner = new VibeCommandRunner(getVibePath(), worktreePath, homePath);
+    try {
+      await runner.spawn(["rename", "renamed-main"]);
+      await runner.waitForExit();
+
+      const output = runner.getOutput();
+      assertNonZeroExitCode(runner.getExitCode());
+      assertOutputContains(output, "'main' is this repository's default branch");
+      expect(branchExists(repoPath, "main")).toBe(true);
+    } finally {
+      runner.dispose();
+    }
+  });
+});

--- a/rust/crates/vibe-core/src/commands/clean.rs
+++ b/rust/crates/vibe-core/src/commands/clean.rs
@@ -9,6 +9,10 @@
 //! worktree set (security #3, a divergence from the TS — non-fatal: a path not in
 //! the set is skipped rather than removed).
 //!
+//! One behavioral addition beyond the TS: branch deletion is SOFT-SKIPPED when
+//! the worktree's branch is the repository's default branch (see
+//! `maybe_delete_branch`), unless `--allow-default-branch` is given.
+//!
 //! `clean.fast_remove` is read from `VibeSettings.extra["clean"]["fast_remove"]`
 //! (default true), preserving the settings round-trip (the `clean` section stays
 //! in `extra`).
@@ -23,8 +27,8 @@ use crate::fast_remove::{
     cleanup_stale_trash, fast_remove_directory, is_fast_remove_supported, BackgroundSpawner,
 };
 use crate::git::{
-    detect_broken_worktree_link, get_main_worktree_path, get_repo_root, get_worktree_by_path,
-    get_worktree_list, has_uncommitted_changes, is_main_worktree, GitRunner,
+    detect_broken_worktree_link, get_default_branch, get_main_worktree_path, get_repo_root,
+    get_worktree_by_path, get_worktree_list, has_uncommitted_changes, is_main_worktree, GitRunner,
 };
 use crate::hooks::{run_hooks, HookEnv, HookRunner, HookTrackerInfo};
 use crate::io::Io;
@@ -43,6 +47,8 @@ pub struct CleanFlags {
     pub delete_branch: bool,
     pub keep_branch: bool,
     pub worktree_hook: bool,
+    /// Opt out of the default-branch guard (see [`maybe_delete_branch`]).
+    pub allow_default_branch: bool,
 }
 
 /// Bundled seams for `clean`.
@@ -417,6 +423,14 @@ where
 
 /// Delete-branch precedence: CLI delete > CLI keep > config > default false.
 /// Best-effort: a failure warns, never errors.
+///
+/// The default branch (`origin/HEAD`, else `init.defaultBranch`, else `master`)
+/// is SOFT-SKIPPED: the worktree is still removed, only the branch survives, and
+/// we say why. Deleting `main`/`develop` is disruptive to everyone on the repo
+/// and is almost never what the user meant, but it is also not a reason to fail
+/// a clean that has already succeeded — hence a skip with a message rather than
+/// an error (`rename`, whose whole product IS the branch change, hard-errors
+/// instead). `--allow-default-branch` opts out.
 #[allow(clippy::too_many_arguments)]
 fn maybe_delete_branch<I, G, R, P, Pc, Sr>(
     deps: &CleanDeps<I, G, R, P, Pc, Sr>,
@@ -447,6 +461,23 @@ fn maybe_delete_branch<I, G, R, P, Pc, Sr>(
 
     if !should_delete || branch.is_empty() {
         return;
+    }
+
+    if !flags.allow_default_branch {
+        let default_branch = get_default_branch(deps.git);
+        if branch == default_branch {
+            warn_log(
+                deps.io,
+                &format!(
+                    "Skipped deleting branch {branch}: it is this repository's default branch."
+                ),
+            );
+            warn_log(
+                deps.io,
+                "Pass --allow-default-branch if you really want to delete it.",
+            );
+            return;
+        }
     }
 
     match deps

--- a/rust/crates/vibe-core/src/commands/clean_tests.rs
+++ b/rust/crates/vibe-core/src/commands/clean_tests.rs
@@ -23,6 +23,9 @@ struct MockGit {
     main_path: String,
     worktree_list: String,
     uncommitted: bool,
+    /// What `symbolic-ref refs/remotes/origin/HEAD --short` answers; `None` →
+    /// the ref is missing, so `get_default_branch` falls through to `master`.
+    origin_head: Option<String>,
     pub calls: RefCell<Vec<Vec<String>>>,
 }
 impl MockGit {
@@ -32,11 +35,17 @@ impl MockGit {
             main_path: main_path.to_string(),
             worktree_list: worktree_list.to_string(),
             uncommitted: false,
+            origin_head: None,
             calls: RefCell::new(vec![]),
         }
     }
     fn with_uncommitted(mut self, yes: bool) -> Self {
         self.uncommitted = yes;
+        self
+    }
+    /// Make `origin/HEAD` resolve to `branch`, i.e. declare it the default.
+    fn with_default_branch(mut self, branch: &str) -> Self {
+        self.origin_head = Some(format!("origin/{branch}"));
         self
     }
     fn calls_contain(&self, prefix: &[&str]) -> bool {
@@ -60,6 +69,23 @@ impl GitRunner for MockGit {
         }
         if args.contains(&"status") {
             return Ok(if self.uncommitted { " M file" } else { "" }.to_string());
+        }
+        if args.contains(&"symbolic-ref") {
+            return match &self.origin_head {
+                Some(h) => Ok(h.clone()),
+                None => Err(VibeError::GitOperation {
+                    command: args.join(" "),
+                    message: "failed: is not a symbolic ref".into(),
+                }),
+            };
+        }
+        if args.contains(&"init.defaultBranch") {
+            // Unconfigured → `get_default_branch` lands on `master`, which no
+            // fixture branch here is named.
+            return Err(VibeError::GitOperation {
+                command: args.join(" "),
+                message: "failed: key missing".into(),
+            });
         }
         // worktree remove / branch -d succeed.
         Ok(String::new())
@@ -497,6 +523,105 @@ fn default_does_not_delete_branch() {
     let d = deps(&io, &git, &r, &p, &proc, &sin, &fk, &wt_path);
     clean_command(&d, &CleanFlags::default(), OutputOptions::default()).unwrap();
     assert!(!git.calls_contain(&["-C", "/main", "branch", "-d"]));
+}
+
+// --- default-branch guard (#578) ---
+
+#[test]
+fn delete_branch_is_skipped_for_the_default_branch_but_the_worktree_still_goes() {
+    // A worktree on the default branch: `--delete-branch` must remove the
+    // worktree and KEEP the branch, saying why, and still exit successfully.
+    let fx = Fixture::new();
+    let wt = fx.mkdir("wt-develop");
+    let wt_path = wt.to_string_lossy().into_owned();
+    let io = FakeIo::new().with_env("HOME", fx.path().to_str().unwrap());
+    let git = MockGit::new(
+        &wt_path,
+        "/main",
+        &two_worktrees("/main", &wt_path, "develop"),
+    )
+    .with_default_branch("develop");
+    let (r, p, sin, fk) = (
+        NoResolver,
+        ScriptPrompt { confirm: true },
+        FakeStdin::none(),
+        Fakes::new(),
+    );
+    let proc = FakeProcess::new(&wt_path);
+    let d = deps(&io, &git, &r, &p, &proc, &sin, &fk, &wt_path);
+    let flags = CleanFlags {
+        delete_branch: true,
+        ..Default::default()
+    };
+    let outcome = clean_command(&d, &flags, OutputOptions::default()).unwrap();
+
+    assert_eq!(outcome, Outcome::cd("/main"));
+    assert!(git.calls_contain(&["-C", "/main", "worktree", "remove"]));
+    assert!(
+        !git.calls_contain(&["-C", "/main", "branch", "-d"]),
+        "the default branch must survive"
+    );
+    let out = io.stderr_text();
+    assert!(
+        out.contains("Skipped deleting branch develop"),
+        "stderr: {out}"
+    );
+    assert!(out.contains("--allow-default-branch"), "stderr: {out}");
+}
+
+#[test]
+fn allow_default_branch_deletes_the_default_branch() {
+    let fx = Fixture::new();
+    let wt = fx.mkdir("wt-develop");
+    let wt_path = wt.to_string_lossy().into_owned();
+    let io = FakeIo::new().with_env("HOME", fx.path().to_str().unwrap());
+    let git = MockGit::new(
+        &wt_path,
+        "/main",
+        &two_worktrees("/main", &wt_path, "develop"),
+    )
+    .with_default_branch("develop");
+    let (r, p, sin, fk) = (
+        NoResolver,
+        ScriptPrompt { confirm: true },
+        FakeStdin::none(),
+        Fakes::new(),
+    );
+    let proc = FakeProcess::new(&wt_path);
+    let d = deps(&io, &git, &r, &p, &proc, &sin, &fk, &wt_path);
+    let flags = CleanFlags {
+        delete_branch: true,
+        allow_default_branch: true,
+        ..Default::default()
+    };
+    clean_command(&d, &flags, OutputOptions::default()).unwrap();
+    assert!(git.calls_contain(&["-C", "/main", "branch", "-d", "--", "develop"]));
+}
+
+#[test]
+fn the_guard_leaves_non_default_branches_alone() {
+    // Regression fence: with `develop` declared default, deleting `feat` still
+    // happens exactly as before.
+    let fx = Fixture::new();
+    let wt = fx.mkdir("wt-feat");
+    let wt_path = wt.to_string_lossy().into_owned();
+    let io = FakeIo::new().with_env("HOME", fx.path().to_str().unwrap());
+    let git = MockGit::new(&wt_path, "/main", &two_worktrees("/main", &wt_path, "feat"))
+        .with_default_branch("develop");
+    let (r, p, sin, fk) = (
+        NoResolver,
+        ScriptPrompt { confirm: true },
+        FakeStdin::none(),
+        Fakes::new(),
+    );
+    let proc = FakeProcess::new(&wt_path);
+    let d = deps(&io, &git, &r, &p, &proc, &sin, &fk, &wt_path);
+    let flags = CleanFlags {
+        delete_branch: true,
+        ..Default::default()
+    };
+    clean_command(&d, &flags, OutputOptions::default()).unwrap();
+    assert!(git.calls_contain(&["-C", "/main", "branch", "-d", "--", "feat"]));
 }
 
 // --- G-10: delete-branch 4-tier precedence boundaries ---

--- a/rust/crates/vibe-core/src/commands/rename.rs
+++ b/rust/crates/vibe-core/src/commands/rename.rs
@@ -4,14 +4,16 @@
 //! pushed-branch guard, path resolution (from the MAIN worktree), dry-run output
 //! and move→chdir→rename sequence (with rollback on failure) mirror the TS
 //! byte-for-byte on the success/normal paths. Two ERROR-ONLY divergences harden
-//! the move/chdir sequence — see the SECURITY notes at points 4a/4b.
+//! the move/chdir sequence — see the SECURITY notes at points 4a/4b. A third
+//! divergence refuses to rename the repository's default branch unless
+//! `--allow-default-branch` is given.
 
 use crate::commands::{Outcome, ProcessControl};
 use crate::config_loader::load_vibe_config;
 use crate::error::{Result, VibeError};
 use crate::git::{
-    branch_exists, find_worktree_by_branch, get_main_worktree_path, get_worktree_by_path,
-    is_main_worktree, sanitize_branch_name, GitRunner,
+    branch_exists, find_worktree_by_branch, get_default_branch, get_main_worktree_path,
+    get_worktree_by_path, is_main_worktree, sanitize_branch_name, GitRunner,
 };
 use crate::io::Io;
 use crate::mru::update_mru_branch;
@@ -47,11 +49,19 @@ where
     pub now_ms: i64,
 }
 
-/// Run `vibe rename <new_name>` (optionally `--dry-run`).
+/// Flags controlling a `rename` run.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RenameFlags {
+    pub dry_run: bool,
+    /// Opt out of the default-branch guard below.
+    pub allow_default_branch: bool,
+}
+
+/// Run `vibe rename <new_name>`.
 pub fn rename_command<I, G, R, S, P>(
     deps: &RenameDeps<I, G, R, S, P>,
     new_name: &str,
-    dry_run: bool,
+    flags: RenameFlags,
     opts: OutputOptions,
 ) -> Result<Outcome>
 where
@@ -88,6 +98,31 @@ where
     if new_name == old_name {
         log(deps.io, &format!("Already named '{old_name}'"), opts);
         return Ok(Outcome::cd(old_path));
+    }
+
+    // Default-branch guard. Renaming `main`/`develop` breaks every clone, PR and
+    // CI reference pointing at it, so this is a HARD error — unlike `clean`,
+    // where the branch is incidental and skipping its deletion still leaves a
+    // useful result. Placed BEFORE the pushed-branch guard so the message names
+    // the real problem: a default branch that happens to be unpushed (a fresh
+    // repo with no remote) must still be refused.
+    if !flags.allow_default_branch {
+        let default_branch = get_default_branch(deps.git);
+        if old_name == default_branch {
+            error_log(
+                deps.io,
+                &format!("Error: '{old_name}' is this repository's default branch"),
+            );
+            error_log(
+                deps.io,
+                "Renaming it would break clones, open pull requests and CI references.",
+            );
+            error_log(
+                deps.io,
+                "Pass --allow-default-branch if you really want to rename it.",
+            );
+            return Err(VibeError::AlreadyReported);
+        }
     }
 
     // Pushed-branch guard: refuse to rename a branch tracking a remote.
@@ -155,7 +190,7 @@ where
         );
     }
 
-    if dry_run {
+    if flags.dry_run {
         if !path_unchanged {
             log_dry_run(
                 deps.io,
@@ -352,6 +387,9 @@ mod tests {
         upstream_remote: Option<String>,
         /// Branches that `show-ref` reports as existing.
         existing_branches: Vec<String>,
+        /// What `symbolic-ref refs/remotes/origin/HEAD --short` returns, or
+        /// `None` → the ref is missing (no remote HEAD configured).
+        origin_head: Option<String>,
         /// Fail any call whose args START WITH this vector (e.g. ["branch","-m"]).
         fail_on: Option<Vec<String>>,
         /// Fail any call whose args EXACTLY equal this vector. Unlike `fail_on`'s
@@ -368,6 +406,7 @@ mod tests {
                 current_root: current_root.to_string(),
                 upstream_remote: None,
                 existing_branches: vec![],
+                origin_head: None,
                 fail_on: None,
                 fail_on_exact: None,
                 calls: RefCell::new(vec![]),
@@ -389,6 +428,11 @@ mod tests {
         }
         fn with_existing_branch(mut self, branch: &str) -> Self {
             self.existing_branches.push(branch.to_string());
+            self
+        }
+        /// Make `origin/HEAD` resolve to `branch`, i.e. declare it the default.
+        fn with_default_branch(mut self, branch: &str) -> Self {
+            self.origin_head = Some(format!("origin/{branch}"));
             self
         }
         fn calls_contain(&self, prefix: &[&str]) -> bool {
@@ -427,6 +471,23 @@ mod tests {
             }
             if args.contains(&"list") && args.contains(&"worktree") {
                 return Ok(self.worktree_list.clone());
+            }
+            if args.contains(&"symbolic-ref") {
+                return match &self.origin_head {
+                    Some(h) => Ok(h.clone()),
+                    None => Err(VibeError::GitOperation {
+                        command: args.join(" "),
+                        message: "failed: is not a symbolic ref".into(),
+                    }),
+                };
+            }
+            if args.contains(&"init.defaultBranch") {
+                // Unconfigured in these tests → `get_default_branch` falls back
+                // to `master`, which no fixture branch is named.
+                return Err(VibeError::GitOperation {
+                    command: args.join(" "),
+                    message: "failed: key missing".into(),
+                });
             }
             if args.contains(&"--get") {
                 // branch.<name>.remote lookup.
@@ -586,7 +647,8 @@ mod tests {
         let git = MockGit::new("", "/main");
         let (r, s, p) = (NoResolver, NoScript, FakeProcessControl::new("/feat"));
         let d = deps(&io, &git, &r, &s, &p, "/feat");
-        let err = rename_command(&d, "   ", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(&d, "   ", RenameFlags::default(), OutputOptions::default())
+            .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
         assert!(io.stderr_text().contains("New branch name is required"));
     }
@@ -598,7 +660,8 @@ mod tests {
         let git = MockGit::new(&two_worktrees("/main", "/wt/feat", "feat"), "/wt/feat");
         let (r, s, p) = (NoResolver, NoScript, FakeProcessControl::new("/elsewhere"));
         let d = deps(&io, &git, &r, &s, &p, "/elsewhere");
-        let err = rename_command(&d, "new", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(&d, "new", RenameFlags::default(), OutputOptions::default())
+            .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
         assert!(io.stderr_text().contains("Not in a vibe worktree"));
     }
@@ -610,7 +673,8 @@ mod tests {
         let git = MockGit::new(&two_worktrees("/main", "/wt/feat", "feat"), "/main");
         let (r, s, p) = (NoResolver, NoScript, FakeProcessControl::new("/main"));
         let d = deps(&io, &git, &r, &s, &p, "/main");
-        let err = rename_command(&d, "new", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(&d, "new", RenameFlags::default(), OutputOptions::default())
+            .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
         assert!(io.stderr_text().contains("Cannot rename main worktree"));
     }
@@ -621,7 +685,8 @@ mod tests {
         let git = MockGit::new(&two_worktrees("/main", "/wt/feat", "feat"), "/wt/feat");
         let (r, s, p) = (NoResolver, NoScript, FakeProcessControl::new("/wt/feat"));
         let d = deps(&io, &git, &r, &s, &p, "/wt/feat");
-        let outcome = rename_command(&d, "feat", false, OutputOptions::default()).unwrap();
+        let outcome =
+            rename_command(&d, "feat", RenameFlags::default(), OutputOptions::default()).unwrap();
         assert_eq!(outcome, Outcome::cd("/wt/feat"));
         assert!(io.stderr_text().contains("Already named 'feat'"));
         assert!(!git.calls_contain(&["branch", "-m"]));
@@ -635,7 +700,13 @@ mod tests {
             .with_remote("origin");
         let (r, s, p) = (NoResolver, NoScript, FakeProcessControl::new("/wt/feat"));
         let d = deps(&io, &git, &r, &s, &p, "/wt/feat");
-        let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
         let out = io.stderr_text();
         assert!(out.contains("branch 'feat' is pushed to 'origin'"));
@@ -651,7 +722,13 @@ mod tests {
             .with_existing_branch("renamed");
         let (r, s, p) = (NoResolver, NoScript, FakeProcessControl::new("/wt/feat"));
         let d = deps(&io, &git, &r, &s, &p, "/wt/feat");
-        let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
         assert!(io.stderr_text().contains("branch 'renamed' already exists"));
     }
@@ -667,7 +744,13 @@ mod tests {
         let git = MockGit::new(&porcelain, "/wt/feat");
         let (r, s, p) = (NoResolver, NoScript, FakeProcessControl::new("/wt/feat"));
         let d = deps(&io, &git, &r, &s, &p, "/wt/feat");
-        let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
         assert!(io
             .stderr_text()
@@ -681,7 +764,16 @@ mod tests {
         let git = MockGit::new(&two_worktrees("/main", "/wt/feat", "feat"), "/wt/feat");
         let (r, s, p) = (NoResolver, NoScript, FakeProcessControl::new("/wt/feat"));
         let d = deps(&io, &git, &r, &s, &p, "/wt/feat");
-        let outcome = rename_command(&d, "renamed", true, OutputOptions::default()).unwrap();
+        let outcome = rename_command(
+            &d,
+            "renamed",
+            RenameFlags {
+                dry_run: true,
+                ..RenameFlags::default()
+            },
+            OutputOptions::default(),
+        )
+        .unwrap();
         // Dry-run emits NO cd.
         assert_eq!(outcome, Outcome::none());
         let out = io.stderr_text();
@@ -701,7 +793,13 @@ mod tests {
         let (r, s) = (NoResolver, NoScript);
         let p = FakeProcessControl::new(&FEAT);
         let d = deps(&io, &git, &r, &s, &p, &FEAT);
-        let outcome = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap();
+        let outcome = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap();
         assert_eq!(outcome, Outcome::cd(&**RENAMED));
         // Moved, chdir'd into new, then renamed branch — in that order.
         assert!(git.calls_contain(&["worktree", "move", &FEAT, &RENAMED]));
@@ -722,7 +820,13 @@ mod tests {
         let (r, s) = (NoResolver, NoScript);
         let p = FakeProcessControl::new(&FEAT);
         let d = deps(&io, &git, &r, &s, &p, &FEAT);
-        let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         // Forward move happened, then the ROLLBACK move (new → old) happened.
@@ -749,7 +853,13 @@ mod tests {
         // chdir to the NEW path fails.
         let p = FakeProcessControl::failing_to(&FEAT, &RENAMED);
         let d = deps(&io, &git, &r, &s, &p, &FEAT);
-        let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         // Forward move + rollback move both issued; branch rename NEVER attempted.
@@ -779,7 +889,13 @@ mod tests {
         let (r, s) = (NoResolver, NoScript);
         let p = FakeProcessControl::new(&FEAT);
         let d = deps(&io, &git, &r, &s, &p, &FEAT);
-        let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         // Forward move happened; rollback move (new → old) was ATTEMPTED.
@@ -812,7 +928,13 @@ mod tests {
         // chdir into the NEW path fails → triggers the 4a rollback path.
         let p = FakeProcessControl::failing_to(&FEAT, &RENAMED);
         let d = deps(&io, &git, &r, &s, &p, &FEAT);
-        let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         assert!(git.calls_contain(&["worktree", "move", &FEAT, &RENAMED]));
@@ -847,7 +969,13 @@ mod tests {
         // chdir to new succeeds, but current_dir() reports a DIFFERENT path.
         let p = FakeProcessControl::reporting_dir(&FEAT, "/somewhere/else-entirely");
         let d = deps(&io, &git, &r, &s, &p, &FEAT);
-        let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         // (a) branch rename NEVER attempted.
@@ -883,7 +1011,7 @@ mod tests {
         let outcome = rename_command(
             &d,
             "renamed",
-            false,
+            RenameFlags::default(),
             OutputOptions::new(true, false), // verbose so the unchanged line prints
         )
         .unwrap();
@@ -920,7 +1048,16 @@ mod tests {
         let (r, s) = (NoResolver, NoScript);
         let p = FakeProcessControl::new(&RENAMED);
         let d = deps(&io, &git, &r, &s, &p, &RENAMED);
-        let outcome = rename_command(&d, "renamed", true, OutputOptions::default()).unwrap();
+        let outcome = rename_command(
+            &d,
+            "renamed",
+            RenameFlags {
+                dry_run: true,
+                ..RenameFlags::default()
+            },
+            OutputOptions::default(),
+        )
+        .unwrap();
         assert_eq!(outcome, Outcome::none());
 
         let out = io.stderr_text();
@@ -951,7 +1088,13 @@ mod tests {
         // chdir to NEW succeeds (first chdir), chdir BACK to old fails (second).
         let p = FakeProcessControl::failing_to(&FEAT, &FEAT);
         let d = deps(&io, &git, &r, &s, &p, &FEAT);
-        let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         // Forward + rollback move both happened (rollback SUCCEEDED).
@@ -984,7 +1127,13 @@ mod tests {
         let (r, s) = (NoResolver, NoScript);
         let p = FakeProcessControl::new(&FEAT);
         let d = deps(&io, &git, &r, &s, &p, &FEAT);
-        let err = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap_err();
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, VibeError::AlreadyReported));
 
         assert!(
@@ -1014,9 +1163,121 @@ mod tests {
         let d = deps(&io, &git, &r, &s, &p, &FEAT);
         // The MRU write targets /home/u/myrepo-renamed which does not exist on
         // disk; update_mru_branch is best-effort and its failure is swallowed.
-        let outcome = rename_command(&d, "renamed", false, OutputOptions::default()).unwrap();
+        let outcome = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap();
         assert_eq!(outcome, Outcome::cd(&**RENAMED));
         assert!(io.stderr_text().contains("Renamed feat -> renamed"));
+    }
+
+    // --- default-branch guard (#578) ----------------------------------------
+
+    #[test]
+    fn renaming_the_default_branch_errors_without_mutating() {
+        // A secondary worktree checked out on the repo's default branch: the
+        // rename must be refused outright, with nothing moved or renamed.
+        let (_fx, io) = io_with_home();
+        let git = MockGit::new(&two_worktrees(&MAIN, &FEAT, "develop"), &FEAT)
+            .with_default_branch("develop");
+        let (r, s) = (NoResolver, NoScript);
+        let p = FakeProcessControl::new(&FEAT);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, VibeError::AlreadyReported));
+
+        let out = io.stderr_text();
+        assert!(
+            out.contains("'develop' is this repository's default branch"),
+            "stderr: {out}"
+        );
+        assert!(out.contains("--allow-default-branch"), "stderr: {out}");
+        assert!(!git.calls_contain(&["branch", "-m"]));
+        assert!(!git.calls_contain(&["worktree", "move"]));
+    }
+
+    #[test]
+    fn allow_default_branch_lets_the_rename_through() {
+        // The escape hatch must reach the normal success path, not merely
+        // downgrade the message.
+        let (_fx, io) = io_with_home();
+        let git = MockGit::new(&two_worktrees(&MAIN, &FEAT, "develop"), &FEAT)
+            .with_default_branch("develop");
+        let (r, s) = (NoResolver, NoScript);
+        let p = FakeProcessControl::new(&FEAT);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
+        let outcome = rename_command(
+            &d,
+            "renamed",
+            RenameFlags {
+                allow_default_branch: true,
+                ..RenameFlags::default()
+            },
+            OutputOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(outcome, Outcome::cd(&**RENAMED));
+        assert!(git.calls_contain(&["branch", "-m", "develop", "renamed"]));
+        assert!(io.stderr_text().contains("Renamed develop -> renamed"));
+    }
+
+    #[test]
+    fn default_branch_guard_precedes_the_pushed_branch_guard() {
+        // Both guards apply to a pushed default branch. The default-branch one
+        // must win, because it names the actual reason the rename is refused.
+        let (_fx, io) = io_with_home();
+        let git = MockGit::new(&two_worktrees(&MAIN, &FEAT, "develop"), &FEAT)
+            .with_default_branch("develop")
+            .with_remote("origin");
+        let (r, s) = (NoResolver, NoScript);
+        let p = FakeProcessControl::new(&FEAT);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
+        let err = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, VibeError::AlreadyReported));
+
+        let out = io.stderr_text();
+        assert!(
+            out.contains("is this repository's default branch"),
+            "stderr: {out}"
+        );
+        assert!(!out.contains("is pushed to"), "stderr: {out}");
+    }
+
+    #[test]
+    fn a_non_default_branch_is_unaffected_by_the_guard() {
+        // Regression fence: declaring some OTHER branch the default must leave
+        // the ordinary rename path untouched.
+        let (_fx, io) = io_with_home();
+        let git =
+            MockGit::new(&two_worktrees(&MAIN, &FEAT, "feat"), &FEAT).with_default_branch("main");
+        let (r, s) = (NoResolver, NoScript);
+        let p = FakeProcessControl::new(&FEAT);
+        let d = deps(&io, &git, &r, &s, &p, &FEAT);
+        let outcome = rename_command(
+            &d,
+            "renamed",
+            RenameFlags::default(),
+            OutputOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(outcome, Outcome::cd(&**RENAMED));
+        assert!(git.calls_contain(&["branch", "-m", "feat", "renamed"]));
     }
 
     #[test]

--- a/rust/crates/vibe-core/src/completion/snapshots/fish.snap
+++ b/rust/crates/vibe-core/src/completion/snapshots/fish.snap
@@ -45,11 +45,13 @@ complete -c vibe -n '__fish_seen_subcommand_from scratch' -s n -l dry-run -d 'Sh
 
 # rename flags
 complete -c vibe -n '__fish_seen_subcommand_from rename' -s n -l dry-run -d 'Show what would be executed'
+complete -c vibe -n '__fish_seen_subcommand_from rename' -l allow-default-branch -d 'Allow operating on the repository\'s default branch'
 
 # clean flags
 complete -c vibe -n '__fish_seen_subcommand_from clean' -s f -l force -d 'Skip confirmation prompts'
 complete -c vibe -n '__fish_seen_subcommand_from clean' -l delete-branch -d 'Delete the branch after removing the worktree'
 complete -c vibe -n '__fish_seen_subcommand_from clean' -l keep-branch -d 'Keep the branch after removing the worktree'
+complete -c vibe -n '__fish_seen_subcommand_from clean' -l allow-default-branch -d 'Allow operating on the repository\'s default branch'
 
 # upgrade flags
 complete -c vibe -n '__fish_seen_subcommand_from upgrade' -l check -d 'Check for updates without upgrade instructions'

--- a/rust/crates/vibe-core/src/completion/snapshots/zsh.snap
+++ b/rust/crates/vibe-core/src/completion/snapshots/zsh.snap
@@ -62,14 +62,16 @@ _vibe_jump() {
 
 _vibe_rename() {
   _arguments \
-    '(-n --dry-run)'{-n,--dry-run}'[Show what would be executed]'
+    '(-n --dry-run)'{-n,--dry-run}'[Show what would be executed]' \
+    '--allow-default-branch[Allow operating on the repository'\''s default branch]'
 }
 
 _vibe_clean() {
   _arguments \
     '(-f --force)'{-f,--force}'[Skip confirmation prompts]' \
     '--delete-branch[Delete the branch after removing the worktree]' \
-    '--keep-branch[Keep the branch after removing the worktree]'
+    '--keep-branch[Keep the branch after removing the worktree]' \
+    '--allow-default-branch[Allow operating on the repository'\''s default branch]'
 }
 
 _vibe_home() {

--- a/rust/crates/vibe-core/src/completion/spec.rs
+++ b/rust/crates/vibe-core/src/completion/spec.rs
@@ -128,11 +128,13 @@ pub const SUBCOMMANDS: &[CommandSpec] = &[
         name: "rename",
         description: "Rename the current worktree's branch and directory",
         positional_completion: None,
-        flags: &[FlagSpec::flag_short(
-            "dry-run",
-            "n",
-            "Show what would be executed",
-        )],
+        flags: &[
+            FlagSpec::flag_short("dry-run", "n", "Show what would be executed"),
+            FlagSpec::flag(
+                "allow-default-branch",
+                "Allow operating on the repository's default branch",
+            ),
+        ],
     },
     CommandSpec {
         name: "clean",
@@ -145,6 +147,10 @@ pub const SUBCOMMANDS: &[CommandSpec] = &[
                 "Delete the branch after removing the worktree",
             ),
             FlagSpec::flag("keep-branch", "Keep the branch after removing the worktree"),
+            FlagSpec::flag(
+                "allow-default-branch",
+                "Allow operating on the repository's default branch",
+            ),
         ],
     },
     CommandSpec {

--- a/rust/crates/vibe-core/src/git.rs
+++ b/rust/crates/vibe-core/src/git.rs
@@ -308,6 +308,56 @@ pub fn branch_exists(runner: &impl GitRunner, branch_name: &str) -> bool {
         .is_ok()
 }
 
+/// Last-resort default-branch name when git tells us nothing.
+///
+/// `master` (not `main`): it is what git itself still falls back to when
+/// `init.defaultBranch` is unset, so a repository that gives us no signal at all
+/// is most likely an old-style one.
+const FALLBACK_DEFAULT_BRANCH: &str = "master";
+
+/// Resolve the repository's default branch NAME (no `origin/` prefix).
+///
+/// Resolution order, first hit wins:
+/// 1. `git symbolic-ref refs/remotes/origin/HEAD --short` → `origin/<name>`,
+///    the authoritative answer for a cloned repo.
+/// 2. `git config --get init.defaultBranch` → what a fresh `git init` here would
+///    have created (covers repos with no remote).
+/// 3. [`FALLBACK_DEFAULT_BRANCH`].
+///
+/// Never fails: every git call is best-effort, because this feeds a *guard*, and
+/// a guard that errors out would break `clean`/`rename` in repositories where
+/// git simply has no opinion.
+pub fn get_default_branch(runner: &impl GitRunner) -> String {
+    if let Ok(out) = runner.run(&["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]) {
+        if let Some(name) = strip_remote_prefix(out.trim()) {
+            return name;
+        }
+    }
+
+    if let Ok(out) = runner.run(&["config", "--get", "init.defaultBranch"]) {
+        let trimmed = out.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    FALLBACK_DEFAULT_BRANCH.to_string()
+}
+
+/// Strip the leading `origin/` from a `symbolic-ref --short` answer.
+///
+/// Returns `None` for an empty input or a bare `origin/` with nothing after it,
+/// so the caller falls through to the next resolution step instead of adopting
+/// an empty branch name (which would make the guard match every branch).
+fn strip_remote_prefix(short_ref: &str) -> Option<String> {
+    let name = short_ref.strip_prefix("origin/").unwrap_or(short_ref);
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
 /// Result of [`detect_broken_worktree_link`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct BrokenWorktreeLink {
@@ -630,6 +680,73 @@ branch refs/heads/main
                 },
             ]
         );
+    }
+
+    // --- default-branch resolution ------------------------------------------
+
+    /// A runner that answers only the calls listed in `answers` (exact arg-vector
+    /// match) and fails everything else, so each test states precisely which
+    /// resolution step git is able to satisfy.
+    struct ScriptedGit {
+        answers: Vec<(Vec<&'static str>, String)>,
+    }
+    impl ScriptedGit {
+        fn new(answers: &[(&[&'static str], &str)]) -> Self {
+            ScriptedGit {
+                answers: answers
+                    .iter()
+                    .map(|(args, out)| (args.to_vec(), out.to_string()))
+                    .collect(),
+            }
+        }
+    }
+    impl GitRunner for ScriptedGit {
+        fn run(&self, args: &[&str]) -> Result<String> {
+            for (expected, out) in &self.answers {
+                if expected.as_slice() == args {
+                    return Ok(out.clone());
+                }
+            }
+            Err(VibeError::GitOperation {
+                command: args.join(" "),
+                message: "failed: not scripted".into(),
+            })
+        }
+    }
+
+    const SYMREF: &[&str] = &["symbolic-ref", "refs/remotes/origin/HEAD", "--short"];
+    const INIT_DEFAULT: &[&str] = &["config", "--get", "init.defaultBranch"];
+
+    #[test]
+    fn default_branch_comes_from_origin_head_without_the_remote_prefix() {
+        let git = ScriptedGit::new(&[(SYMREF, "origin/develop\n")]);
+        assert_eq!(get_default_branch(&git), "develop");
+    }
+
+    #[test]
+    fn default_branch_keeps_slashes_inside_the_branch_name() {
+        // Only the leading `origin/` is stripped; `release/` is part of the name.
+        let git = ScriptedGit::new(&[(SYMREF, "origin/release/stable")]);
+        assert_eq!(get_default_branch(&git), "release/stable");
+    }
+
+    #[test]
+    fn default_branch_falls_back_to_init_default_branch_config() {
+        let git = ScriptedGit::new(&[(INIT_DEFAULT, "trunk\n")]);
+        assert_eq!(get_default_branch(&git), "trunk");
+    }
+
+    #[test]
+    fn default_branch_falls_back_to_master_when_git_knows_nothing() {
+        let git = ScriptedGit::new(&[]);
+        assert_eq!(get_default_branch(&git), "master");
+    }
+
+    #[test]
+    fn default_branch_ignores_empty_answers_and_keeps_resolving() {
+        // A bare `origin/` and a blank config value must not become the answer.
+        let git = ScriptedGit::new(&[(SYMREF, "origin/"), (INIT_DEFAULT, "   ")]);
+        assert_eq!(get_default_branch(&git), "master");
     }
 
     #[test]

--- a/rust/crates/vibe/src/cli.rs
+++ b/rust/crates/vibe/src/cli.rs
@@ -151,6 +151,9 @@ pub struct RenameArgs {
     pub new_name: Option<String>,
     #[arg(short = 'n', long = "dry-run")]
     pub dry_run: bool,
+    /// Allow operating on the repository's default branch.
+    #[arg(long = "allow-default-branch")]
+    pub allow_default_branch: bool,
 }
 
 #[derive(Debug, Args)]
@@ -164,6 +167,9 @@ pub struct CleanArgs {
     /// Keep the branch after removing the worktree.
     #[arg(long = "keep-branch")]
     pub keep_branch: bool,
+    /// Allow operating on the repository's default branch.
+    #[arg(long = "allow-default-branch")]
+    pub allow_default_branch: bool,
     /// Claude Code worktree-hook mode (reads JSON from stdin).
     #[arg(long = "claude-code-worktree-hook")]
     pub worktree_hook: bool,

--- a/rust/crates/vibe/src/commands/mod.rs
+++ b/rust/crates/vibe/src/commands/mod.rs
@@ -90,7 +90,12 @@ pub fn untrust(opts: OutputOptions) -> Result<Outcome> {
 }
 
 /// `vibe rename <new_name> [--dry-run]`.
-pub fn rename(new_name: &str, dry_run: bool, opts: OutputOptions) -> Result<Outcome> {
+pub fn rename(
+    new_name: &str,
+    dry_run: bool,
+    allow_default_branch: bool,
+    opts: OutputOptions,
+) -> Result<Outcome> {
     let io = RealIo;
     let git = RealGit;
     let resolver = RealRepoResolver::new(&git);
@@ -116,7 +121,11 @@ pub fn rename(new_name: &str, dry_run: bool, opts: OutputOptions) -> Result<Outc
         version: version::VERSION,
         now_ms: now_ms(),
     };
-    commands::rename::rename_command(&deps, new_name, dry_run, opts)
+    let flags = commands::rename::RenameFlags {
+        dry_run,
+        allow_default_branch,
+    };
+    commands::rename::rename_command(&deps, new_name, flags, opts)
 }
 
 /// Choose a live progress tracker (interactive stderr, not quiet) or a no-op.
@@ -254,6 +263,7 @@ pub fn clean(
     delete_branch: bool,
     keep_branch: bool,
     worktree_hook: bool,
+    allow_default_branch: bool,
     opts: OutputOptions,
 ) -> Result<Outcome> {
     let io = RealIo;
@@ -297,6 +307,7 @@ pub fn clean(
         delete_branch,
         keep_branch,
         worktree_hook,
+        allow_default_branch,
     };
     clean_command(&deps, &flags, opts)
 }

--- a/rust/crates/vibe/src/main.rs
+++ b/rust/crates/vibe/src/main.rs
@@ -112,6 +112,7 @@ fn dispatch(
                 args.delete_branch,
                 args.keep_branch,
                 args.worktree_hook,
+                args.allow_default_branch,
                 opts,
             )
         }
@@ -152,7 +153,7 @@ fn dispatch(
         }
         Command::Rename(args) => {
             let new_name = args.new_name.unwrap_or_default();
-            commands::rename(&new_name, args.dry_run, opts)
+            commands::rename(&new_name, args.dry_run, args.allow_default_branch, opts)
         }
         Command::Home => commands::home(opts),
         Command::Trust => commands::trust(opts),


### PR DESCRIPTION
## Summary

Protects the repository's default branch from `vibe clean --delete-branch` and `vibe rename`, as proposed in #578.

- **Dynamic resolution** — `get_default_branch` in `vibe-core/src/git.rs` resolves the name from `git symbolic-ref refs/remotes/origin/HEAD --short` (stripping the `origin/` prefix), falling back to `git config --get init.defaultBranch`, then to `master`. Every step is best-effort: a guard that failed hard would break `clean` and `rename` in repositories where git has no opinion about a default branch. Empty answers (a bare `origin/`, a blank config value) are skipped rather than adopted, so the guard can never match every branch.
- **`vibe clean` soft-skips** — the worktree is still removed and the command still exits 0; only the branch deletion is skipped, with a message explaining why. The branch is incidental to `clean`, so a successful cleanup should not be turned into a failure.
- **`vibe rename` hard-errors** — the branch change *is* the product of `rename`, so there is nothing useful left to do. The guard is placed before the pushed-branch guard so the message names the real reason, including for a default branch in a repo with no remote.
- **`--allow-default-branch`** on both commands is the escape hatch. It is wired through clap, the completion spec, and the fish/zsh completion snapshots.

## Tests

- `git.rs`: 5 unit tests covering each resolution tier, `origin/` prefix stripping, branch names containing slashes, and empty-answer fallthrough.
- `clean_tests.rs`: 3 unit tests — default branch soft-skipped (worktree still removed, branch survives), `--allow-default-branch` deletes it, non-default branches unaffected.
- `rename.rs`: 4 unit tests — refused without mutation, `--allow-default-branch` reaches the success path, precedence over the pushed-branch guard, non-default branches unaffected.
- `packages/e2e/default-branch.test.ts`: 6 new E2E tests driving the real binary through node-pty, including one that verifies `origin/HEAD` wins over `init.defaultBranch`.

## Checks run

All of `pnpm run check:all`'s constituent checks passed locally:

- `fmt:check`, `lint`, `check:i18n`, `check:licenses`, `test:npm`, `check:docs` — via `pnpm run <script>`
- `check:rust` — `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` (605 vibe-core tests + the binary suites, all green)
- `test:e2e` — the full `packages/e2e` suite, 51 passed / 1 skipped, including the 6 new tests

The cargo and e2e steps were run with `CARGO_TARGET_DIR` pointed at an existing warm target directory and `VIBE_BINARY_PATH` at the resulting debug binary, because the sandbox host had insufficient free disk for a second full target tree. The commands and their inputs are otherwise identical to what `check:all` runs.

## Follow-up

No user-facing docs were touched to keep this PR code-focused. `packages/docs/src/content/docs/commands/{clean,rename}.mdx` (and the `ja/` + `zh/` mirrors) should document `--allow-default-branch` in a follow-up.

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)
