### PR TITLE
docs: document --allow-default-branch on clean and rename

### DIFF
--- a/packages/docs/src/content/docs/commands/clean.mdx
+++ b/packages/docs/src/content/docs/commands/clean.mdx
@@ -41,6 +41,16 @@ Keep the branch after removing the worktree. This overrides the `delete_branch` 
 vibe clean --keep-branch
 ```
 
+### `--allow-default-branch` <Badge text="v3.1.0+" />
+
+`--delete-branch` never deletes the repository's default branch: the worktree is still removed, but the branch is kept and vibe prints why. Pass `--allow-default-branch` when you really do want it deleted.
+
+```bash
+vibe clean --delete-branch --allow-default-branch
+```
+
+See [Default branch protection](#default-branch-protection) for how the default branch is detected.
+
 ### `-V`, `--verbose`
 
 Show detailed output including git commands being executed.
@@ -143,6 +153,27 @@ If you have uncommitted changes, vibe will:
 - Show a warning
 - Ask for confirmation
 - Only proceed if you explicitly confirm
+
+### Default branch protection
+
+When `--delete-branch` (or `delete_branch = true` in the config) targets the repository's default branch, vibe removes the worktree but keeps the branch:
+
+```
+$ vibe clean --delete-branch
+Worktree /path/to/repo-main has been removed.
+Skipped deleting branch main: it is this repository's default branch.
+Pass --allow-default-branch if you really want to delete it.
+```
+
+The command still exits with code 0: the cleanup succeeded, only the branch deletion was skipped.
+
+The default branch is detected in this order, first hit wins:
+
+1. `refs/remotes/origin/HEAD` (set when the repository was cloned)
+2. `git config init.defaultBranch`
+3. `master`
+
+`origin/HEAD` is only written by `git clone`, so it does not follow a later change of the default branch on the remote. Run `git remote set-head origin -a` to refresh it. A repository created with `git init` has no `origin/HEAD` at all and falls back to `init.defaultBranch`, then `master`.
 
 ## Hooks
 

--- a/packages/docs/src/content/docs/commands/rename.mdx
+++ b/packages/docs/src/content/docs/commands/rename.mdx
@@ -15,11 +15,12 @@ vibe rename <new-name> [options]
 
 ## Options
 
-| Option            | Description                          |
-| ----------------- | ------------------------------------ |
-| `-n`, `--dry-run` | Preview operations without executing |
-| `-V`, `--verbose` | Show detailed output                 |
-| `-q`, `--quiet`   | Suppress non-essential output        |
+| Option                   | Description                                              |
+| ------------------------ | -------------------------------------------------------- |
+| `-n`, `--dry-run`        | Preview operations without executing                     |
+| `--allow-default-branch` | Allow renaming the repository's default branch (v3.1.0+) |
+| `-V`, `--verbose`        | Show detailed output                                     |
+| `-q`, `--quiet`          | Suppress non-essential output                            |
 
 ## Examples
 
@@ -52,6 +53,21 @@ Directory: /path/to/scratch-20260427-143052 -> /path/to/repo-my-feature
 2. `git branch -m <old-name> <new-name>` — rename the branch
 
 After both succeed, vibe updates its internal MRU bookkeeping and emits a `cd` command for the shell wrapper, dropping you into the renamed worktree.
+
+### The default branch is protected
+
+`vibe rename` refuses to rename the repository's default branch, even when it has never been pushed:
+
+```
+$ vibe rename my-feature
+Error: 'main' is this repository's default branch
+Renaming it would break clones, open pull requests and CI references.
+Pass --allow-default-branch if you really want to rename it.
+```
+
+Nothing is changed in that case. Pass `--allow-default-branch` to proceed anyway.
+
+The default branch is detected from `refs/remotes/origin/HEAD`, then `git config init.defaultBranch`, then `master`. `origin/HEAD` is only written by `git clone`; run `git remote set-head origin -a` if the default branch has since changed on the remote. See [`vibe clean`](/commands/clean/#default-branch-protection) for details.
 
 ### Pushed branches are not supported
 
@@ -97,10 +113,10 @@ If your worktree was tracked in the MRU list (used by `vibe jump` for ordering),
 
 ## Exit Codes
 
-| Code | Condition                                                                |
-| ---- | ------------------------------------------------------------------------ |
-| `0`  | Successful rename, or same-name no-op                                    |
-| `1`  | Error (empty name, main worktree, pushed branch, collision, git failure) |
+| Code | Condition                                                                                |
+| ---- | ---------------------------------------------------------------------------------------- |
+| `0`  | Successful rename, or same-name no-op                                                    |
+| `1`  | Error (empty name, main worktree, default branch, pushed branch, collision, git failure) |
 
 ## Related
 

--- a/packages/docs/src/content/docs/ja/commands/clean.mdx
+++ b/packages/docs/src/content/docs/ja/commands/clean.mdx
@@ -41,6 +41,16 @@ Worktree削除後もブランチを保持します。設定ファイルの`delet
 vibe clean --keep-branch
 ```
 
+### `--allow-default-branch` <Badge text="v3.1.0+" />
+
+`--delete-branch`はリポジトリのデフォルトブランチを削除しません。Worktreeは削除されますが、ブランチは残り、その理由が表示されます。本当に削除したい場合は`--allow-default-branch`を指定します。
+
+```bash
+vibe clean --delete-branch --allow-default-branch
+```
+
+デフォルトブランチの検出方法は[デフォルトブランチの保護](#デフォルトブランチの保護)を参照してください。
+
 ### `-V`, `--verbose`
 
 実行されるgitコマンドなど、詳細な出力を表示します。
@@ -143,6 +153,27 @@ $ vibe clean
 - 警告を表示
 - 確認を求める
 - 明示的に確認した場合のみ続行
+
+### デフォルトブランチの保護
+
+`--delete-branch`（または設定の`delete_branch = true`）の対象がリポジトリのデフォルトブランチだった場合、vibeはWorktreeを削除しつつブランチは残します：
+
+```
+$ vibe clean --delete-branch
+Worktree /path/to/repo-main has been removed.
+Skipped deleting branch main: it is this repository's default branch.
+Pass --allow-default-branch if you really want to delete it.
+```
+
+クリーンアップ自体は成功しているため、終了コードは0のままです。スキップされるのはブランチ削除だけです。
+
+デフォルトブランチは次の順序で検出され、最初に見つかったものが採用されます：
+
+1. `refs/remotes/origin/HEAD`（リポジトリをcloneしたときに設定される）
+2. `git config init.defaultBranch`
+3. `master`
+
+`origin/HEAD`は`git clone`のときにしか書き込まれないため、その後リモート側でデフォルトブランチを変更しても追従しません。`git remote set-head origin -a`を実行すると更新されます。`git init`で作成したリポジトリには`origin/HEAD`が存在せず、`init.defaultBranch`、次いで`master`にフォールバックします。
 
 ## フック
 

--- a/packages/docs/src/content/docs/ja/commands/rename.mdx
+++ b/packages/docs/src/content/docs/ja/commands/rename.mdx
@@ -15,11 +15,12 @@ vibe rename <new-name> [options]
 
 ## Options
 
-| Option            | 説明                     |
-| ----------------- | ------------------------ |
-| `-n`, `--dry-run` | 実行せずに操作を確認する |
-| `-V`, `--verbose` | 詳細出力を表示する       |
-| `-q`, `--quiet`   | 必須でない出力を抑制する |
+| Option                   | 説明                                                          |
+| ------------------------ | ------------------------------------------------------------- |
+| `-n`, `--dry-run`        | 実行せずに操作を確認する                                      |
+| `--allow-default-branch` | リポジトリのデフォルトブランチのリネームを許可する（v3.1.0+） |
+| `-V`, `--verbose`        | 詳細出力を表示する                                            |
+| `-q`, `--quiet`          | 必須でない出力を抑制する                                      |
 
 ## Examples
 
@@ -52,6 +53,21 @@ Directory: /path/to/scratch-20260427-143052 -> /path/to/repo-my-feature
 2. `git branch -m <old-name> <new-name>` — ブランチをリネーム
 
 両方が成功すると、内部の MRU 情報を更新し、shell wrapper 用の `cd` コマンドを出力してリネーム先へ移動します。
+
+### デフォルトブランチは保護される
+
+`vibe rename` はリポジトリのデフォルトブランチのリネームを拒否します。まだ push していないブランチであっても同様です:
+
+```
+$ vibe rename my-feature
+Error: 'main' is this repository's default branch
+Renaming it would break clones, open pull requests and CI references.
+Pass --allow-default-branch if you really want to rename it.
+```
+
+この場合、何も変更されません。それでも実行したい場合は `--allow-default-branch` を指定してください。
+
+デフォルトブランチは `refs/remotes/origin/HEAD`、次に `git config init.defaultBranch`、最後に `master` の順で検出されます。`origin/HEAD` は `git clone` のときにしか書き込まれないため、その後リモート側でデフォルトブランチが変わった場合は `git remote set-head origin -a` を実行してください。詳細は [`vibe clean`](/ja/commands/clean/#デフォルトブランチの保護) を参照してください。
 
 ### Push 済みブランチは対象外
 
@@ -97,10 +113,10 @@ To rename manually:
 
 ## Exit Codes
 
-| Code | 条件                                                               |
-| ---- | ------------------------------------------------------------------ |
-| `0`  | リネーム成功、または同名 no-op                                     |
-| `1`  | エラー（名前未指定、main worktree、push 済み、衝突、git 失敗など） |
+| Code | 条件                                                                                   |
+| ---- | -------------------------------------------------------------------------------------- |
+| `0`  | リネーム成功、または同名 no-op                                                         |
+| `1`  | エラー（名前未指定、main worktree、デフォルトブランチ、push 済み、衝突、git 失敗など） |
 
 ## 関連
 

--- a/packages/docs/src/content/docs/zh/commands/clean.mdx
+++ b/packages/docs/src/content/docs/zh/commands/clean.mdx
@@ -41,6 +41,16 @@ vibe clean --delete-branch
 vibe clean --keep-branch
 ```
 
