### PR TITLE
perf: skip copy dirs already contained by another entry

### DIFF
--- a/rust/crates/vibe-core/src/copy/symlink.rs
+++ b/rust/crates/vibe-core/src/copy/symlink.rs
@@ -182,9 +182,11 @@ fn filesystem_ignores_case(dir: &Path) -> bool {
     ignores
 }
 
-/// Normalize a relative pattern to its `Normal` components, or `None` when it is
-/// absolute, escapes with `..`, or is empty.
-fn normalize_relative(pattern: &str) -> Option<Vec<String>> {
+/// Normalize a relative pattern to its `Normal` components, or `None` when it
+/// carries any component that is not `Normal` or `.` — a root component, a `..`,
+/// or a Windows drive prefix (`C:foo` has one without being absolute) — or when
+/// no `Normal` component is left, as for `""` and `"."`.
+pub(crate) fn normalize_relative(pattern: &str) -> Option<Vec<String>> {
     let path = Path::new(pattern);
     if path.is_absolute() {
         return None;

--- a/rust/crates/vibe-core/src/copy_runner.rs
+++ b/rust/crates/vibe-core/src/copy_runner.rs
@@ -10,7 +10,7 @@
 
 use crate::config::VibeConfig;
 use crate::copy::strategies::CopyExecutor;
-use crate::copy::symlink::{without_symlinked, SymlinkedPaths};
+use crate::copy::symlink::{normalize_relative, without_symlinked, SymlinkedPaths};
 use crate::glob::{expand_copy_patterns, expand_directory_patterns};
 use crate::io::Io;
 use crate::output::{log_dry_run, sanitize_for_display, warn_log};
@@ -50,6 +50,81 @@ pub fn resolve_copy_concurrency(io: &impl Io, config: Option<&VibeConfig>) -> us
     }
 
     DEFAULT_COPY_CONCURRENCY as usize
+}
+
+/// Drop the directories another entry in the same list already contains.
+///
+/// `dirs = ["a", "a/b"]` asks for one tree twice: cloning `a` puts `a/b` there
+/// as part of it. The overlap is not merely redundant — `clonefile` refuses a
+/// destination that already exists, so one of the two fails EEXIST (which one is
+/// not fixed: the copies run concurrently, and a nested entry's `ensure_parent`
+/// can materialise the ancestor's destination first). EEXIST is a SOFT error, so
+/// [`crate::copy::strategies::CopyExecutor::copy_directory`] falls back to the
+/// Standard recursive copy and rewrites file-by-file what the clone had just
+/// placed. The result stays correct and nothing warns, which is why the cost is
+/// invisible: measured on a 360MB / 17,789-file `node_modules`, `vibe start`
+/// takes 3.0s with the overlap and 0.48s without it.
+///
+/// This is reached by ordinary config, not a contrived one. `dirs =
+/// ["**/node_modules"]` expands to the root `node_modules` plus every nested one
+/// npm and pnpm leave inside it, plus each workspace's own — 31 entries in this
+/// repository, 27 of them contained in the root one.
+///
+/// Applied AFTER glob expansion for the same reason as [`without_symlinked`]: a
+/// pattern only reveals the overlap once expanded.
+///
+/// Comparison is EXACT, deliberately, even though a case-insensitive volume
+/// (the APFS and NTFS default, though both can be case-sensitive) makes `A/b`
+/// and `a/b` one directory, an overlap this therefore misses. The two mistakes are not symmetric: failing to drop a
+/// contained entry costs the redundant copy that happens today, while dropping
+/// one that was NOT contained silently skips a directory the user asked for.
+/// The safe direction is therefore to under-drop. Note this inverts
+/// [`SymlinkedPaths`]'s choice, where folding case is the safe direction because
+/// there an over-broad match skips a copy while an under-broad one writes
+/// THROUGH the link into the origin repository.
+///
+/// An entry that cannot be normalized is kept rather than dropped, whatever made
+/// it unnormalizable. The common case is a pattern naming the repository root —
+/// anything built only from empty and `.` components (`""`, `"."`, `"./"`,
+/// `"./."`, …) reduces to no components at all — but the set is not enumerated
+/// here on purpose: a Windows drive-relative pattern (`C:foo`) is not absolute,
+/// so it too can reach this filter and normalize to `None`.
+///
+/// Keeping them is the conservative choice in every case. Whatever the copy
+/// layer does with such an entry today, it keeps doing; deciding their fate is
+/// not this filter's business, and dropping one here would silently alter
+/// behaviour that predates this change.
+fn without_contained_by_siblings(dirs: &[String]) -> Vec<String> {
+    let normalized: Vec<Option<Vec<String>>> = dirs.iter().map(|d| normalize_relative(d)).collect();
+
+    dirs.iter()
+        .enumerate()
+        .filter(|(i, _)| {
+            let Some(mine) = &normalized[*i] else {
+                return true;
+            };
+            // Kept unless some OTHER entry contains this one. A strict
+            // ancestor always wins; for two entries that normalize to the SAME
+            // path the tie is broken by index so exactly one survives — dropping
+            // on `<=` alone would discard both halves of the pair.
+            //
+            // The equal case is not hypothetical: `glob.rs` dedupes non-glob
+            // patterns by their literal string, so `dirs = ["a", "./a"]` and
+            // `["a", "a/"]` both reach here as two entries naming one directory,
+            // and would otherwise hit the very EEXIST fallback this removes.
+            !normalized.iter().enumerate().any(|(j, other)| {
+                if *i == j {
+                    return false;
+                }
+                let Some(other) = other else { return false };
+                if other.len() == mine.len() {
+                    return j < *i && other == mine;
+                }
+                other.len() < mine.len() && mine.starts_with(other.as_slice())
+            })
+        })
+        .map(|(_, d)| d.clone())
+        .collect()
 }
 
 /// Join two path segments with `/` (forward-slash join, like node `path.join`).
@@ -196,10 +271,14 @@ where
     E: CopyExecutor + Sync,
     T: ProgressTracker + Sync,
 {
-    let dirs = without_symlinked(
+    // Contained entries are dropped LAST: `without_symlinked` may remove the
+    // very ancestor that would have covered a nested entry, and dropping the
+    // nested one against an ancestor that is no longer being copied would leave
+    // it uncopied altogether.
+    let dirs = without_contained_by_siblings(&without_symlinked(
         symlinked,
         &expand_directory_patterns(io, patterns, repo_root),
-    );
+    ));
     if dirs.is_empty() {
         return Ok(());
     }
@@ -722,6 +801,121 @@ mod tests {
     }
 
     // --- copy_directories concurrency + error aggregation ---
+
+    // --- contained-entry elimination ---
+
+    #[test]
+    fn a_directory_contained_by_another_entry_is_dropped() {
+        // `a` already brings `a/b` and `a/b/c` with it. Copying them again is
+        // not free: clonefile fails EEXIST on a destination that already exists,
+        // and that soft error demotes the copy to the Standard recursive
+        // fallback, which rewrites every file the clone had just placed.
+        let kept = without_contained_by_siblings(&[
+            "a".to_string(),
+            "a/b".to_string(),
+            "a/b/c".to_string(),
+        ]);
+        assert_eq!(kept, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn siblings_and_partial_name_matches_are_all_kept() {
+        // Containment is by PATH COMPONENT, not by string prefix: `node_modules2`
+        // starts with `node_modules` as text but is a different directory, and
+        // dropping it would silently skip a copy the user asked for.
+        let kept = without_contained_by_siblings(&[
+            "node_modules".to_string(),
+            "node_modules2".to_string(),
+            "packages/a".to_string(),
+            "packages/b".to_string(),
+        ]);
+        assert_eq!(
+            kept,
+            vec![
+                "node_modules".to_string(),
+                "node_modules2".to_string(),
+                "packages/a".to_string(),
+                "packages/b".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_nested_entry_survives_when_a_symlink_removes_its_ancestor() {
+        // The two filters must run symlink-first, and this pins WHY by composing
+        // them in both orders over one input.
+        //
+        // `symlink = ["a/c"]` makes `without_symlinked` drop `a` — copying it
+        // would write through the created link into the origin — while keeping
+        // its sibling subtree `a/b`. Production order therefore ends at `a/b`,
+        // which still gets copied.
+        //
+        // Reversed, containment runs first and drops `a/b` (contained by `a`),
+        // then the symlink filter drops `a`, and NOTHING is copied: the user
+        // asked for `a/b` and silently got no directory at all.
+        let dirs = vec!["a".to_string(), "a/b".to_string()];
+        let symlinked = SymlinkedPaths::from_patterns(&["a/c".to_string()], false);
+
+        let production = without_contained_by_siblings(&without_symlinked(&symlinked, &dirs));
+        assert_eq!(
+            production,
+            vec!["a/b".to_string()],
+            "symlink-first must leave the nested entry to be copied"
+        );
+
+        let reversed = without_symlinked(&symlinked, &without_contained_by_siblings(&dirs));
+        assert!(
+            reversed.is_empty(),
+            "containment-first loses the directory entirely — this is what the \
+             ordering prevents, so if this ever becomes non-empty the two \
+             filters no longer conflict and the ordering comment is stale"
+        );
+    }
+
+    #[test]
+    fn entries_that_normalize_to_the_same_directory_collapse_to_one() {
+        // `glob.rs` dedupes non-glob patterns by their literal string, so these
+        // pairs each arrive as two entries naming one directory — exactly the
+        // EEXIST-then-fallback case this filter exists to remove. Exactly one
+        // must survive: dropping both would skip the copy altogether.
+        assert_eq!(
+            without_contained_by_siblings(&["a".to_string(), "./a".to_string()]),
+            vec!["a".to_string()]
+        );
+        assert_eq!(
+            without_contained_by_siblings(&["./a".to_string(), "a".to_string()]),
+            vec!["./a".to_string()],
+            "the first spelling wins, so the survivor is stable rather than \
+             depending on which form the user happened to write second"
+        );
+        assert_eq!(
+            without_contained_by_siblings(&["a/b".to_string(), "a/./b".to_string()]),
+            vec!["a/b".to_string()]
+        );
+    }
+
+    #[test]
+    fn case_differing_entries_are_both_kept() {
+        // Exact comparison, deliberately. On a case-insensitive volume these
+        // name one directory and the overlap is missed — costing the redundant
+        // copy that happens today. The alternative errs the other way: on a
+        // case-SENSITIVE volume folding case would drop a genuinely distinct
+        // directory, and a silently missing directory is worse than a slow one.
+        let kept = without_contained_by_siblings(&["a".to_string(), "A/b".to_string()]);
+        assert_eq!(kept, vec!["a".to_string(), "A/b".to_string()]);
+    }
+
+    #[test]
+    fn an_entry_that_cannot_be_normalized_is_passed_through_unchanged() {
+        // What this pins is that the filter has no opinion of its own about an
+        // entry it cannot normalize: whatever reaches it, reaches the copy layer
+        // unaltered. These two particular spellings are stopped earlier by
+        // `expand_directory_patterns`, but others are not (a Windows
+        // drive-relative `C:foo` is not absolute), so the pass-through is a
+        // property worth pinning rather than a vacuous one.
+        let kept = without_contained_by_siblings(&["/abs".to_string(), "../up".to_string()]);
+        assert_eq!(kept, vec!["/abs".to_string(), "../up".to_string()]);
+    }
 
     #[test]
     fn copy_directories_copies_all_dirs() {


### PR DESCRIPTION
Suggested by @kexi: if `dirs` lists `./a`, `./a/b` and `./a/b/c`, copying `a`
alone should be enough. It is — and the redundant entries are not just wasted,
they are actively expensive.

## Why it costs so much

Cloning `a` creates `a/b` as part of it. The second entry then meets a
destination that already exists, so `clonefile` fails `EEXIST`. That maps to
`CopyError::Failed`, a **soft** error, so `copy_directory` falls back to
`standard_copy_directory` and rewrites file-by-file exactly what the clone had
just placed.

The result is correct and nothing warns, which is why nobody would notice.

## This is ordinary config, not a contrived one

`dirs = ["**/node_modules"]` expands to the root `node_modules`, plus every
nested `node_modules` npm and pnpm leave inside it, plus each workspace's own —
**31 entries in this repository, 27 of them contained in the root one**.

Measured end-to-end, 360MB / 17,789 files:

| | wall |
|---|---|
| before | 3.425s |
| after | 0.482s |

`diff -r` between the two resulting worktrees: **no differences**. Only the time
changed.

Entries that do not overlap — the shape the docs recommend,
`["node_modules", ".cache", "packages/*"]` — are unaffected, so this speeds up
nobody who was not already paying for a redundant copy.

## Two ordering choices are load-bearing

Both are pinned by tests rather than left to comments.

**Containment elimination runs after the symlink filter.** That filter can drop
the ancestor (copying it would write through a created link into the origin)
while keeping a sibling subtree. Run the other way round, containment drops the
subtree against an ancestor nobody copies, and the directory goes uncopied
entirely. The test composes both filters in both orders and asserts the reverse
yields an empty list.

**Comparison is exact, not case-folded** — the opposite of `SymlinkedPaths`'
choice. The mistakes are not symmetric: failing to drop a contained entry costs
the redundant copy that happens today, while dropping one that was *not*
contained silently skips a directory the user asked for. In `SymlinkedPaths` the
safe direction inverts, because there an under-broad match writes *through* the
link into the origin repository.

## What was considered and rejected

The other reading of the suggestion — infer the parent and copy that instead
(`packages/app` in place of `packages/app/node_modules`) — is unsafe, and I
verified both failures:

- The parent holds files `[copy] dirs` never asked for. A `.env` sitting beside
  `node_modules` lands in the worktree.
- Worse, most of the parent is git-tracked, and git has already placed *that
  branch's* content there. Overwriting it from the origin turned a `feature`
  worktree's file back into the `main` version, and git reported it as an
  unexplained local modification.

Only entries the user listed themselves are eliminated here.

## Review

Reviewed with `codex exec` over nine rounds; the last found nothing. The
substantive findings:

| round | finding |
|---|---|
| 1 | rustfmt violation (CI blocker); normalized-equivalent duplicates like `["a", "./a"]` survived, since `glob.rs` dedupes by literal string; the ordering test was vacuous; a comment wrongly said the copy layer rejects unnormalizable entries |
| 3 | asserted which side of an overlap gets EEXIST, but the copies run concurrently; the entry count was wrong (31, not 28); "APFS/NTFS are case-insensitive" needs qualifying; `"."` and `"./"` also normalize to nothing |
| 5–8 | successive corrections to how `normalize_relative` returns `None` — a Windows drive-relative `C:foo` is not absolute yet returns `None`, and `\a` has a root component without `is_absolute()` |

Rounds 5–8 were all my own inaccuracies in one doc comment.

## Verification

- `just check` — exit 0
- 25 `copy_runner` tests, including the equal-path tie-break (`["a", "./a"]`
  collapses to one, and the first spelling wins so the survivor is stable) and
  the component-wise containment check (`node_modules2` is not contained by
  `node_modules`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGinK4fsB4xi9M9UJLvyJT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory copying when entries overlap, ensuring nested directories are handled consistently.
  * Fixed cases involving symlinked directories where nested content could otherwise be skipped.
  * Improved handling of relative paths, including absolute paths, parent-directory traversal, Windows drive prefixes, and patterns without valid components.
* **Tests**
  * Added coverage for overlapping directory entries and related path-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->