### PR TITLE
chore: release v3.1.0

### DIFF
--- a/.bmp.yml
+++ b/.bmp.yml
@@ -23,7 +23,7 @@
 # commits itself); no --allow-net (module fetch is out-of-band); --frozen
 # requires the committed deno.lock so a release can never fetch an unpinned
 # transitive dep. Keep the flag list in sync with the `files:` map below.
-version: 3.0.0
+version: 3.1.0
 
 files:
   package.json: '"version": "%.%.%"'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-monorepo",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "type": "module",
   "description": "Monorepo for vibe CLI - Git worktree management tool",

--- a/packages/docs/src/content/docs/changelog.mdx
+++ b/packages/docs/src/content/docs/changelog.mdx
@@ -5,6 +5,23 @@ description: Version history and release notes for vibe
 
 All notable changes to vibe are documented here.
 
+## v3.1.0
+
+**Released:** 2026-08-08
+
+### Added
+
+- `vibe list` shows every worktree in the current repository, marking the current and scratch worktrees and ordering recent worktrees first. Use `vibe list --json` for scripting and editor integrations.
+- `vibe start` and `vibe scratch` can now carry untracked, non-ignored files and locally modified tracked files into a new worktree. Enable this per invocation with `--copy-untracked` / `--copy-modified`, or persist it with `untracked = true` / `modified = true` under `[copy]` in `.vibe.toml`.
+- `[copy] symlink` can share exact directories such as caches between the origin repository and its worktrees instead of duplicating them. Unsafe or unavailable links produce a warning without making the new worktree unusable, and existing real files or directories are never replaced.
+- `vibe clean --delete-branch` and `vibe rename` now protect the repository's detected default branch. Use `--allow-default-branch` when the operation is intentional.
+
+### Fixed
+
+- GitHub Release assets now include `LICENSE` and `THIRD-PARTY-LICENSES.md`, and the third-party license document reproduces the required notices for dependencies whose permissive license option was selected.
+
+---
+
 ## v3.0.0
 
 **Released:** 2026-08-02

--- a/packages/docs/src/content/docs/ja/changelog.mdx
+++ b/packages/docs/src/content/docs/ja/changelog.mdx
@@ -5,6 +5,23 @@ description: vibeのバージョン履歴とリリースノート
 
 vibeの主要な変更はここに記録されています。
 
+## v3.1.0
+
+**リリース日:** 2026年8月8日
+
+### 追加
+
+- `vibe list` で現在のリポジトリにあるすべての worktree を一覧表示できるようになりました。現在の worktree と scratch worktree を識別でき、最近使った worktree が先に並びます。スクリプトやエディター連携では `vibe list --json` を利用できます。
+- `vibe start` と `vibe scratch` で、未追跡かつ無視されていないファイルや、ローカルで変更した追跡済みファイルを新しい worktree へ引き継げるようになりました。実行ごとに `--copy-untracked` / `--copy-modified` を指定するか、`.vibe.toml` の `[copy]` で `untracked = true` / `modified = true` を設定できます。
+- `[copy] symlink` で、キャッシュなどの指定ディレクトリを複製せず、origin リポジトリと worktree の間で共有できるようになりました。安全にリンクできない場合やリンクを作成できない環境では、新しい worktree を使用不能にせず警告を表示します。既存の通常ファイルやディレクトリを置き換えることもありません。
+- `vibe clean --delete-branch` と `vibe rename` が、検出したリポジトリの既定ブランチを保護するようになりました。意図的に操作する場合は `--allow-default-branch` を指定できます。
+
+### 修正
+
+- GitHub Release のアセットに `LICENSE` と `THIRD-PARTY-LICENSES.md` が含まれるようになり、第三者ライセンス文書に、選択された許容的ライセンスで必要となる依存関係の告知全文が収録されるようになりました。
+
+---
+
 ## v3.0.0
 
 **リリース日:** 2026年8月2日

--- a/packages/docs/src/content/docs/zh/changelog.mdx
+++ b/packages/docs/src/content/docs/zh/changelog.mdx
@@ -5,6 +5,23 @@ description: vibe 的版本历史与发行说明
 
 vibe 的所有重要变更都记录在这里。
 
