### PR TITLE
test: drop on-disk fixtures from control-character copy tests

### DIFF
--- a/rust/crates/vibe-core/src/copy_runner.rs
+++ b/rust/crates/vibe-core/src/copy_runner.rs
@@ -617,9 +617,9 @@ mod tests {
 
     #[test]
     fn copy_failure_warning_neutralizes_control_characters() {
-        let fx = Fixture::new();
+        // No fixture: the fake executor never touches the filesystem, and a name
+        // carrying an ESC byte cannot even be created on Windows (NTFS).
         let nasty = "bad\u{1b}[2Kname.txt";
-        fx.write(nasty, "x");
         let io = FakeIo::new();
         let exec = FakeCopyExecutor::new(CopyStrategyKind::Standard)
             .fail_on(nasty, CopyError::Failed("disk full".into()));
@@ -630,7 +630,7 @@ mod tests {
             &tracker,
             &[nasty.to_string()],
             &SymlinkedPaths::none(),
-            fx.path().to_str().unwrap(),
+            "/repo",
             "/wt",
             false,
         );
@@ -651,9 +651,8 @@ mod tests {
         // so the attacker-controlled filename appears a SECOND time inside the
         // error message. Sanitizing only the label would still let an ESC reach the
         // terminal, a few characters further along the same warning line.
-        let fx = Fixture::new();
+        // No fixture, for the same Windows reason as the warning test above.
         let nasty = "bad\u{1b}[2Kname.txt";
-        fx.write(nasty, "x");
         let io = FakeIo::new();
         let exec = FakeCopyExecutor::new(CopyStrategyKind::Standard).fail_on(
             nasty,
@@ -668,7 +667,7 @@ mod tests {
             &tracker,
             &[nasty.to_string()],
             &SymlinkedPaths::none(),
-            fx.path().to_str().unwrap(),
+            "/repo",
             "/wt",
             false,
         );


### PR DESCRIPTION
## Summary

The `rust-windows` CI job has been failing on `develop` since the merges of #585 / #586: the two copy-failure sanitization tests

- `copy_runner::tests::copy_failure_warning_neutralizes_control_characters`
- `copy_runner::tests::copy_failure_neutralizes_control_characters_inside_the_error_text`

wrote a fixture file whose name contains an ESC byte, which NTFS rejects (`os error 123: InvalidFilename`), so fixture creation panicked before the assertions ever ran.

The on-disk file was never needed: `copy_resolved_files` builds src/dest paths purely from strings and `FakeCopyExecutor` never touches the filesystem. This PR drops the `Fixture` from both tests and passes a literal `"/repo"` root, matching the neighbouring `dry_run_neutralizes_control_characters_in_git_derived_names` test. What the tests guarantee (control characters are neutralized in the warning line, the error text, and the tracker message) is unchanged.

## Test Plan

- `cargo test -p vibe-core --lib copy_runner` — 19 passed
- Ran `pnpm run check:all` in the Nix dev shell and all checks pass (fmt, lint, i18n, rust, licenses, npm shim tests, E2E, docs)

## Checklist

- [x] Tests added/updated
- [x] `pnpm run check:all` passes
- [ ] Docs updated (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFQdQUb1tdTv7G6YvmWu93
