### PR TITLE
chore: update Nix binary hashes for 4.1.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,19 +24,19 @@
       platforms = {
         x86_64-linux = {
           artifact = "vibe-linux-x64";
-          hash = "sha256-nfuO9Z4pxNVM9RqJa7VXt3GRuoZKvRnzhVVOGV4EIWc=";
+          hash = "sha256-h2nHIC5RjWTeI6yuI61xi4Fgs+eZea/5mca38gBayd4=";
         };
         aarch64-linux = {
           artifact = "vibe-linux-arm64";
-          hash = "sha256-Z5/qXwPfHmPOKCpn7M2Y/10TzV9Da80HBJ/mPyeJG3U=";
+          hash = "sha256-f0gBVe3ItN2pRzEyzakHCe5Xu/bA3tBlmmWnjIGAsJs=";
         };
         x86_64-darwin = {
           artifact = "vibe-darwin-x64";
-          hash = "sha256-KxpUkmp+hMWQ+3rgzeb2hVtwWuC+3chveDVfTfBu25A=";
+          hash = "sha256-1JpNZnOidg8AnbnFUn3D5uIntFBD9EAgyMK96VaaqiQ=";
         };
         aarch64-darwin = {
           artifact = "vibe-darwin-arm64";
-          hash = "sha256-Klet6Trsysq7QZbbIur3MCrzD4RPlkH6DwXCU22PSys=";
+          hash = "sha256-1HwWtHW4g2SfDUnoWP6cm5kilTzUyq5oD79IAtiwWxg=";
         };
       };
 


### PR DESCRIPTION
Post-release follow-up for v4.1.0, the same chore `b3b311e` did for v4.0.0.

`flake.nix` derives the version from `package.json`, so as soon as v4.1.0
merged it began requesting the v4.1.0 release artifacts while still carrying
v4.0.0's fixed-output hashes. These four `platforms.*.hash` values are the one
release input `flake.lock` does not cover, so they need a hand refresh once the
binaries are published.

Hashes taken with `nix store prefetch-file` against the published v4.1.0 assets.

## Verification

- `nix build .#binary` — exit 0
- the built binary reports `vibe 4.1.0+6ea54dee3895f9de8bad68d6c8126b8c4cdcaa57`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGinK4fsB4xi9M9UJLvyJT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform-specific integrity checks for the Linux and Darwin prebuilt binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->