### PR TITLE
docs: stop treating auto-merge as the default an agent may apply

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -16,13 +16,19 @@ GitHub Flow: `main` is the only long-lived branch.
 
 ## Merging
 
-- Merge with `gh pr merge <pr> --auto --merge`. Auto-merge lands the PR the
-  moment its required checks go green, so there is no need to sit on a run.
+- **IMPORTANT**: opening the PR is where an agent stops. Do not merge, and do
+  not enable auto-merge on your own initiative. Landing a change on `main` is
+  the maintainer's call — they may still want to read the diff, wait on the
+  `ci-full` leg, or stack another PR on top.
+- When the maintainer asks for it, auto-merge is the right tool:
+  `gh pr merge <pr> --auto --merge` lands the PR the moment its required checks
+  go green, so nobody has to sit on a run. Asked for, never assumed.
 - `mergeStateStatus: BLOCKED` while checks are still pending is normal; it does
   not mean auto-merge failed.
 - `--admin` is a last resort, not the routine path. `main` requires a PR and
   seven passing checks but **no approving review**, precisely so a single
-  maintainer can use auto-merge instead of overriding protection on every merge.
+  maintainer can merge — with `--auto` or by hand — instead of overriding
+  protection on every merge.
 - The required checks are the seven that actually run on a PR: `build`, `lint`,
   `rust-macos`, `docs`, `pinact-verify`, `gitleaks`, `nix-build (ubuntu-latest)`.
   Never add a push-only job (`rust-linux`, `rust-windows`, `e2e-test`,

--- a/.claude/skills/vibe-release-new-version/SKILL.md
+++ b/.claude/skills/vibe-release-new-version/SKILL.md
@@ -406,11 +406,22 @@ EOF
 
 ### 5.2 Merge it
 
-`main` is protected, so the PR needs its checks green. Prefer auto-merge:
+`main` is protected, so the PR needs its checks green.
 
-```bash
-gh pr merge <pr-number> --auto --merge
-```
+Ask before landing it, with `AskUserQuestion`:
+
+- `question`: "Merge the release PR for `v<resolvedVersion>` into `main`?"
+- `header`: "Merge release"
+- `options`:
+  - `Merge with auto-merge` (Recommended) — `gh pr merge <pr-number> --auto --merge`
+  - `Hold — I'll merge it myself` — stop here and report the PR URL
+
+Why ask when the user already confirmed a version in Step 2: that answer chose a
+number, not a merge. This is the last checkpoint before the change is on `main`
+and the release becomes reachable, so the general rule in
+`.claude/rules/git-workflow.md` (open the PR and stop) holds here too. It also
+covers resuming into this step on an existing release PR, where neither Step 2.2
+nor 2.3 ever ran.
 
 ### 5.3 Wait for the post-merge CI run
 
@@ -762,7 +773,9 @@ done
 nix build .#binary --no-link   # must exit 0
 ```
 
-Commit, open a PR to `main`, and merge it like any other change.
+Commit and open a PR to `main`. Like any other change, that is where you
+stop — see `.claude/rules/git-workflow.md`; report the URL and let the user
+merge or ask for auto-merge.
 
 ### 7.6 Cleanup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ GitHub Flow: `main` is the only long-lived branch.
 ### Workflow
 
 1. Create a topic branch from `main`
-2. Open a PR into `main`; merge it once CI is green
+2. Open a PR into `main`; the maintainer merges it once CI is green
 3. To release, bump the version on a `release/vX.Y.Z` branch, merge that PR,
    then dispatch the Release workflow on `main` — it creates the tag
 


### PR DESCRIPTION
## Why

`.claude/rules/git-workflow.md` opened its Merging section with an imperative
that had no actor and no gate:

> - Merge with `gh pr merge <pr> --auto --merge`. Auto-merge lands the PR the
>   moment its required checks go green, so there is no need to sit on a run.

An agent read that as standing permission, enabled auto-merge on #644 without
being asked, and the change landed on `main` before I had looked at it.

That was never what 694139a (#638) was for. Its subject was retiring routine
`--admin` overrides of branch protection — auto-merge was documented as the
mechanism that made dropping `--admin` viable, not as authority to merge
unattended. This PR narrows *who* pulls the trigger and leaves that stance, the
required-checks constraint, and the BLOCKED-is-normal note untouched.

## What changed

Opening the PR is now where an agent stops, everywhere:

- **`.claude/rules/git-workflow.md`** — states it outright, and keeps `--auto` as
  the right tool when the maintainer asks for it. The `--admin` bullet now reads
  "can merge — with `--auto` or by hand —", so auto-merge is no longer presented
  as the sole alternative to overriding protection.
- **`.claude/skills/vibe-release-new-version/SKILL.md` §5.2** — takes an explicit
  `AskUserQuestion` before merging the release PR. The Step 2 version
  confirmation does not stand in for it: that answer chose a number, not a
  merge, and resuming into §5.2 on an existing release PR reaches it without
  either Step 2.2 or 2.3 having run.
- **`.claude/skills/vibe-release-new-version/SKILL.md` §7.5** — the post-release
  flake-hash PR stops at the PR too, rather than merging "like any other change".
- **`AGENTS.md`** — "the maintainer merges it once CI is green".

## Review

Reviewed with `codex exec` over five rounds; the last found nothing. The rounds
that found something are the point of including this:

| round | finding |
|-------|---------|
| 1 | The release skill's first wording contradicted the skill itself — Step 2.3 already confirms, so it double-asked |
| 2 | "The Step 2.3 confirmation is the authorisation" was false on the no-argument path, where 2.3 is skipped |
| 3 | Treating a *version* confirmation as *merge* authorisation was overreach, and contradicted the new general rule; also false when resuming into §5.2 |
| 4 | §7.5 still said "merge it like any other change" — a path I had missed; and "the user's only chance to read the diff" was overstated |
| 5 | none — all 351 tracked files searched for remaining unconfirmed merge paths |

Round 3 is why the release skill has no exception left: carving one out for
releases put the rule back in conflict with itself.

## Notes

- No i18n mirrors needed: `.claude/` is exempt per `.claude/rules/markdown.md`
  Exceptions, and `AGENTS.md` has no `.ja.md` / `.zh.md` siblings. `just
  check-i18n` passes.
- `just check` passes (exit 0).
- Nothing in the repo mechanically enables auto-merge — this was documentation
  only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGinK4fsB4xi9M9UJLvyJT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that pull requests must not be merged or configured for auto-merge without maintainer instruction.
  * Updated release guidance to request confirmation before enabling auto-merge or to pause and provide the pull request for manual merging.
  * Clarified that maintainers merge changes into the main branch after continuous integration checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->