### PR TITLE
fix: keep SummaryFixture's config path identical to its resolver key

### DIFF
--- a/rust/crates/vibe-core/src/commands/list_tests.rs
+++ b/rust/crates/vibe-core/src/commands/list_tests.rs
@@ -2180,6 +2180,13 @@ fn a_real_head_sha_is_published_unchanged() {
 struct SummaryFixture {
     fx: vibe_test_support::Fixture,
     main_path: String,
+    /// The `.vibe.toml` path exactly as it was registered in `resolver`.
+    ///
+    /// Kept rather than rebuilt on demand so the lookup key and the path handed
+    /// to the product can never drift apart: `MapResolver` matches on the raw
+    /// string, so any difference in separator style is an unresolvable path and
+    /// therefore a silent "untrusted" verdict.
+    config_path: String,
     io: FakeIo,
     resolver: MapResolver,
 }
@@ -2256,9 +2263,11 @@ impl SummaryFixture {
         }
         save_user_settings(&io, &settings, V).unwrap();
 
+        let config_path = file_path.to_string_lossy().into_owned();
+
         let mut repos = StdHashMap::new();
         repos.insert(
-            file_path.to_string_lossy().into_owned(),
+            config_path.clone(),
             RepoInfo {
                 remote_url: None,
                 repo_root: main_path.clone(),
@@ -2269,18 +2278,16 @@ impl SummaryFixture {
         SummaryFixture {
             fx,
             main_path,
+            config_path,
             io,
             resolver: MapResolver { repos },
         }
     }
 
-    /// The absolute path of the fixture's `.vibe.toml`.
+    /// The absolute path of the fixture's `.vibe.toml`, byte-identical to the
+    /// key it is registered under in the resolver.
     fn config_path(&self) -> String {
-        self.fx
-            .path()
-            .join("repo/.vibe.toml")
-            .to_string_lossy()
-            .into_owned()
+        self.config_path.clone()
     }
 
     /// A git whose main worktree is this fixture's real directory, plus any
@@ -2451,7 +2458,7 @@ fn editing_only_the_summary_section_revokes_trust() {
     let verdict =
         crate::settings_io::verify_trust_and_read(&fixture.io, &fixture.resolver, V, &path)
             .unwrap();
-    assert!(verdict.trusted);
+    assert!(verdict.trusted, "the unedited file starts out trusted");
 
     // Swap in a different command; nothing else about the file changes.
     fixture.fx.write(


### PR DESCRIPTION
Fixes the Windows-only test failure that has been breaking every `develop` push since #613 was merged (32c46f7; the preceding 9d88e8d was green). `rust-windows` failed on each push and the aggregate `build` job failed with it.

## Symptom

A single test failed, and only on Windows:

```
commands::list::tests::editing_only_the_summary_section_revokes_trust
```

The **first** `verify_trust_and_read` call returned `trusted == false`, so `assert!(verdict.trusted)` blew up before the test ever got to the edit it was meant to exercise.

## Root cause

`SummaryFixture::config_path` (`rust/crates/vibe-core/src/commands/list_tests.rs`) rebuilt the `.vibe.toml` path with a raw `Path::join`:

```rust
self.fx.path().join("repo/.vibe.toml")
```

Windows accepts `/` as a separator when *opening* a file, but preserves it verbatim inside the `PathBuf`. So the rebuilt path was `...\repo/.vibe.toml`, whereas the key registered in `MapResolver` came from `Fixture::write` and was the host-canonical `...\repo\.vibe.toml`.

This is exactly the hazard `Fixture::join` already exists to avoid, and documents in its own comment — `config_path` was the one place that bypassed it.

`MapResolver::repo_info` matches on the raw string, so the lookup missed, no `RepoInfo` was found, and the config was reported untrusted. Note the file still *opened* fine, which is why the call returned `Ok(..)` with `trusted == false` instead of erroring.

That also explains the otherwise confusing evidence that every other `SummaryFixture::trusted` test passed on Windows: they all reach the trust check through `fixture.run()`, whose path comes from the git/`main_path` side. This test is the only caller of `config_path()`.

No production code is at fault — `verify_trust_and_read` behaved correctly for the path it was given.

## Fix

Keep the `PathBuf` returned by `Fixture::write` and hand that same string to both the resolver key and `config_path()`. The key and the path are now identical by construction, rather than depending on someone remembering to use the right join helper — so this class of drift cannot reappear in this fixture.

While here: the test's second assertion (`!after_edit.trusted`) was passing on Windows for the wrong reason, since an unresolvable path is also untrusted. The trust-revocation guarantee the test exists to protect was therefore silently void on Windows even when it "passed". The first assertion now carries a message saying what it checks.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all green on macOS.
- `ci-full` label applied so `rust-windows` runs on this PR and confirms the actual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)