+### `--allow-default-branch` <Badge text="v3.1.0+" />
+
+`--delete-branch` 不会删除仓库的默认分支：worktree 仍会被删除，但分支会被保留，并由 vibe 说明原因。如果确实要删除它，请传入 `--allow-default-branch`。
+
+```bash
+vibe clean --delete-branch --allow-default-branch
+```
+
+默认分支的检测方式请参阅[默认分支保护](#默认分支保护)。
+
 ### `-V`, `--verbose`
 
 显示详细输出，包括所执行的 git 命令。
@@ -143,6 +153,27 @@ $ vibe clean
 - 显示警告
 - 请求确认
 - 只有在你明确确认后才继续
+
+### 默认分支保护
+
+当 `--delete-branch`（或配置中的 `delete_branch = true`）指向仓库的默认分支时，vibe 会删除 worktree 但保留该分支：
+
+```
+$ vibe clean --delete-branch
+Worktree /path/to/repo-main has been removed.
+Skipped deleting branch main: it is this repository's default branch.
+Pass --allow-default-branch if you really want to delete it.
+```
+
+命令仍以退出码 0 结束：清理本身已成功，只是跳过了分支删除。
+
+默认分支按以下顺序检测，最先命中的生效：
+
+1. `refs/remotes/origin/HEAD`（在克隆仓库时设置）
+2. `git config init.defaultBranch`
+3. `master`
+
+`origin/HEAD` 只在 `git clone` 时写入，因此不会跟随远程之后对默认分支的更改。运行 `git remote set-head origin -a` 可以刷新它。通过 `git init` 创建的仓库完全没有 `origin/HEAD`，会回退到 `init.defaultBranch`，然后是 `master`。
 
 ## 钩子
 

--- a/packages/docs/src/content/docs/zh/commands/rename.mdx
+++ b/packages/docs/src/content/docs/zh/commands/rename.mdx
@@ -15,11 +15,12 @@ vibe rename <new-name> [options]
 
 ## 选项
 
-| 选项              | 说明                 |
-| ----------------- | -------------------- |
-| `-n`, `--dry-run` | 预览操作而不实际执行 |
-| `-V`, `--verbose` | 显示详细输出         |
-| `-q`, `--quiet`   | 抑制非必要的输出     |
+| 选项                     | 说明                                |
+| ------------------------ | ----------------------------------- |
+| `-n`, `--dry-run`        | 预览操作而不实际执行                |
+| `--allow-default-branch` | 允许重命名仓库的默认分支（v3.1.0+） |
+| `-V`, `--verbose`        | 显示详细输出                        |
+| `-q`, `--quiet`          | 抑制非必要的输出                    |
 
 ## 示例
 
@@ -52,6 +53,21 @@ Directory: /path/to/scratch-20260427-143052 -> /path/to/repo-my-feature
 2. `git branch -m <old-name> <new-name>` —— 重命名分支
 
 两者都成功后，vibe 会更新内部的 MRU 记录，并向 shell 包装函数输出 `cd` 命令，把你带入重命名后的 worktree。
+
+### 默认分支受到保护
+
+`vibe rename` 会拒绝重命名仓库的默认分支，即使该分支从未被推送过：
+
+```
+$ vibe rename my-feature
+Error: 'main' is this repository's default branch
+Renaming it would break clones, open pull requests and CI references.
+Pass --allow-default-branch if you really want to rename it.
+```
+
+这种情况下不会有任何改动。如果仍要继续，请传入 `--allow-default-branch`。
+
+默认分支依次从 `refs/remotes/origin/HEAD`、`git config init.defaultBranch`、`master` 检测。`origin/HEAD` 只在 `git clone` 时写入；如果远程的默认分支之后发生了变化，请运行 `git remote set-head origin -a`。详情请参阅 [`vibe clean`](/zh/commands/clean/#默认分支保护)。
 
 ### 不支持已推送的分支
 
@@ -97,10 +113,10 @@ To rename manually:
 
 ## 退出码
 
-| 退出码 | 条件                                                            |
-| ------ | --------------------------------------------------------------- |
-| `0`    | 重命名成功，或同名的空操作                                      |
-| `1`    | 错误（名称为空、主 worktree、已推送的分支、冲突、git 执行失败） |
+| 退出码 | 条件                                                                      |
+| ------ | ------------------------------------------------------------------------- |
+| `0`    | 重命名成功，或同名的空操作                                                |
+| `1`    | 错误（名称为空、主 worktree、默认分支、已推送的分支、冲突、git 执行失败） |
 
 ## 相关内容
 

--- a/rust/crates/vibe-core/src/git.rs
+++ b/rust/crates/vibe-core/src/git.rs
@@ -894,8 +894,8 @@ pub struct DefaultBranch {
 
 /// [`get_default_branch`] with the resolution outcome attached.
 ///
-/// Split out rather than changing the existing signature: `clean`, `rename` and
-/// `start` use this as a guard, where a guessed name is exactly as usable as a
+/// Split out rather than changing the existing signature: `clean` and `rename`
+/// use this as a guard, where a guessed name is exactly as usable as a
 /// resolved one — only the summary cache needs to tell them apart.
 ///
 /// # The value and the confidence are computed separately


### PR DESCRIPTION
## Summary

PR #584 shipped the default-branch guard for `vibe clean --delete-branch` and `vibe rename` (#578), but the escape hatch `--allow-default-branch` was only mentioned in the changelog; the `clean` and `rename` command pages never explained it. This PR fills that gap, in all three locales (en / ja / zh):

- **`commands/clean.mdx`** — adds the `--allow-default-branch` option and a "Default branch protection" section: the soft-skip behaviour (worktree removed, branch kept, exit 0), the detection order (`refs/remotes/origin/HEAD` → `init.defaultBranch` → `master`), and the caveat that `origin/HEAD` is only written by `git clone`, so a default branch changed later on the remote is unguarded until `git remote set-head origin -a` is run.
- **`commands/rename.mdx`** — adds the option to the table, a "The default branch is protected" section with the error output, and lists the default branch in the exit-code conditions.
- **`vibe-core/src/git.rs`** — drops the stale claim in `resolve_default_branch`'s doc comment that `start` also uses the guard (only `clean` and `rename` do).

Body headings deliberately carry no `<Badge>`: Starlight appends a trailing `-` to the slug of a heading that contains one, which would have broken the in-page and cross-page anchors. The badge stays on the option heading, which nothing links to.

Related to #578.

## Test Plan

- `pnpm run check:all` passes (fmt, lint, i18n, rust fmt/clippy/tests, licenses, npm, e2e, docs build).
- Verified in the built `dist/` that the new heading ids (`default-branch-protection`, `デフォルトブランチの保護`, `默认分支保护`) match the anchors used from the option section and from the `rename` pages.
- Before writing the docs, exercised the real debug binary against scratch repositories to confirm the documented behaviour: soft-skip on a cloned repo, `--allow-default-branch` deleting the branch, `rename` refusing with the shown message, and the stale-`origin/HEAD` case leaving the real default branch unguarded until `git remote set-head origin -a`.

## Checklist

- [ ] Tests added/updated (docs-only; existing unit + e2e coverage from #584 unchanged)
- [x] `pnpm run check:all` passes
- [x] Docs updated (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGinK4fsB4xi9M9UJLvyJT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated `clean` command documentation in English, Japanese, and Chinese to explain default branch protection.
  - Documented the `--allow-default-branch` override for branch deletion, including preserved branches, removed worktrees, and successful exit behavior.
  - Updated `rename` command documentation across supported languages to describe default branch protection, override usage, detection order, and related error conditions.
  - Clarified default branch detection and repository setup caveats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->