### PR TITLE
chore: update Nix binary hashes for 4.2.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,19 +24,19 @@
       platforms = {
         x86_64-linux = {
           artifact = "vibe-linux-x64";
-          hash = "sha256-h2nHIC5RjWTeI6yuI61xi4Fgs+eZea/5mca38gBayd4=";
+          hash = "sha256-DDFPpcOnPEWKcCnaWp2GjRrDUHlc3h186EewfMddRZM=";
         };
         aarch64-linux = {
           artifact = "vibe-linux-arm64";
-          hash = "sha256-f0gBVe3ItN2pRzEyzakHCe5Xu/bA3tBlmmWnjIGAsJs=";
+          hash = "sha256-dV4MYUXMsZa/NXtwv4mgcsCyJrZks9xHSwa1YOD+UHw=";
         };
         x86_64-darwin = {
           artifact = "vibe-darwin-x64";
-          hash = "sha256-1JpNZnOidg8AnbnFUn3D5uIntFBD9EAgyMK96VaaqiQ=";
+          hash = "sha256-y8OJfE5HLw4wTomJWKMB6KaxSOvNeaBLM+id3wFIlFU=";
         };
         aarch64-darwin = {
           artifact = "vibe-darwin-arm64";
-          hash = "sha256-1HwWtHW4g2SfDUnoWP6cm5kilTzUyq5oD79IAtiwWxg=";
+          hash = "sha256-xKXtLxE/gJl0xKJnfOiyIRYgmJhgkow0dogtO+Qhaao=";
         };
       };
 


### PR DESCRIPTION
## Summary

`flake.nix` derives the version from `package.json`, so since v4.2.0 landed it
has been requesting the v4.2.0 release artifacts while still carrying v4.1.0's
fixed-output hashes. This is the one release step `flake.lock` cannot cover, so
it is done by hand after each release (same as #647 for 4.1.0).

Only the four `platforms.*.hash` values change.

## Verification

- `nix build .#binary` — exit 0
- Running the result: `vibe 4.2.0+9cdad66` (matches the release commit)
- `just check` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MG8Uk8EtC621oG6KxbL75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated checksums for prebuilt release binaries across supported Linux and macOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->