### PR TITLE
fix(ci): authenticate pinact against the GitHub API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,7 +592,12 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-toolchain
+      # pinact resolves each `uses:` against the GitHub API. Unauthenticated it
+      # shares the runner's IP quota (60 req/h) and dies with a 403 on busy
+      # hours; GITHUB_TOKEN lifts it to 1000 req/h for this repo.
       - run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   gitleaks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

`pinact-verify` failed on #593 (a Dependabot bump that is itself correct):

```
ERROR failed to handle a line: list tags: GET https://api.github.com/repos/dtolnay/rust-toolchain/tags?per_page=100:
403 API rate limit exceeded for 52.154.130.209.
(But here's the good news: Authenticated requests get a higher rate limit.) [rate reset in 4m55s]
```

`pinact run --check` resolves every `uses:` through the GitHub API. Without a
token it authenticates as nobody and shares the runner IP's 60 req/h quota with
every other job scheduled on that host, so it fails intermittently on unrelated
PRs. The failure also cascades: `build` gates on `pinact-verify`, so the whole
required check goes red.

## What

Pass `GITHUB_TOKEN` to the step. That raises the limit to 1000 req/h scoped to
this repository. The workflow's default `permissions: contents: read` already
covers the tag lookups pinact performs, so no permission change is needed.

## Verification

Ran both commands locally against #593's tree with a token — the bump's pins are
valid, only the anonymous API access was broken:

```
$ pinact run --check   # exit 0
$ pinact run --verify  # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation to provide the required access token when checking workflow action versions.
  * Improved CI reliability without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->