+## v3.1.0
+
+**发布日期：** 2026年8月8日
+
+### 新增
+
+- `vibe list` 现在可以列出当前仓库中的所有 worktree，并标记当前 worktree 和 scratch worktree，同时将最近使用的 worktree 排在前面。脚本和编辑器集成可使用 `vibe list --json`。
+- `vibe start` 和 `vibe scratch` 现在可以把未跟踪且未被忽略的文件，以及本地修改过的已跟踪文件带入新的 worktree。可以在单次调用中使用 `--copy-untracked` / `--copy-modified`，也可以在 `.vibe.toml` 的 `[copy]` 下设置 `untracked = true` / `modified = true`。
+- `[copy] symlink` 现在可以让原始仓库与 worktree 通过符号链接共享缓存等指定目录，而无需复制。链接不安全或无法创建时会显示警告，但不会导致新 worktree 无法使用；已有的普通文件或目录也不会被替换。
+- `vibe clean --delete-branch` 和 `vibe rename` 现在会保护检测到的仓库默认分支。如确需执行该操作，可使用 `--allow-default-branch`。
+
+### 修复
+
+- GitHub Release 资源现在会附带 `LICENSE` 和 `THIRD-PARTY-LICENSES.md`；第三方许可证文档也会完整收录所选宽松许可证要求保留的依赖声明文本。
+
+---
+
 ## v3.0.0
 
 **发布日期：** 2026年8月2日

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Git worktree helper CLI",
   "type": "module",
   "bin": {
@@ -15,11 +15,11 @@
     "test:watch": "vitest"
   },
   "optionalDependencies": {
-    "@kexi/vibe-linux-x64": "3.0.0",
-    "@kexi/vibe-linux-arm64": "3.0.0",
-    "@kexi/vibe-darwin-x64": "3.0.0",
-    "@kexi/vibe-darwin-arm64": "3.0.0",
-    "@kexi/vibe-win32-x64": "3.0.0"
+    "@kexi/vibe-linux-x64": "3.1.0",
+    "@kexi/vibe-linux-arm64": "3.1.0",
+    "@kexi/vibe-darwin-x64": "3.1.0",
+    "@kexi/vibe-darwin-arm64": "3.1.0",
+    "@kexi/vibe-win32-x64": "3.1.0"
   },
   "devDependencies": {
     "vitest": "^3.2.6"

--- a/packages/vibe-darwin-arm64/package.json
+++ b/packages/vibe-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-darwin-arm64",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "macOS arm64 binary for the vibe CLI",
   "os": [
     "darwin"

--- a/packages/vibe-darwin-x64/package.json
+++ b/packages/vibe-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-darwin-x64",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "macOS x64 binary for the vibe CLI",
   "os": [
     "darwin"

--- a/packages/vibe-linux-arm64/package.json
+++ b/packages/vibe-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-linux-arm64",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Linux arm64 binary for the vibe CLI",
   "os": [
     "linux"

--- a/packages/vibe-linux-x64/package.json
+++ b/packages/vibe-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-linux-x64",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Linux x64 binary for the vibe CLI",
   "os": [
     "linux"

--- a/packages/vibe-win32-x64/package.json
+++ b/packages/vibe-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kexi/vibe-win32-x64",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Windows x64 binary for the vibe CLI",
   "os": [
     "win32"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,19 +80,19 @@ importers:
         version: 3.2.6(@types/debug@4.1.12)(@types/node@24.13.2)(@vitest/ui@3.2.6)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2)
     optionalDependencies:
       '@kexi/vibe-darwin-arm64':
-        specifier: 3.0.0
+        specifier: 3.1.0
         version: link:../vibe-darwin-arm64
       '@kexi/vibe-darwin-x64':
-        specifier: 3.0.0
+        specifier: 3.1.0
         version: link:../vibe-darwin-x64
       '@kexi/vibe-linux-arm64':
-        specifier: 3.0.0
+        specifier: 3.1.0
         version: link:../vibe-linux-arm64
       '@kexi/vibe-linux-x64':
-        specifier: 3.0.0
+        specifier: 3.1.0
         version: link:../vibe-linux-x64
       '@kexi/vibe-win32-x64':
-        specifier: 3.0.0
+        specifier: 3.1.0
         version: link:../vibe-win32-x64
 
   packages/vibe-darwin-arm64: {}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-core"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "globset",
  "indicatif",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-test-support"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "tempfile",
 ]

--- a/rust/crates/vibe-core/Cargo.toml
+++ b/rust/crates/vibe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-core"
-version = "3.0.0"
+version = "3.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/rust/crates/vibe-test-support/Cargo.toml
+++ b/rust/crates/vibe-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-test-support"
-version = "3.0.0"
+version = "3.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/rust/crates/vibe/Cargo.toml
+++ b/rust/crates/vibe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe"
-version = "3.0.0"
+version = "3.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

- Release version 3.1.0
- Sync npm and Cargo manifests
- Add English, Japanese, and Simplified Chinese changelog entries

## Checklist

- [x] Version updated and synchronized across manifests
- [x] Changelog updated in all supported languages
- [x] pnpm run check:all passes locally
- [ ] CI checks passing

---

After merging this PR:
1. Create a PR from develop to main
2. Merge the develop → main PR
3. Run the Release workflow for main
4. The workflow builds binaries, publishes GitHub Release v3.1.0, and triggers npm publishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added worktree listing, including JSON output.
  * Added support for carrying untracked and modified files into new worktrees.
  * Added shared symlink directories between worktrees.
  * Added protection for the default branch.

* **Bug Fixes**
  * Updated GitHub Release license assets and third-party license documentation.

* **Documentation**
  * Added the v3.1.0 changelog in English, Japanese, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->